### PR TITLE
M7: Mac menu-bar app (rumps, lazy-imported)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@ concurrency:
 
 jobs:
   lint-type-test:
-    name: Lint, type-check, unit tests
-    runs-on: ubuntu-latest
+    name: Lint, type-check, unit tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,12 +30,21 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install dependencies
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         # --group dev installs workspace-wide dev tools (pytest, ruff, mypy,
         # bandit, pytest-asyncio, pytest-httpx). We do NOT use --all-extras
         # here because the app package's `robot` extra pulls reachy-mini,
-        # which has a broken Windows-only transitive dep.
+        # which has a broken Windows-only transitive dep, and the menubar's
+        # `macos` extra pulls rumps which is macOS-only.
         run: uv sync --all-packages --group dev
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        # On macOS we additionally pull the menubar's `macos` extra so the
+        # real rumps import path is exercised (catches regressions in the
+        # lazy-import contract that a fake-rumps unit test can't see).
+        run: uv sync --all-packages --group dev --extra macos
 
       - name: Ruff lint
         run: uv run ruff check .
@@ -39,8 +52,14 @@ jobs:
       - name: Ruff format (check only)
         run: uv run ruff format --check .
 
-      - name: Mypy (strict)
+      - name: Mypy (strict) — src
         run: uv run mypy --strict daemon/src app/src menubar/src protocol/src
+
+      - name: Mypy (strict) — tests
+        # Match the local lefthook behaviour so a test that fails locally
+        # can never slip through CI. Tests are production-grade per
+        # .claude/rules/testing-standards.md.
+        run: uv run mypy --strict daemon/tests protocol/tests menubar/tests
 
       - name: Bandit (security)
         run: uv run bandit -ll -r daemon/src app/src menubar/src protocol/src

--- a/daemon/tests/test_server_e2e.py
+++ b/daemon/tests/test_server_e2e.py
@@ -26,19 +26,23 @@ from reachy_ducky_daemon.project import Project
 from reachy_ducky_daemon.server import create_app
 
 
+def _run_git(repo: Path, args: list[str]) -> None:
+    """Run a git subcommand in ``repo`` with `check=True` and output captured."""
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
 def _init_repo(root: Path) -> Path:
     """Minimal git repo with one plan + one uncommitted change."""
     root.mkdir(parents=True, exist_ok=True)
-    run = lambda args: subprocess.run(["git", *args], cwd=root, check=True, capture_output=True)  # noqa: E731
-    run(["init", "-b", "main"])
-    run(["config", "user.email", "t@t"])
-    run(["config", "user.name", "t"])
-    run(["config", "commit.gpgsign", "false"])
+    _run_git(root, ["init", "-b", "main"])
+    _run_git(root, ["config", "user.email", "t@t"])
+    _run_git(root, ["config", "user.name", "t"])
+    _run_git(root, ["config", "commit.gpgsign", "false"])
     (root / "docs" / "plans").mkdir(parents=True)
     (root / "docs" / "plans" / "p.md").write_text("# Plan Foo\nAdd feature X\n")
     (root / "a.py").write_text("x = 1\n")
-    run(["add", "."])
-    run(["commit", "-m", "init"])
+    _run_git(root, ["add", "."])
+    _run_git(root, ["commit", "-m", "init"])
     # Modify a TRACKED file so `git diff` (working-tree vs HEAD) surfaces
     # the change. Adding an untracked file wouldn't — git diff omits
     # untracked additions without --no-index/--untracked.
@@ -161,11 +165,8 @@ def test_e2e_multi_project_routes_to_correct_brain_and_repo(tmp_path: Path) -> N
     beta_repo = _init_repo(tmp_path / "beta")
     # Make beta's plan different so we can prove the right repo was read.
     (beta_repo / "docs" / "plans" / "p.md").write_text("# Plan Beta\nBeta's feature\n")
-    run_beta = lambda args: subprocess.run(  # noqa: E731
-        ["git", *args], cwd=beta_repo, check=True, capture_output=True
-    )
-    run_beta(["add", "."])
-    run_beta(["commit", "--amend", "-m", "init-beta"])
+    _run_git(beta_repo, ["add", "."])
+    _run_git(beta_repo, ["commit", "--amend", "-m", "init-beta"])
 
     alpha_brain = MockBrain()
     beta_brain = MockBrain()

--- a/menubar/src/reachy_ducky_menubar/main.py
+++ b/menubar/src/reachy_ducky_menubar/main.py
@@ -1,0 +1,96 @@
+"""Rumps-based Mac menu-bar app for Reachy Ducky.
+
+Polls the daemon's /health every 2s. Icon reflects local state
+(idle <-> muted). Daemon unreachable -> warning glyph + status message.
+
+macOS-only: ``rumps`` is an optional ``macos`` extra. Importing this
+module on non-Darwin stays cheap (no rumps import at module scope);
+``main()`` raises ``ImportError`` before it would try to import rumps,
+so tests and Linux CI don't blow up.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from typing import Any
+
+import httpx
+from reachy_ducky_protocol.messages import State
+
+from .state_icon import icon_for
+
+_DAEMON_URL_DEFAULT = "http://127.0.0.1:8765"
+_POLL_INTERVAL_SECONDS = 2.0
+_UNREACHABLE_GLYPH = "🦆⚠"
+
+
+def main() -> None:
+    """Start the menubar app. Raises ``ImportError`` on non-Darwin platforms."""
+    if sys.platform != "darwin":
+        raise ImportError(
+            "reachy-ducky-menubar is macOS-only (requires rumps). "
+            "Install on a Mac with `uv sync --all-packages --extra macos`."
+        )
+    # Lazy import so non-Darwin CI can import this module without rumps.
+    # `rumps` ships no type stubs; it's only installed in the `macos` extra,
+    # hence the import-not-found ignore.
+    import rumps  # type: ignore[import-not-found]
+
+    app = _build_app(rumps)
+    app.run()
+
+
+def _build_app(rumps_mod: Any, *, start_poll: bool = True) -> Any:
+    """Construct the ``rumps.App`` with state, menu, and polling thread.
+
+    Factored out so tests can construct (without running) by passing a fake
+    ``rumps`` module. ``start_poll=False`` skips the background thread, which
+    keeps unit tests deterministic.
+    """
+    # Local state — mute is menubar-controlled.
+    state: dict[str, State] = {"current": State.IDLE}
+    daemon_url = _DAEMON_URL_DEFAULT
+
+    app = rumps_mod.App(icon_for(State.IDLE), quit_button="Quit")
+    mute_item = rumps_mod.MenuItem("Mute")
+    status_item = rumps_mod.MenuItem(f"Status: {State.IDLE.value}")
+    app.menu = [status_item, mute_item]
+
+    def _set_state(new: State) -> None:
+        state["current"] = new
+        app.title = icon_for(new)
+        status_item.title = f"Status: {new.value}"
+
+    def _toggle_mute(_item: Any) -> None:
+        if state["current"] == State.MUTED:
+            _set_state(State.IDLE)
+            mute_item.state = 0
+        else:
+            _set_state(State.MUTED)
+            mute_item.state = 1
+
+    mute_item.set_callback(_toggle_mute)
+
+    def _poll_loop() -> None:
+        while True:
+            if state["current"] == State.MUTED:
+                time.sleep(_POLL_INTERVAL_SECONDS)
+                continue
+            try:
+                r = httpx.get(f"{daemon_url}/health", timeout=1.0)
+                if r.is_success:
+                    status_item.title = f"Status: {state['current'].value}"
+                    app.title = icon_for(state["current"])
+                else:
+                    app.title = _UNREACHABLE_GLYPH
+                    status_item.title = f"Status: daemon error ({r.status_code})"
+            except httpx.HTTPError:
+                app.title = _UNREACHABLE_GLYPH
+                status_item.title = "Status: daemon unreachable"
+            time.sleep(_POLL_INTERVAL_SECONDS)
+
+    if start_poll:
+        threading.Thread(target=_poll_loop, daemon=True).start()
+    return app

--- a/menubar/src/reachy_ducky_menubar/main.py
+++ b/menubar/src/reachy_ducky_menubar/main.py
@@ -34,9 +34,12 @@ def main() -> None:
             "Install on a Mac with `uv sync --all-packages --extra macos`."
         )
     # Lazy import so non-Darwin CI can import this module without rumps.
-    # `rumps` ships no type stubs; it's only installed in the `macos` extra,
-    # hence the import-not-found ignore.
-    import rumps  # type: ignore[import-not-found]
+    # rumps is in the optional `macos` extra and ships no stubs / py.typed
+    # marker. Mypy silencing lives in the root pyproject.toml's
+    # [[tool.mypy.overrides]] section (module = "rumps") so the behaviour is
+    # consistent whether rumps is installed (macOS CI) or not (Linux CI,
+    # default dev venv).
+    import rumps
 
     app = _build_app(rumps)
     app.run()

--- a/menubar/src/reachy_ducky_menubar/state_icon.py
+++ b/menubar/src/reachy_ducky_menubar/state_icon.py
@@ -1,0 +1,21 @@
+"""Pure mapping from conversational :class:`State` to a title-bar glyph.
+
+Lives outside ``main.py`` so it has no ``rumps`` dependency and can be
+tested on any platform.
+"""
+
+from __future__ import annotations
+
+from reachy_ducky_protocol.messages import State
+
+_MAP: dict[State, str] = {
+    State.IDLE: "🦆",
+    State.LISTENING: "🦆👂",
+    State.THINKING: "🦆💭",
+    State.MUTED: "🦆🔇",
+}
+
+
+def icon_for(state: State) -> str:
+    """Return the title-bar glyph for a given conversational state."""
+    return _MAP[state]

--- a/menubar/tests/test_main.py
+++ b/menubar/tests/test_main.py
@@ -1,0 +1,113 @@
+"""Cross-platform tests for ``reachy_ducky_menubar.main``.
+
+Uses a hand-rolled fake ``rumps`` module so we can exercise the menubar
+app's construction + mute toggle on Linux CI without installing rumps.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from reachy_ducky_menubar.main import _UNREACHABLE_GLYPH, _build_app, main
+from reachy_ducky_menubar.state_icon import icon_for
+from reachy_ducky_protocol.messages import State
+
+
+class _FakeApp:
+    """Stand-in for ``rumps.App`` — stores title + menu, nothing else."""
+
+    def __init__(self, title: str, quit_button: str | None = None) -> None:
+        self.title = title
+        self.quit_button = quit_button
+        self.menu: list[Any] | None = None
+
+
+class _FakeMenuItem:
+    """Stand-in for ``rumps.MenuItem`` — captures callback + state."""
+
+    def __init__(self, title: str) -> None:
+        self.title = title
+        self.state = 0
+        self._callback: Any = None
+
+    def set_callback(self, cb: Any) -> None:
+        self._callback = cb
+
+
+class _FakeRumps:
+    """Minimal ``rumps`` module surface used by ``_build_app``."""
+
+    App = _FakeApp
+    MenuItem = _FakeMenuItem
+
+
+def _find_mute_item(app: _FakeApp) -> _FakeMenuItem:
+    """Locate the Mute menu item on a fake app, failing loudly if absent."""
+    assert app.menu is not None, "menu was never assigned"
+    for item in app.menu:
+        if isinstance(item, _FakeMenuItem) and item.title == "Mute":
+            return item
+    raise AssertionError("Mute menu item missing from app.menu")
+
+
+def _find_status_item(app: _FakeApp) -> _FakeMenuItem:
+    """Locate the Status menu item (its title starts with 'Status: ')."""
+    assert app.menu is not None, "menu was never assigned"
+    for item in app.menu:
+        if isinstance(item, _FakeMenuItem) and item.title.startswith("Status: "):
+            return item
+    raise AssertionError("Status menu item missing from app.menu")
+
+
+def test_main_raises_import_error_on_non_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On non-Darwin platforms, ``main()`` refuses to import rumps."""
+    monkeypatch.setattr("sys.platform", "linux")
+    with pytest.raises(ImportError, match="macOS-only"):
+        main()
+
+
+def test_build_app_initial_state_is_idle() -> None:
+    """_build_app starts with IDLE icon and a 'Status: idle' menu entry."""
+    app = _build_app(_FakeRumps(), start_poll=False)
+    assert isinstance(app, _FakeApp)
+    assert app.title == icon_for(State.IDLE)
+    status = _find_status_item(app)
+    assert status.title == f"Status: {State.IDLE.value}"
+
+
+def test_build_app_menu_contains_status_and_mute_items() -> None:
+    """The menu wires up both the status entry and the mute toggle."""
+    app = _build_app(_FakeRumps(), start_poll=False)
+    assert isinstance(app, _FakeApp)
+    mute = _find_mute_item(app)
+    status = _find_status_item(app)
+    assert mute.title == "Mute"
+    assert status.title.startswith("Status: ")
+
+
+def test_mute_callback_toggles_to_muted_then_back_to_idle() -> None:
+    """Hitting the mute item flips state MUTED↔IDLE and updates the icon."""
+    app = _build_app(_FakeRumps(), start_poll=False)
+    assert isinstance(app, _FakeApp)
+    mute = _find_mute_item(app)
+    status = _find_status_item(app)
+
+    # First click: IDLE → MUTED.
+    assert mute._callback is not None, "mute callback was never registered"
+    mute._callback(mute)
+    assert app.title == icon_for(State.MUTED)
+    assert status.title == f"Status: {State.MUTED.value}"
+    assert mute.state == 1
+
+    # Second click: MUTED → IDLE.
+    mute._callback(mute)
+    assert app.title == icon_for(State.IDLE)
+    assert status.title == f"Status: {State.IDLE.value}"
+    assert mute.state == 0
+
+
+def test_unreachable_glyph_is_distinct_from_state_icons() -> None:
+    """The daemon-unreachable glyph must not collide with any state icon."""
+    state_icons = {icon_for(s) for s in State}
+    assert _UNREACHABLE_GLYPH not in state_icons

--- a/menubar/tests/test_state_icon.py
+++ b/menubar/tests/test_state_icon.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+from reachy_ducky_menubar.state_icon import icon_for
+from reachy_ducky_protocol.messages import State
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (State.IDLE, "🦆"),
+        (State.LISTENING, "🦆👂"),
+        (State.THINKING, "🦆💭"),
+        (State.MUTED, "🦆🔇"),
+    ],
+    ids=[s.value for s in (State.IDLE, State.LISTENING, State.THINKING, State.MUTED)],
+)
+def test_icon_for_each_state(state: State, expected: str) -> None:
+    """Every State value has a deterministic icon."""
+    assert icon_for(state) == expected
+
+
+def test_icon_for_covers_every_state() -> None:
+    """The icon map is exhaustive — adding a new State without an icon fails fast."""
+    for state in State:
+        # Should not raise KeyError for any member.
+        icon_for(state)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,14 @@ markers = [
     "integration: requires live external APIs",
 ]
 
+# Mypy per-module overrides. Keep this list short — one-liners for deps
+# that ship no stubs. Prefer real typing when available.
+#   rumps: macOS-only menu-bar lib, no stubs / py.typed. Used only from
+#          menubar.main via a lazy import behind `sys.platform == "darwin"`.
+[[tool.mypy.overrides]]
+module = "rumps"
+ignore_missing_imports = true
+
 # Pyright config lives in ./pyrightconfig.json (takes precedence over
 # [tool.pyright] here; pyrightconfig.json is more reliably live-reloaded
 # by IDE language servers).


### PR DESCRIPTION
## Summary

Phase A Milestone 7 — tiny Mac-side menu-bar app that gives a visual indicator of daemon state and hosts a mute toggle.

- \`state_icon.py\`: pure \`State → glyph\` map. 🦆 / 🦆👂 / 🦆💭 / 🦆🔇
- \`main.py\`: rumps-backed app. 2s poll of daemon \`/health\`. Mute toggle is menubar-local. Listening/thinking icons defined but not wired yet — they need a daemon→menubar event channel that lands with the voice app work.
- rumps imported LAZILY inside \`main()\`; module import stays clean on Linux CI (rumps is an optional \`macos\` extra).
- \`_build_app(rumps_mod, *, start_poll=True)\` factored out so tests construct with a fake rumps and skip the polling thread.

## Test plan

- [x] \`uv run pytest -q\` → 382 passed, 2 skipped (+10 from 372)
- [x] \`uv run python -c \"import reachy_ducky_menubar.main\"\` without rumps → clean
- [x] lefthook pre-commit green
- [x] CI (first run on this branch)
- [ ] Manual run on macOS with \`uv sync --all-packages --extra macos && uv run reachy-ducky-menubar\` (deferred to dogfooding)

## Not included

- Listening/thinking icon wiring (defer to M8/M10 when voice layer exists).
- Clickable status menu beyond the mute toggle.
- launchd plist for auto-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)