### PR TITLE
Phase A: Reachy-side voice, embodiment, orchestration + E2E docs (M8–M13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,33 @@ See `docs/plans/2026-04-21-reachy-ducky-design.md` for the full design.
 
 Status: Phase A MVP in progress.
 
+## Run (Phase A)
+
+- Mac daemon: `uv run reachy-ducky-daemon` (first run: `uv run reachy-ducky init`
+  to write `~/.reachy-ducky/config.toml` + `.env`).
+- Menu-bar (macOS only): `uv run reachy-ducky-menubar`. On Linux this raises
+  `ImportError` by design — `rumps` lives in the optional `macos` extra.
+- Reachy app: one-click install from the on-robot dashboard after publishing
+  via HF Spaces. The publish path is **unverified** in Phase A — see
+  `docs/testing/2026-04-21-phase-a-e2e-procedure.md` Known gaps §3.
+- Wake-word detection is a no-op stub in Phase A (`MockWakeDetector`); saying
+  "Hey Ducky" does nothing today. The smoke procedure above shows how to
+  exercise a turn without wake.
+
+See `docs/testing/2026-04-21-phase-a-e2e-procedure.md` for the full end-to-end
+smoke procedure and known gaps.
+
+## Development
+
+- `uv sync --all-packages --group dev` — install the workspace plus dev tools
+  (pytest, ruff, mypy, bandit). On the robot only, add `--extra robot` to pull
+  `reachy-mini`.
+- `uv run pytest -q` — unit tests (default tier).
+- `uv run pytest -m integration` — integration tests, opt-in; require live API
+  env vars (`OPENAI_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, etc.).
+- `uv run pytest -m hardware` — hardware tests, opt-in; require a connected
+  Reachy Mini.
+
+See `CLAUDE.md` for the full developer workflow (lint, type-check, pre-commit).
+
 Licensed under Apache 2.0.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ Status: Phase A MVP in progress.
 
 - Mac daemon: `uv run reachy-ducky-daemon` (first run: `uv run reachy-ducky init`
   to write `~/.reachy-ducky/config.toml` + `.env`).
-- Menu-bar (macOS only): `uv run reachy-ducky-menubar`. On Linux this raises
-  `ImportError` by design — `rumps` lives in the optional `macos` extra.
+- Menu-bar (macOS-only in Phase A — `rumps` lives in the optional `macos`
+  extra): `uv run reachy-ducky-menubar`.
 - Reachy app: one-click install from the on-robot dashboard after publishing
   via HF Spaces. The publish path is **unverified** in Phase A — see
-  `docs/testing/2026-04-21-phase-a-e2e-procedure.md` Known gaps §3.
+  `docs/testing/2026-04-21-phase-a-e2e-procedure.md` Known gaps §3. For
+  running the app locally during development, see `app/README.md`.
 - Wake-word detection is a no-op stub in Phase A (`MockWakeDetector`); saying
-  "Hey Ducky" does nothing today. The smoke procedure above shows how to
+  "Hey Ducky" does nothing today. The smoke procedure below shows how to
   exercise a turn without wake.
 
 See `docs/testing/2026-04-21-phase-a-e2e-procedure.md` for the full end-to-end
@@ -56,9 +57,11 @@ real use you need a trusted channel.
    ```
    Tailscale's ACLs (and your firewall) restrict who can reach :8765 — only
    devices on your tailnet.
-3. On the Reachy, point the app at the Mac's MagicDNS name:
+3. On the Reachy, point the app at the Mac's MagicDNS name (and set the
+   OpenAI key the Realtime voice needs — see `app/README.md`):
    ```bash
    DAEMON_URL=http://<your-mac>.<your-tailnet>.ts.net:8765
+   OPENAI_API_KEY=sk-...
    ```
 
 No shared secret, no token rotation. If a device is lost, revoke it in the
@@ -78,6 +81,7 @@ If you'd rather not use Tailscale, you can run the daemon with a shared token.
    ```bash
    DAEMON_URL=http://<your-mac>.local:8765
    DAEMON_AUTH_TOKEN=<paste the same token>
+   OPENAI_API_KEY=sk-...
    ```
 3. The daemon requires `Authorization: Bearer <token>` on every route except
    the three open paths `/health`, `/docs`, and `/openapi.json`. Treat the
@@ -89,7 +93,11 @@ If you bind the daemon to a non-loopback host **without** setting
 `REACHY_DUCKY_AUTH_TOKEN`, the daemon logs a loud warning on startup
 (`AppConfig.warn_if_exposed_without_auth` in
 `daemon/src/reachy_ducky_daemon/config.py`). Anyone on the same network could
-invoke your Claude subscription and read your code. Either use Tailscale or
-set a token — never both off.
+invoke your Claude subscription and read your code. Don't run exposed without
+at least one of Tailscale or a token.
 
-Licensed under Apache 2.0.
+`/docs` and `/openapi.json` are always open for discoverability, even with a
+token — acceptable inside Tailscale; reconsider if you ever bind publicly.
+
+For vulnerability reporting, see `SECURITY.md`. Python 3.12+ is required
+(workspace-wide). Licensed under Apache 2.0 — see `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -36,4 +36,60 @@ smoke procedure and known gaps.
 
 See `CLAUDE.md` for the full developer workflow (lint, type-check, pre-commit).
 
+## Networking & auth
+
+Reachy Ducky runs as two processes on two machines: a daemon on your Mac and an
+app on your Reachy Mini. They talk over HTTP. The default bind is
+`127.0.0.1:8765` (loopback-only), which won't work across devices — so for
+real use you need a trusted channel.
+
+### Recommended: Tailscale (zero-trust mesh)
+
+1. Install Tailscale on your Mac and on your Reachy (`brew install tailscale` /
+   `curl -fsSL https://tailscale.com/install.sh | sh`). Run `sudo tailscale up`
+   on both. Both devices appear in your tailnet with MagicDNS names like
+   `<your-mac>.<your-tailnet>.ts.net` (example only — substitute your own).
+2. On the Mac, run the daemon bound to all interfaces so the tailnet can
+   reach it:
+   ```bash
+   REACHY_DUCKY_DAEMON_HOST=0.0.0.0 uv run reachy-ducky-daemon
+   ```
+   Tailscale's ACLs (and your firewall) restrict who can reach :8765 — only
+   devices on your tailnet.
+3. On the Reachy, point the app at the Mac's MagicDNS name:
+   ```bash
+   DAEMON_URL=http://<your-mac>.<your-tailnet>.ts.net:8765
+   ```
+
+No shared secret, no token rotation. If a device is lost, revoke it in the
+Tailscale admin console.
+
+### Alternative: bearer token over LAN
+
+If you'd rather not use Tailscale, you can run the daemon with a shared token.
+
+1. On the Mac:
+   ```bash
+   export REACHY_DUCKY_AUTH_TOKEN="$(openssl rand -hex 32)"
+   export REACHY_DUCKY_DAEMON_HOST=0.0.0.0
+   uv run reachy-ducky-daemon
+   ```
+2. On the Reachy, set the same token and point at the Mac:
+   ```bash
+   DAEMON_URL=http://<your-mac>.local:8765
+   DAEMON_AUTH_TOKEN=<paste the same token>
+   ```
+3. The daemon requires `Authorization: Bearer <token>` on every route except
+   the three open paths `/health`, `/docs`, and `/openapi.json`. Treat the
+   token like a password — do not commit it.
+
+### Warning
+
+If you bind the daemon to a non-loopback host **without** setting
+`REACHY_DUCKY_AUTH_TOKEN`, the daemon logs a loud warning on startup
+(`AppConfig.warn_if_exposed_without_auth` in
+`daemon/src/reachy_ducky_daemon/config.py`). Anyone on the same network could
+invoke your Claude subscription and read your code. Either use Tailscale or
+set a token — never both off.
+
 Licensed under Apache 2.0.

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,48 @@
+---
+title: reachy-ducky
+emoji: "\U0001F986"
+colorFrom: yellow
+colorTo: blue
+sdk: static
+pinned: false
+short_description: Read-only rubber-ducky companion for agentic SWE work.
+tags:
+  - reachy_mini
+  - reachy_mini_python_app
+---
+
+# Reachy Ducky — Reachy Mini App
+
+The Reachy Mini side of the [Reachy Ducky project](https://github.com/Obsidian-Owl/reachy-ducky).
+
+## What it does
+
+On-demand conversational rubber-ducky companion for agentic SWE work.
+Say "Hey Ducky", ask a question, get an answer. The Mac-side daemon
+does the thinking (Claude Agent SDK with a project-scoped tool surface);
+this app handles voice I/O on the robot.
+
+## Install
+
+1. **Mac side (the thinking brain)**
+   - `pip install reachy-ducky-daemon`
+   - `reachy-ducky init` (first-time setup wizard)
+   - `reachy-ducky-daemon` (starts the HTTP service)
+
+2. **Robot side (this app)**
+   - From the Reachy dashboard at `http://<robot>:8000`, one-click
+     install this app from its HF Space URL.
+   - Set environment variables on the robot:
+     - `DAEMON_URL=http://<your-mac>.tailnet.ts.net:8765`
+     - `DAEMON_AUTH_TOKEN=<bearer token if you set one on the Mac>`
+     - `OPENAI_API_KEY=<for OpenAI Realtime voice>`
+
+## Architecture
+
+Split-brain: voice on the robot, thinking on the Mac.
+Full design: https://github.com/Obsidian-Owl/reachy-ducky/blob/main/docs/plans/2026-04-21-reachy-ducky-design.md
+
+Phase A scope: on-demand conversational mode only. Wake-word triggers
+a single turn; response speaks back. Listening / thinking state machine
+expresses body motion (head tilt, antenna animation) via the Reachy
+emotions library. Always-on passive observation (phase C) is deferred.

--- a/app/reachy_mini_app.yaml
+++ b/app/reachy_mini_app.yaml
@@ -1,0 +1,8 @@
+title: reachy-ducky
+emoji: "\U0001F986"
+python_version: "3.12"
+app_class: reachy_ducky_app.main.ReachyDuckyApp
+description: >
+  A read-only rubber-ducky development companion: watches your agentic
+  SWE workflow (via a Mac daemon), answers questions in conversation,
+  flags concerns during SDD flows. Does not write code.

--- a/app/src/reachy_ducky_app/conversation.py
+++ b/app/src/reachy_ducky_app/conversation.py
@@ -40,20 +40,25 @@ async def run_one_turn(
     daemon: DaemonClient,
     project_slug: str | None = None,
 ) -> None:
-    """Run one user-Ducky turn. No-op if the state machine is MUTED."""
+    """Run one user-Ducky turn. No-op if the state machine is MUTED.
+
+    The voice turn is driven under ``async with voice.start_turn()`` so
+    its underlying connection (e.g. the OpenAI Realtime WebSocket) is
+    released whether the turn completes normally or raises mid-flight.
+    """
     if sm.state == State.MUTED:
         return
 
     sm.transition(State.LISTENING)
-    turn = await voice.start_turn()
-    user_text = await turn.get_user_text()
+    async with voice.start_turn() as turn:
+        user_text = await turn.get_user_text()
 
-    sm.transition(State.THINKING)
-    reply = await daemon.brain_query(user_text, project_slug=project_slug)
+        sm.transition(State.THINKING)
+        reply = await daemon.brain_query(user_text, project_slug=project_slug)
 
-    # Speak while in LISTENING posture — the robot looks at the user
-    # as Ducky replies, not while thinking.
-    sm.transition(State.LISTENING)
-    await turn.speak_text(reply.text)
+        # Speak while in LISTENING posture — the robot looks at the user
+        # as Ducky replies, not while thinking.
+        sm.transition(State.LISTENING)
+        await turn.speak_text(reply.text)
 
     sm.transition(State.IDLE)

--- a/app/src/reachy_ducky_app/conversation.py
+++ b/app/src/reachy_ducky_app/conversation.py
@@ -1,0 +1,59 @@
+"""Single-turn conversation orchestration.
+
+Composes the Reachy-side pieces into one flow::
+
+    wake_trigger -> embodiment=LISTENING
+                 -> voice.start_turn()  (awaits final user transcript)
+                 -> embodiment=THINKING
+                 -> daemon.brain_query(text)
+                 -> embodiment=LISTENING (speak reply; robot looks at
+                    the user as Ducky replies, not while thinking)
+                 -> voice.speak_text(reply)
+                 -> embodiment=IDLE
+
+Muted state is honoured at entry: if the state machine is in
+:data:`~reachy_ducky_protocol.messages.State.MUTED`, :func:`run_one_turn`
+returns immediately without calling into voice or the daemon. This is
+the embodiment-level mute (visible "off" posture). The separate
+:class:`~reachy_ducky_app.mute.MuteGate` is the *audio-path* gate —
+different concern, not conflated here.
+
+The loop is intentionally one-turn, one-function. A future task wraps
+it in a wake-word listen loop that calls :func:`run_one_turn`
+repeatedly. Interrupt-while-speaking (barge-in mid-reply) is out of
+scope for Phase A.
+"""
+
+from __future__ import annotations
+
+from reachy_ducky_protocol.messages import State
+
+from .daemon_client import DaemonClient
+from .embodiment.state_machine import EmbodimentStateMachine
+from .voice.interface import VoiceInterface
+
+
+async def run_one_turn(
+    *,
+    voice: VoiceInterface,
+    sm: EmbodimentStateMachine,
+    daemon: DaemonClient,
+    project_slug: str | None = None,
+) -> None:
+    """Run one user-Ducky turn. No-op if the state machine is MUTED."""
+    if sm.state == State.MUTED:
+        return
+
+    sm.transition(State.LISTENING)
+    turn = await voice.start_turn()
+    user_text = await turn.get_user_text()
+
+    sm.transition(State.THINKING)
+    reply = await daemon.brain_query(user_text, project_slug=project_slug)
+
+    # Speak while in LISTENING posture — the robot looks at the user
+    # as Ducky replies, not while thinking.
+    sm.transition(State.LISTENING)
+    await turn.speak_text(reply.text)
+
+    sm.transition(State.IDLE)

--- a/app/src/reachy_ducky_app/conversation.py
+++ b/app/src/reachy_ducky_app/conversation.py
@@ -50,15 +50,20 @@ async def run_one_turn(
         return
 
     sm.transition(State.LISTENING)
-    async with voice.start_turn() as turn:
-        user_text = await turn.get_user_text()
+    try:
+        async with voice.start_turn() as turn:
+            user_text = await turn.get_user_text()
 
-        sm.transition(State.THINKING)
-        reply = await daemon.brain_query(user_text, project_slug=project_slug)
+            sm.transition(State.THINKING)
+            reply = await daemon.brain_query(user_text, project_slug=project_slug)
 
-        # Speak while in LISTENING posture — the robot looks at the user
-        # as Ducky replies, not while thinking.
-        sm.transition(State.LISTENING)
-        await turn.speak_text(reply.text)
-
-    sm.transition(State.IDLE)
+            # Speak while in LISTENING posture — the robot looks at the user
+            # as Ducky replies, not while thinking.
+            sm.transition(State.LISTENING)
+            await turn.speak_text(reply.text)
+    finally:
+        # Reset posture to IDLE on every exit path. Without this, an
+        # exception mid-turn would pin the robot to LISTENING/THINKING
+        # until the next turn. The caller still sees the exception —
+        # ``finally`` does not swallow.
+        sm.transition(State.IDLE)

--- a/app/src/reachy_ducky_app/daemon_client.py
+++ b/app/src/reachy_ducky_app/daemon_client.py
@@ -1,0 +1,103 @@
+"""Async HTTP client for the Reachy Ducky Mac daemon.
+
+The daemon exposes ``/health`` (open), ``/brain/query`` (bearer-auth when
+``REACHY_DUCKY_AUTH_TOKEN`` is set on the daemon side), and
+``/specialists/plan-reviewer`` (same auth). This client wraps them with
+typed Pydantic-in, Pydantic-out.
+
+Configuration from env:
+
+- ``DAEMON_URL`` — default ``http://127.0.0.1:8765``.
+- ``DAEMON_AUTH_TOKEN`` — if set (and non-empty), sent as
+  ``Authorization: Bearer <token>``. Presence wins: setting the env var
+  to an empty string is an explicit "no token" (mirrors the daemon's
+  :class:`~reachy_ducky_daemon.config.AppConfig` semantics).
+
+Per-endpoint timeouts:
+
+- ``/health`` — 2s (cheap, cacheable).
+- ``/brain/query`` — 60s (LLM round-trip).
+- ``/specialists/plan-reviewer`` — 120s (subagent invocation can take a
+  while with tool use).
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+from reachy_ducky_protocol.messages import (
+    BrainRequest,
+    BrainResponse,
+    HealthResponse,
+    SpecialistRequest,
+    SpecialistResponse,
+)
+
+
+class DaemonClient:
+    """Typed async HTTP client for the daemon's three public endpoints."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        auth_token: str | None = None,
+    ) -> None:
+        resolved_base = base_url or os.environ.get("DAEMON_URL") or "http://127.0.0.1:8765"
+        self._base: str = resolved_base.rstrip("/")
+        # Presence-wins semantics (mirrors the daemon's own AppConfig):
+        #   explicit arg > env-var (even "" clears) > None.
+        if auth_token is not None:
+            self._token: str | None = auth_token
+        else:
+            env_token = os.environ.get("DAEMON_AUTH_TOKEN")
+            self._token = env_token or None
+
+    @classmethod
+    def from_env(cls) -> DaemonClient:
+        """Build a client from ``DAEMON_URL`` / ``DAEMON_AUTH_TOKEN``."""
+        return cls()
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._token}"} if self._token else {}
+
+    async def health(self) -> HealthResponse:
+        """GET ``/health``. Returns the daemon's health envelope."""
+        async with httpx.AsyncClient(timeout=2.0) as http:
+            r = await http.get(f"{self._base}/health", headers=self._headers())
+            r.raise_for_status()
+            return HealthResponse.model_validate(r.json())
+
+    async def brain_query(
+        self,
+        text: str,
+        *,
+        project_slug: str | None = None,
+    ) -> BrainResponse:
+        """POST ``/brain/query`` with a user utterance and get Ducky's reply."""
+        req = BrainRequest(user_utterance=text, project_slug=project_slug)
+        async with httpx.AsyncClient(timeout=60.0) as http:
+            r = await http.post(
+                f"{self._base}/brain/query",
+                json=req.model_dump(),
+                headers=self._headers(),
+            )
+            r.raise_for_status()
+            return BrainResponse.model_validate(r.json())
+
+    async def plan_reviewer(
+        self,
+        *,
+        project_slug: str,
+        branch: str | None = None,
+    ) -> SpecialistResponse:
+        """POST ``/specialists/plan-reviewer`` and get a review envelope."""
+        req = SpecialistRequest(name="plan-reviewer", project_slug=project_slug, branch=branch)
+        async with httpx.AsyncClient(timeout=120.0) as http:
+            r = await http.post(
+                f"{self._base}/specialists/plan-reviewer",
+                json=req.model_dump(),
+                headers=self._headers(),
+            )
+            r.raise_for_status()
+            return SpecialistResponse.model_validate(r.json())

--- a/app/src/reachy_ducky_app/daemon_client.py
+++ b/app/src/reachy_ducky_app/daemon_client.py
@@ -13,12 +13,19 @@ Configuration from env:
   to an empty string is an explicit "no token" (mirrors the daemon's
   :class:`~reachy_ducky_daemon.config.AppConfig` semantics).
 
-Per-endpoint timeouts:
+Per-endpoint timeouts (applied per-call, not on the pooled client):
 
 - ``/health`` — 2s (cheap, cacheable).
 - ``/brain/query`` — 60s (LLM round-trip).
 - ``/specialists/plan-reviewer`` — 120s (subagent invocation can take a
   while with tool use).
+
+Connection pooling
+------------------
+A single :class:`httpx.AsyncClient` is constructed in ``__init__`` and
+reused across all endpoint calls. This avoids a TLS handshake per call
+(measurable latency over Tailscale). Call :meth:`aclose` on shutdown to
+drain the pool cleanly.
 """
 
 from __future__ import annotations
@@ -36,7 +43,11 @@ from reachy_ducky_protocol.messages import (
 
 
 class DaemonClient:
-    """Typed async HTTP client for the daemon's three public endpoints."""
+    """Typed async HTTP client for the daemon's three public endpoints.
+
+    Holds one pooled :class:`httpx.AsyncClient` for the life of the
+    instance. Callers must :meth:`aclose` on shutdown.
+    """
 
     def __init__(
         self,
@@ -52,21 +63,32 @@ class DaemonClient:
         else:
             env_token = os.environ.get("DAEMON_AUTH_TOKEN")
             self._token = env_token or None
+        # Per-call timeouts diverge by endpoint, so the pooled client has
+        # no global timeout — each endpoint method sets its own.
+        self._http: httpx.AsyncClient = httpx.AsyncClient()
 
     @classmethod
     def from_env(cls) -> DaemonClient:
         """Build a client from ``DAEMON_URL`` / ``DAEMON_AUTH_TOKEN``."""
         return cls()
 
+    async def aclose(self) -> None:
+        """Close the pooled httpx client. Idempotent."""
+        if not self._http.is_closed:
+            await self._http.aclose()
+
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self._token}"} if self._token else {}
 
     async def health(self) -> HealthResponse:
         """GET ``/health``. Returns the daemon's health envelope."""
-        async with httpx.AsyncClient(timeout=2.0) as http:
-            r = await http.get(f"{self._base}/health", headers=self._headers())
-            r.raise_for_status()
-            return HealthResponse.model_validate(r.json())
+        r = await self._http.get(
+            f"{self._base}/health",
+            headers=self._headers(),
+            timeout=2.0,
+        )
+        r.raise_for_status()
+        return HealthResponse.model_validate(r.json())
 
     async def brain_query(
         self,
@@ -76,14 +98,14 @@ class DaemonClient:
     ) -> BrainResponse:
         """POST ``/brain/query`` with a user utterance and get Ducky's reply."""
         req = BrainRequest(user_utterance=text, project_slug=project_slug)
-        async with httpx.AsyncClient(timeout=60.0) as http:
-            r = await http.post(
-                f"{self._base}/brain/query",
-                json=req.model_dump(),
-                headers=self._headers(),
-            )
-            r.raise_for_status()
-            return BrainResponse.model_validate(r.json())
+        r = await self._http.post(
+            f"{self._base}/brain/query",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=60.0,
+        )
+        r.raise_for_status()
+        return BrainResponse.model_validate(r.json())
 
     async def plan_reviewer(
         self,
@@ -93,11 +115,11 @@ class DaemonClient:
     ) -> SpecialistResponse:
         """POST ``/specialists/plan-reviewer`` and get a review envelope."""
         req = SpecialistRequest(name="plan-reviewer", project_slug=project_slug, branch=branch)
-        async with httpx.AsyncClient(timeout=120.0) as http:
-            r = await http.post(
-                f"{self._base}/specialists/plan-reviewer",
-                json=req.model_dump(),
-                headers=self._headers(),
-            )
-            r.raise_for_status()
-            return SpecialistResponse.model_validate(r.json())
+        r = await self._http.post(
+            f"{self._base}/specialists/plan-reviewer",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=120.0,
+        )
+        r.raise_for_status()
+        return SpecialistResponse.model_validate(r.json())

--- a/app/src/reachy_ducky_app/embodiment/__init__.py
+++ b/app/src/reachy_ducky_app/embodiment/__init__.py
@@ -1,0 +1,13 @@
+"""Embodiment: motion driver ABC + state machine + gaze helpers."""
+
+from __future__ import annotations
+
+from .motion_driver import MockMotionDriver, MotionDriver, ReachyMotionDriver
+from .state_machine import EmbodimentStateMachine
+
+__all__ = [
+    "EmbodimentStateMachine",
+    "MockMotionDriver",
+    "MotionDriver",
+    "ReachyMotionDriver",
+]

--- a/app/src/reachy_ducky_app/embodiment/gaze.py
+++ b/app/src/reachy_ducky_app/embodiment/gaze.py
@@ -1,0 +1,76 @@
+"""Face-tracking gaze: pure selection helper + hardware-only live loop.
+
+:func:`pick_primary_face` is pure Python and unit-testable. :func:`gaze_loop`
+runs a mediapipe face detector against ``mini.media`` frames and drives
+:meth:`MotionDriver.look_at_image`; it needs real hardware + a working
+mediapipe install and is hardware-tier only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .motion_driver import MotionDriver
+
+
+def pick_primary_face(
+    detections: list[tuple[float, float, float]],
+) -> tuple[float, float] | None:
+    """Pick the highest-confidence face center.
+
+    Args:
+        detections: list of ``(u, v, confidence)`` tuples where ``u`` and
+            ``v`` are image-normalised in ``[0, 1]``.
+
+    Returns:
+        ``(u, v)`` of the top-confidence detection, or ``None`` if
+        ``detections`` is empty.
+
+    Ties are broken by list order (``max`` returns the first maximum).
+    Callers feeding mediapipe output should pre-filter by a confidence
+    threshold.
+    """
+    if not detections:
+        return None
+    best = max(detections, key=lambda d: d[2])
+    return (best[0], best[1])
+
+
+async def gaze_loop(mini: object, driver: MotionDriver, *, fps: float = 5.0) -> None:
+    """Hardware-only face-tracking loop.
+
+    Captures frames from ``mini.media``, runs mediapipe face detection, and
+    feeds the primary face to ``driver.look_at_image``. Runs until cancelled.
+
+    Cancellation model: caller wraps in ``asyncio.create_task(...)`` and
+    cancels the task for shutdown. ``try``/``finally`` closes the detector.
+
+    ``mediapipe`` is imported lazily so this module stays importable on dev
+    machines where the runtime detector may not yet be exercised.
+    """
+    import asyncio
+
+    import mediapipe as mp
+
+    detector = mp.solutions.face_detection.FaceDetection(min_detection_confidence=0.5)
+    period = 1.0 / fps
+    try:
+        while True:
+            frame = mini.media.get_frame()  # type: ignore[attr-defined]
+            if frame is not None:
+                results = detector.process(frame)
+                dets: list[tuple[float, float, float]] = []
+                for d in results.detections or []:
+                    bb = d.location_data.relative_bounding_box
+                    u = bb.xmin + bb.width / 2
+                    v = bb.ymin + bb.height / 2
+                    score = d.score[0] if d.score else 0.0
+                    dets.append((u, v, score))
+                primary = pick_primary_face(dets)
+                if primary is not None:
+                    h, w = frame.shape[:2]
+                    driver.look_at_image(primary[0] * w, primary[1] * h)
+            await asyncio.sleep(period)
+    finally:
+        detector.close()

--- a/app/src/reachy_ducky_app/embodiment/gaze.py
+++ b/app/src/reachy_ducky_app/embodiment/gaze.py
@@ -48,7 +48,16 @@ async def gaze_loop(mini: object, driver: MotionDriver, *, fps: float = 5.0) -> 
 
     ``mediapipe`` is imported lazily so this module stays importable on dev
     machines where the runtime detector may not yet be exercised.
+
+    Raises:
+        ValueError: if ``fps <= 0``. Guarding at entry gives hardware-tier
+            callers a clear error instead of a downstream
+            :class:`ZeroDivisionError` (``fps=0``) or a silent tight loop
+            (``fps<0``).
     """
+    if fps <= 0:
+        raise ValueError(f"fps must be positive, got {fps}")
+
     import asyncio
 
     import mediapipe as mp

--- a/app/src/reachy_ducky_app/embodiment/gaze.py
+++ b/app/src/reachy_ducky_app/embodiment/gaze.py
@@ -72,8 +72,11 @@ async def gaze_loop(mini: object, driver: MotionDriver, *, fps: float = 5.0) -> 
                 dets: list[tuple[float, float, float]] = []
                 for d in results.detections or []:
                     bb = d.location_data.relative_bounding_box
-                    u = bb.xmin + bb.width / 2
-                    v = bb.ymin + bb.height / 2
+                    # mediapipe relative bboxes can extend outside [0, 1] for
+                    # partial faces at the frame edge; clamp so the robot
+                    # never tries to aim outside its motion envelope.
+                    u = min(1.0, max(0.0, bb.xmin + bb.width / 2))
+                    v = min(1.0, max(0.0, bb.ymin + bb.height / 2))
                     score = d.score[0] if d.score else 0.0
                     dets.append((u, v, score))
                 primary = pick_primary_face(dets)

--- a/app/src/reachy_ducky_app/embodiment/motion_driver.py
+++ b/app/src/reachy_ducky_app/embodiment/motion_driver.py
@@ -1,0 +1,85 @@
+"""Pluggable motion backend for the Reachy-side app.
+
+``MotionDriver`` is the ABC the :class:`EmbodimentStateMachine` talks to.
+``MockMotionDriver`` records calls for unit tests. ``ReachyMotionDriver``
+wraps a real ``reachy_mini.ReachyMini`` instance and is only instantiable
+on the robot where the ``robot`` extra is installed.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class MotionDriver(ABC):
+    """Pluggable motion backend.
+
+    ``ReachyMotionDriver`` wraps the real SDK; ``MockMotionDriver`` records
+    calls for side-effect verification in unit tests.
+    """
+
+    @abstractmethod
+    def play_move(self, name: str) -> None:
+        """Play a named move from the emotion library."""
+
+    @abstractmethod
+    def go_to_sleep(self) -> None:
+        """Drive the robot into the visible "off" posture."""
+
+    @abstractmethod
+    def wake_up(self) -> None:
+        """Bring the robot out of the "off" posture."""
+
+    @abstractmethod
+    def look_at_image(self, u: float, v: float, duration: float = 0.3) -> None:
+        """Gaze at image-space coordinates (pixels)."""
+
+
+class MockMotionDriver(MotionDriver):
+    """Records calls for side-effect verification."""
+
+    def __init__(self) -> None:
+        self.moves: list[str] = []
+        self.went_to_sleep: bool = False
+        self.woke_up: bool = False
+        self.gazes: list[tuple[float, float]] = []
+
+    def play_move(self, name: str) -> None:
+        self.moves.append(name)
+
+    def go_to_sleep(self) -> None:
+        self.went_to_sleep = True
+
+    def wake_up(self) -> None:
+        self.woke_up = True
+
+    def look_at_image(self, u: float, v: float, duration: float = 0.3) -> None:
+        del duration  # recorded via (u, v) only
+        self.gazes.append((u, v))
+
+
+class ReachyMotionDriver(MotionDriver):
+    """Real driver. Hardware-only.
+
+    ``reachy_mini`` is in ``app/pyproject.toml``'s ``robot`` extra (not
+    default) because its transitive deps break on non-Linux dev machines.
+    On the Reachy itself, users install via ``uv sync --extra robot``.
+    The caller constructs a ``ReachyMini`` and passes it in.
+    """
+
+    def __init__(self, mini: object) -> None:
+        # Typed as object — the concrete type comes from reachy_mini which
+        # may not be installed on a dev machine. Callers pass a ReachyMini.
+        self._mini = mini
+
+    def play_move(self, name: str) -> None:
+        self._mini.play_move(name)  # type: ignore[attr-defined]
+
+    def go_to_sleep(self) -> None:
+        self._mini.goto_sleep()  # type: ignore[attr-defined]
+
+    def wake_up(self) -> None:
+        self._mini.wake_up()  # type: ignore[attr-defined]
+
+    def look_at_image(self, u: float, v: float, duration: float = 0.3) -> None:
+        self._mini.look_at_image(u, v, duration=duration)  # type: ignore[attr-defined]

--- a/app/src/reachy_ducky_app/embodiment/state_machine.py
+++ b/app/src/reachy_ducky_app/embodiment/state_machine.py
@@ -1,0 +1,51 @@
+"""Embodiment state machine: maps :class:`State` transitions to motion."""
+
+from __future__ import annotations
+
+from reachy_ducky_protocol.messages import State
+
+from .motion_driver import MotionDriver
+
+# State -> emotion-library move name. Keep in sync with the design doc §11
+# (Embodiment) which lists the canonical moves.
+_STATE_TO_MOVE: dict[State, str] = {
+    State.IDLE: "neutral",
+    State.LISTENING: "listening",
+    State.THINKING: "thinking",
+}
+
+
+class EmbodimentStateMachine:
+    """Maps :class:`State` transitions to motion commands.
+
+    Invariants:
+
+    - A transition to the SAME state is a no-op (no redundant motion).
+    - ``MUTED`` is special-cased to :meth:`MotionDriver.go_to_sleep` (visible
+      "off" posture) rather than ``play_move``.
+    - Exiting ``MUTED`` triggers :meth:`MotionDriver.wake_up` BEFORE the
+      target-state ``play_move`` so the robot is upright before it moves.
+    - ``IDLE``/``LISTENING``/``THINKING`` transitions call
+      ``play_move(<name>)`` per :data:`_STATE_TO_MOVE`.
+    """
+
+    def __init__(self, driver: MotionDriver) -> None:
+        self._driver = driver
+        self._state: State = State.IDLE
+
+    @property
+    def state(self) -> State:
+        return self._state
+
+    def transition(self, target: State) -> None:
+        if target == self._state:
+            return
+        if target == State.MUTED:
+            self._driver.go_to_sleep()
+        else:
+            if self._state == State.MUTED:
+                self._driver.wake_up()
+            move = _STATE_TO_MOVE.get(target)
+            if move is not None:
+                self._driver.play_move(move)
+        self._state = target

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -1,0 +1,92 @@
+"""Reachy Ducky app entry point.
+
+Structurally satisfies ``reachy_mini_app.ReachyMiniApp``: the on-robot Pollen
+daemon (distinct from our Mac daemon — this is the robot's process manager
+hosting the dashboard at ``http://<robot>:8000``) calls
+``.run(reachy_mini, stop_event)`` when the app is started from the
+dashboard.
+
+**Hardware-only.** ``reachy_mini`` and ``reachy_mini_app`` live in the
+``robot`` optional extra (see ``app/pyproject.toml``) because their
+transitive deps break on non-Linux dev machines. This module is
+importable on any platform because we do NOT inherit from
+``ReachyMiniApp`` at class-definition time — we match its structural
+shape instead. All actual robot-side usage lives inside :meth:`run` /
+:meth:`_run_async`, which are called by the on-robot daemon (where the
+``robot`` extra is installed) and never at import time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from .conversation import run_one_turn
+from .daemon_client import DaemonClient
+from .embodiment.motion_driver import ReachyMotionDriver
+from .embodiment.state_machine import EmbodimentStateMachine
+from .voice.openai_realtime import OpenAIRealtimeVoice
+from .wake import WakeDetector, load_default_wake_detector
+
+
+class ReachyDuckyApp:
+    """Entry point matching ``reachy_mini_app.ReachyMiniApp``'s shape.
+
+    We deliberately do NOT inherit from ``reachy_mini_app.ReachyMiniApp``
+    at class-definition time: the ``reachy_mini_app`` package is in the
+    ``robot`` optional extra (not installed on macOS / Linux CI dev
+    venvs). The on-robot dashboard instantiates this class and calls
+    ``.run(reachy_mini, stop_event)`` structurally — no Python
+    inheritance is required for the dispatch to work.
+    """
+
+    def run(self, reachy_mini: object, stop_event: threading.Event) -> None:
+        """Start the app's main loop. Called by the on-robot Pollen daemon."""
+        asyncio.run(self._run_async(reachy_mini, stop_event))
+
+    async def _run_async(
+        self,
+        reachy_mini: object,
+        stop_event: threading.Event,
+    ) -> None:
+        """Construct the piece graph and poll for wake events until stopped."""
+        driver = ReachyMotionDriver(reachy_mini)
+        sm = EmbodimentStateMachine(driver=driver)
+        voice = OpenAIRealtimeVoice()
+        daemon = DaemonClient.from_env()
+        wake = load_default_wake_detector()
+
+        while not stop_event.is_set():
+            # Phase A simplification: wake detection is stubbed (the default
+            # `MockWakeDetector.feed_audio` returns False unconditionally). A
+            # future task swaps in the real ONNX-backed detector and wires it
+            # to an audio pump that calls `wake.feed_audio(chunk)` on each
+            # mic buffer; `_wake_triggered` is then the bridge between that
+            # pump and the per-turn conversation loop.
+            if self._wake_triggered(wake):
+                await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug=None)
+            await asyncio.sleep(0.05)
+
+    def _wake_triggered(self, wake: WakeDetector) -> bool:
+        """Placeholder: returns False until the real audio pump is wired.
+
+        Overridable in tests to simulate wake events without needing the
+        ONNX model or mic hardware.
+        """
+        del wake
+        return False
+
+
+def main() -> None:
+    """Module-level entry for ``uv run reachy-ducky-app`` (local dev smoke).
+
+    The production path is the on-robot dashboard instantiating
+    :class:`ReachyDuckyApp` via its HF Space entry point. This ``main()``
+    provides a dev-loop on a Mac without hardware — it will exit
+    immediately because the ``stop_event`` is pre-set. Useful mainly for
+    verifying that the import chain wires up.
+    """
+    app = ReachyDuckyApp()
+    stop = threading.Event()
+    stop.set()  # immediate exit; dev-loop only
+    app.run(reachy_mini=None, stop_event=stop)

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -25,6 +25,7 @@ from .conversation import run_one_turn
 from .daemon_client import DaemonClient
 from .embodiment.motion_driver import ReachyMotionDriver
 from .embodiment.state_machine import EmbodimentStateMachine
+from .voice.audio_io import load_default_mic_source, load_default_speaker_sink
 from .voice.openai_realtime import OpenAIRealtimeVoice
 from .wake import WakeDetector, load_default_wake_detector
 
@@ -58,7 +59,10 @@ class ReachyDuckyApp:
         """
         driver = ReachyMotionDriver(reachy_mini)
         sm = EmbodimentStateMachine(driver=driver)
-        voice = OpenAIRealtimeVoice()
+        voice = OpenAIRealtimeVoice(
+            mic=load_default_mic_source(),
+            speaker=load_default_speaker_sink(),
+        )
         daemon = DaemonClient.from_env()
         wake = load_default_wake_detector()
 

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -49,23 +49,32 @@ class ReachyDuckyApp:
         reachy_mini: object,
         stop_event: threading.Event,
     ) -> None:
-        """Construct the piece graph and poll for wake events until stopped."""
+        """Construct the piece graph and poll for wake events until stopped.
+
+        The daemon client pools an ``httpx.AsyncClient`` across turns; we
+        wrap the wake loop in ``try/finally`` so the pool is drained on
+        any exit path — clean shutdown, cancellation, or a crash inside
+        ``run_one_turn``.
+        """
         driver = ReachyMotionDriver(reachy_mini)
         sm = EmbodimentStateMachine(driver=driver)
         voice = OpenAIRealtimeVoice()
         daemon = DaemonClient.from_env()
         wake = load_default_wake_detector()
 
-        while not stop_event.is_set():
-            # Phase A simplification: wake detection is stubbed (the default
-            # `MockWakeDetector.feed_audio` returns False unconditionally). A
-            # future task swaps in the real ONNX-backed detector and wires it
-            # to an audio pump that calls `wake.feed_audio(chunk)` on each
-            # mic buffer; `_wake_triggered` is then the bridge between that
-            # pump and the per-turn conversation loop.
-            if self._wake_triggered(wake):
-                await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug=None)
-            await asyncio.sleep(0.05)
+        try:
+            while not stop_event.is_set():
+                # Phase A simplification: wake detection is stubbed (the default
+                # `MockWakeDetector.feed_audio` returns False unconditionally). A
+                # future task swaps in the real ONNX-backed detector and wires it
+                # to an audio pump that calls `wake.feed_audio(chunk)` on each
+                # mic buffer; `_wake_triggered` is then the bridge between that
+                # pump and the per-turn conversation loop.
+                if self._wake_triggered(wake):
+                    await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug=None)
+                await asyncio.sleep(0.05)
+        finally:
+            await daemon.aclose()
 
     def _wake_triggered(self, wake: WakeDetector) -> bool:
         """Placeholder: returns False until the real audio pump is wired.

--- a/app/src/reachy_ducky_app/mute.py
+++ b/app/src/reachy_ducky_app/mute.py
@@ -1,0 +1,35 @@
+"""Hard mic-gate: last line of defence between the mic and the network."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+
+class MuteGate:
+    """Hard mic-gate.
+
+    When muted, :meth:`process` zeros out audio frames before they reach any
+    downstream consumer (realtime session, wake detector). This is the last
+    line of defence between the mic and the network. Tests must prove that
+    ``process(chunk)`` returns an all-zero array with the same dtype+shape
+    as the input when muted.
+    """
+
+    def __init__(self) -> None:
+        self._muted = False
+
+    @property
+    def muted(self) -> bool:
+        return self._muted
+
+    def set_muted(self, value: bool) -> None:
+        self._muted = value
+
+    def toggle(self) -> None:
+        self._muted = not self._muted
+
+    def process(self, chunk: npt.NDArray[np.int16]) -> npt.NDArray[np.int16]:
+        if self._muted:
+            return np.zeros_like(chunk)
+        return chunk

--- a/app/src/reachy_ducky_app/voice/__init__.py
+++ b/app/src/reachy_ducky_app/voice/__init__.py
@@ -1,8 +1,16 @@
-"""Voice layer: abstract contract + scripted test double."""
+"""Voice layer: abstract contract + scripted test double + OpenAI Realtime."""
 
 from __future__ import annotations
 
 from .interface import VoiceInterface, VoiceTurn
 from .mock import MockVoice, MockVoiceTurn
+from .openai_realtime import OpenAIRealtimeVoice, OpenAIRealtimeVoiceTurn
 
-__all__ = ["MockVoice", "MockVoiceTurn", "VoiceInterface", "VoiceTurn"]
+__all__ = [
+    "MockVoice",
+    "MockVoiceTurn",
+    "OpenAIRealtimeVoice",
+    "OpenAIRealtimeVoiceTurn",
+    "VoiceInterface",
+    "VoiceTurn",
+]

--- a/app/src/reachy_ducky_app/voice/__init__.py
+++ b/app/src/reachy_ducky_app/voice/__init__.py
@@ -1,0 +1,8 @@
+"""Voice layer: abstract contract + scripted test double."""
+
+from __future__ import annotations
+
+from .interface import VoiceInterface, VoiceTurn
+from .mock import MockVoice, MockVoiceTurn
+
+__all__ = ["MockVoice", "MockVoiceTurn", "VoiceInterface", "VoiceTurn"]

--- a/app/src/reachy_ducky_app/voice/__init__.py
+++ b/app/src/reachy_ducky_app/voice/__init__.py
@@ -2,15 +2,29 @@
 
 from __future__ import annotations
 
+from .audio_io import (
+    MicSource,
+    MockMicSource,
+    MockSpeakerSink,
+    SpeakerSink,
+    load_default_mic_source,
+    load_default_speaker_sink,
+)
 from .interface import VoiceInterface, VoiceTurn
 from .mock import MockVoice, MockVoiceTurn
 from .openai_realtime import OpenAIRealtimeVoice, OpenAIRealtimeVoiceTurn
 
 __all__ = [
+    "MicSource",
+    "MockMicSource",
+    "MockSpeakerSink",
     "MockVoice",
     "MockVoiceTurn",
     "OpenAIRealtimeVoice",
     "OpenAIRealtimeVoiceTurn",
+    "SpeakerSink",
     "VoiceInterface",
     "VoiceTurn",
+    "load_default_mic_source",
+    "load_default_speaker_sink",
 ]

--- a/app/src/reachy_ducky_app/voice/audio_io.py
+++ b/app/src/reachy_ducky_app/voice/audio_io.py
@@ -1,0 +1,85 @@
+"""Pluggable mic-in / speaker-out contracts for the voice layer.
+
+Mirrors the :class:`~reachy_ducky_app.wake.WakeDetector` +
+:class:`~reachy_ducky_app.embodiment.motion_driver.MotionDriver` pattern:
+define a narrow ABC, ship a ``MockImpl`` unit-testable without hardware,
+ship a ``load_default_*`` factory that returns the mock today and will
+return a hardware-backed impl once the Reachy audio API is bound
+(tracked as a follow-up).
+
+Audio format: PCM16 little-endian at 24 kHz mono — the format the
+OpenAI Realtime API expects on both input and output. The SDK's
+``input_audio_buffer.append`` and ``response.output_audio.delta`` events
+carry audio as base64-encoded strings; callers of :class:`MicSource`
+and :class:`SpeakerSink` work in raw PCM bytes, and the voice layer
+handles base64 framing at the connection boundary.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Sequence
+
+
+class MicSource(ABC):
+    """Async source of PCM16 mono 24 kHz mic frames."""
+
+    @abstractmethod
+    def frames(self) -> AsyncIterator[bytes]:
+        """Yield PCM audio frames until the turn ends or the source closes."""
+
+
+class SpeakerSink(ABC):
+    """Async sink that plays PCM16 mono 24 kHz frames through a speaker."""
+
+    @abstractmethod
+    async def play(self, pcm: bytes) -> None:
+        """Play one PCM frame. Implementations may buffer internally."""
+
+
+class MockMicSource(MicSource):
+    """Replays a scripted sequence of PCM frames then terminates.
+
+    Default behaviour yields nothing — a bare ``MockMicSource()`` simulates
+    a silent mic (stream ends immediately). Pass ``frames=[b"...", ...]``
+    to replay a scripted payload sequence — useful for driving the full
+    turn orchestration in tests.
+    """
+
+    def __init__(self, frames: Sequence[bytes] | None = None) -> None:
+        self._frames = tuple(frames) if frames is not None else ()
+
+    async def frames(self) -> AsyncIterator[bytes]:
+        for frame in self._frames:
+            yield frame
+
+
+class MockSpeakerSink(SpeakerSink):
+    """Captures played PCM frames in order for test assertions."""
+
+    def __init__(self) -> None:
+        self.played: list[bytes] = []
+
+    async def play(self, pcm: bytes) -> None:
+        self.played.append(pcm)
+
+
+def load_default_mic_source() -> MicSource:
+    """Factory for the production mic source.
+
+    Phase A returns a silent :class:`MockMicSource`. A follow-up issue
+    swaps in a ``ReachyMicSource`` once the Reachy audio API is bound;
+    callers should never instantiate the mock directly outside tests.
+    """
+    return MockMicSource()
+
+
+def load_default_speaker_sink() -> SpeakerSink:
+    """Factory for the production speaker sink.
+
+    Phase A returns a dropping :class:`MockSpeakerSink`. A follow-up
+    issue swaps in a ``ReachySpeakerSink`` once the Reachy audio API is
+    bound; callers should never instantiate the mock directly outside
+    tests.
+    """
+    return MockSpeakerSink()

--- a/app/src/reachy_ducky_app/voice/interface.py
+++ b/app/src/reachy_ducky_app/voice/interface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from contextlib import AbstractAsyncContextManager
 
 
 class VoiceTurn(ABC):
@@ -32,8 +33,26 @@ class VoiceInterface(ABC):
 
     Pluggable: ``OpenAIRealtimeVoice`` (Task 8.2) and future Gemini Live /
     bring-your-own implementations all satisfy this contract.
+
+    ``start_turn`` returns an **async context manager** (not a coroutine
+    yielding a ``VoiceTurn``). Callers use it as::
+
+        async with voice.start_turn() as turn:
+            user = await turn.get_user_text()
+            await turn.speak_text(reply)
+        # resources released here
+
+    This matches the OpenAI SDK's own ``AsyncRealtimeConnectionManager``
+    shape and enforces websocket cleanup at the type level — the outer
+    ``async with`` drives the implementation's ``__aexit__`` whether the
+    body succeeded or raised, so per-turn websockets cannot leak.
     """
 
     @abstractmethod
-    async def start_turn(self) -> VoiceTurn:
-        """Begin a new conversational turn."""
+    def start_turn(self) -> AbstractAsyncContextManager[VoiceTurn]:
+        """Begin a new conversational turn.
+
+        Not ``async def`` on purpose: this returns a context-manager
+        object (typically from ``@asynccontextmanager``) which the caller
+        then drives with ``async with``.
+        """

--- a/app/src/reachy_ducky_app/voice/interface.py
+++ b/app/src/reachy_ducky_app/voice/interface.py
@@ -1,0 +1,39 @@
+"""Abstract voice layer for the Reachy-side app."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class VoiceTurn(ABC):
+    """A single user-Ducky conversational turn.
+
+    Concrete implementations wrap a realtime session (OpenAI Realtime via
+    fastrtc, etc.) OR a deterministic test double. The public surface is
+    intentionally narrow: the brain-layer only needs to get user text,
+    speak a reply, and optionally cut the reply short.
+    """
+
+    @abstractmethod
+    async def get_user_text(self) -> str:
+        """Block until the realtime layer emits a final user transcript."""
+
+    @abstractmethod
+    async def speak_text(self, text: str) -> None:
+        """Send ``text`` to the realtime layer for TTS + playback."""
+
+    @abstractmethod
+    async def interrupt(self) -> None:
+        """Cancel any in-flight reply (barge-in)."""
+
+
+class VoiceInterface(ABC):
+    """Factory for :class:`VoiceTurn`.
+
+    Pluggable: ``OpenAIRealtimeVoice`` (Task 8.2) and future Gemini Live /
+    bring-your-own implementations all satisfy this contract.
+    """
+
+    @abstractmethod
+    async def start_turn(self) -> VoiceTurn:
+        """Begin a new conversational turn."""

--- a/app/src/reachy_ducky_app/voice/mock.py
+++ b/app/src/reachy_ducky_app/voice/mock.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+
 from .interface import VoiceInterface, VoiceTurn
 
 
@@ -37,5 +40,21 @@ class MockVoice(VoiceInterface):
         # without driving it themselves.
         self._reply = scripted_reply_text
 
-    async def start_turn(self) -> VoiceTurn:
-        return MockVoiceTurn(self._user_text)
+    def start_turn(self) -> AbstractAsyncContextManager[MockVoiceTurn]:
+        """Return an async context manager that yields a :class:`MockVoiceTurn`.
+
+        The mock has no underlying connection to release, but the shape
+        matches :class:`~reachy_ducky_app.voice.openai_realtime.OpenAIRealtimeVoice`'s
+        so tests exercise the same control-flow as production. Subclasses
+        (e.g. the conversation-test spies) override this method and
+        wrap/replace the returned CM; declaring the return type as
+        :class:`AbstractAsyncContextManager` lets those overrides compose
+        naturally without fighting mypy about the private
+        ``_AsyncGeneratorContextManager`` coming out of
+        ``@asynccontextmanager``.
+        """
+        return self._make_turn_cm()
+
+    @asynccontextmanager
+    async def _make_turn_cm(self) -> AsyncIterator[MockVoiceTurn]:
+        yield MockVoiceTurn(self._user_text)

--- a/app/src/reachy_ducky_app/voice/mock.py
+++ b/app/src/reachy_ducky_app/voice/mock.py
@@ -1,0 +1,41 @@
+"""Scripted test double for :class:`VoiceInterface`."""
+
+from __future__ import annotations
+
+from .interface import VoiceInterface, VoiceTurn
+
+
+class MockVoiceTurn(VoiceTurn):
+    """In-memory :class:`VoiceTurn` that records side effects for assertions."""
+
+    def __init__(self, user_text: str) -> None:
+        self._user_text = user_text
+        self.spoken_texts: list[str] = []
+        self.interrupted: bool = False
+
+    async def get_user_text(self) -> str:
+        return self._user_text
+
+    async def speak_text(self, text: str) -> None:
+        self.spoken_texts.append(text)
+
+    async def interrupt(self) -> None:
+        self.interrupted = True
+
+
+class MockVoice(VoiceInterface):
+    """Test double. Scripted user text; captures everything spoken."""
+
+    def __init__(
+        self,
+        *,
+        scripted_user_text: str,
+        scripted_reply_text: str = "",
+    ) -> None:
+        self._user_text = scripted_user_text
+        # Reserved for future use: tests that want to assert the reply path
+        # without driving it themselves.
+        self._reply = scripted_reply_text
+
+    async def start_turn(self) -> VoiceTurn:
+        return MockVoiceTurn(self._user_text)

--- a/app/src/reachy_ducky_app/voice/openai_realtime.py
+++ b/app/src/reachy_ducky_app/voice/openai_realtime.py
@@ -1,0 +1,161 @@
+"""OpenAI Realtime voice implementation.
+
+Wraps the OpenAI Python SDK's realtime WebSocket session behind our
+:class:`~reachy_ducky_app.voice.interface.VoiceInterface`. The SDK handles
+STT + TTS + turn-taking + barge-in at the protocol level; our job is to
+plumb the events through our narrow :class:`VoiceTurn` contract.
+
+**Not run in unit tests.** The stateful session methods require a live
+connection to OpenAI. Unit coverage is construction-shape only (API-key
+plumbing, model plumbing, export surface). One ``@pytest.mark.integration``
+smoke (gated by ``REACHY_DUCKY_RUN_INTEGRATION=1`` + ``OPENAI_API_KEY``)
+opens a real WebSocket session to validate the plumbing.
+
+Verified SDK shape (``openai==1.109.1``)
+-----------------------------------------
+The installed SDK diverges from the Phase A plan sketch in four places,
+so this module adapts:
+
+1. **Session open.** The plan sketch calls
+   ``client.beta.realtime.sessions.create(model=...)``. In 1.109.1 that is
+   a *REST* call returning a ``SessionCreateResponse`` carrying an ephemeral
+   client-secret for browser/WebRTC flows. It does **not** open a live
+   session. The correct path is ``client.realtime.connect(model=...)``,
+   which returns an ``AsyncRealtimeConnectionManager`` (async context
+   manager). Entering it yields an ``AsyncRealtimeConnection`` — the live
+   WebSocket session with ``.response``, ``.session``, ``.input_audio_buffer``,
+   ``.conversation``, ``.output_audio_buffer`` namespace resources and
+   ``.send / .recv / .close`` primitives.
+
+2. **Event iteration.** The plan sketch iterates ``self._session.events()``.
+   The installed SDK's ``AsyncRealtimeConnection`` is itself async-iterable
+   (``async for event in conn``) and also exposes ``await conn.recv()``.
+   We iterate the connection directly.
+
+3. **Final user transcript.** Final transcript arrives as a
+   ``ConversationItemInputAudioTranscriptionCompletedEvent`` whose
+   ``type`` literal is ``"conversation.item.input_audio_transcription.completed"``
+   and whose ``.transcript`` attribute carries the text.
+
+4. **Response create/cancel.** ``conn.response.create(response=params)`` —
+   param field is ``output_modalities`` (not ``modalities`` as in the plan
+   sketch). ``conn.response.cancel()`` — no arguments needed for the
+   common barge-in case.
+
+``fastrtc`` is not wired. The ``openai`` SDK handles the WebSocket transport
+directly; ``fastrtc`` is only needed for browser-style full-duplex WebRTC,
+which is not the Phase A app's topology (mic + speaker on the robot talk
+to OpenAI over a WebSocket from the robot's own process). The ``fastrtc``
+pin in ``pyproject.toml`` remains for future work (e.g., streaming audio
+to a menu-bar preview) but is unused here.
+
+Lifecycle
+---------
+:meth:`OpenAIRealtimeVoice.start_turn` opens a fresh ``AsyncRealtimeConnection``
+per turn. The :class:`VoiceTurn` contract does not declare a close method, so
+callers who want deterministic teardown reach through
+:attr:`OpenAIRealtimeVoiceTurn.connection` and call ``.close()`` directly.
+This matches the Phase A plan's shape; a future extension may add
+``VoiceTurn.aclose`` to the shared contract.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
+    ConversationItemInputAudioTranscriptionCompletedEvent,
+)
+
+from .interface import VoiceInterface, VoiceTurn
+
+if TYPE_CHECKING:
+    from openai.resources.realtime.realtime import AsyncRealtimeConnection
+
+
+class OpenAIRealtimeVoiceTurn(VoiceTurn):
+    """One realtime WebSocket session = one turn.
+
+    See module docstring for the verified SDK shape. ``connection`` is an
+    ``openai.resources.realtime.realtime.AsyncRealtimeConnection`` obtained
+    from ``AsyncRealtimeConnectionManager.enter()``.
+    """
+
+    def __init__(self, connection: AsyncRealtimeConnection) -> None:
+        self._connection = connection
+        self._interrupted = False
+
+    @property
+    def connection(self) -> AsyncRealtimeConnection:
+        """Escape hatch to the underlying SDK connection for lifecycle control."""
+        return self._connection
+
+    async def get_user_text(self) -> str:
+        """Iterate server events until the final user transcript arrives.
+
+        Returns the ``.transcript`` attribute of the first
+        ``conversation.item.input_audio_transcription.completed`` event.
+        Blocks until that event arrives; the SDK's async iterator handles
+        framing and keep-alives.
+        """
+        async for event in self._connection:
+            if isinstance(event, ConversationItemInputAudioTranscriptionCompletedEvent):
+                return event.transcript
+        # Iterator terminated (connection closed) without yielding a final
+        # transcript. Surface the empty string rather than raising so the
+        # caller can decide what to do with silence.
+        return ""
+
+    async def speak_text(self, text: str) -> None:
+        """Ask the SDK to TTS-and-play ``text`` as the assistant turn.
+
+        Uses ``response.create`` with ``instructions=text`` and both audio +
+        text output modalities. The SDK streams audio chunks over the
+        WebSocket; the transport layer (robot's speaker) handles playback.
+        """
+        await self._connection.response.create(
+            response={
+                "output_modalities": ["audio", "text"],
+                "instructions": text,
+            },
+        )
+
+    async def interrupt(self) -> None:
+        """Cancel the in-flight assistant response for barge-in."""
+        self._interrupted = True
+        await self._connection.response.cancel()
+
+
+class OpenAIRealtimeVoice(VoiceInterface):
+    """Factory for :class:`OpenAIRealtimeVoiceTurn`.
+
+    Reads ``OPENAI_API_KEY`` from the environment at construction unless
+    ``api_key=`` is passed explicitly. Fails fast with :class:`ValueError`
+    if neither source is populated — catching a missing credential at
+    startup beats a cryptic WebSocket handshake error on first use.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-realtime",
+        *,
+        api_key: str | None = None,
+    ) -> None:
+        self._model = model
+        self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not self._api_key:
+            raise ValueError("OPENAI_API_KEY not set and no api_key= argument provided")
+
+    async def start_turn(self) -> VoiceTurn:
+        """Open a fresh realtime WebSocket and wrap it in a :class:`VoiceTurn`.
+
+        Lazy-imports :class:`openai.AsyncOpenAI` so unit tests that only
+        exercise construction-shape don't pay the SDK's import cost.
+        """
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(api_key=self._api_key)
+        manager = client.realtime.connect(model=self._model)
+        connection = await manager.enter()
+        return OpenAIRealtimeVoiceTurn(connection)

--- a/app/src/reachy_ducky_app/voice/openai_realtime.py
+++ b/app/src/reachy_ducky_app/voice/openai_realtime.py
@@ -198,10 +198,18 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
         finally:
             if not pump_task.done():
                 pump_task.cancel()
-                try:
-                    await pump_task
-                except asyncio.CancelledError:
-                    pass
+            # Always retrieve the pump's result/exception, even when the
+            # task already finished. If it raised (mic hardware failure)
+            # and we reached this finally via an early transcript return,
+            # the stored exception would otherwise be orphaned — Python
+            # emits "Task exception was never retrieved" and the real
+            # mic failure is silently swallowed. Re-raising here promotes
+            # the mic error over a stale transcript, which is the correct
+            # priority for hardware-level failures.
+            try:
+                await pump_task
+            except asyncio.CancelledError:
+                pass
 
     async def speak_text(self, text: str) -> None:
         """Ask the SDK to TTS-and-play ``text`` as the assistant turn.

--- a/app/src/reachy_ducky_app/voice/openai_realtime.py
+++ b/app/src/reachy_ducky_app/voice/openai_realtime.py
@@ -40,7 +40,11 @@ so this module adapts:
 4. **Response create/cancel.** ``conn.response.create(response=params)`` —
    param field is ``output_modalities`` (not ``modalities`` as in the plan
    sketch). ``conn.response.cancel()`` — no arguments needed for the
-   common barge-in case.
+   common barge-in case. The terminal server event for *any* response
+   (completed / cancelled / failed / incomplete) is a single
+   ``ResponseDoneEvent``; its ``response.status`` field disambiguates
+   the four cases. Session-level problems arrive as ``RealtimeErrorEvent``
+   with ``type == "error"``, decoupled from any specific response.
 
 ``fastrtc`` is not wired. The ``openai`` SDK handles the WebSocket transport
 directly; ``fastrtc`` is only needed for browser-style full-duplex WebRTC,
@@ -68,11 +72,13 @@ returned a bare ``VoiceTurn`` and leaked the websocket on every turn.
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+from openai.types.realtime import RealtimeErrorEvent, ResponseDoneEvent
 from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
     ConversationItemInputAudioTranscriptionCompletedEvent,
 )
@@ -81,6 +87,8 @@ from .interface import VoiceInterface, VoiceTurn
 
 if TYPE_CHECKING:
     from openai.resources.realtime.realtime import AsyncRealtimeConnection
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAIRealtimeVoiceTurn(VoiceTurn):
@@ -125,6 +133,17 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
         Uses ``response.create`` with ``instructions=text`` and both audio +
         text output modalities. The SDK streams audio chunks over the
         WebSocket; the transport layer (robot's speaker) handles playback.
+
+        Drains the connection's event iterator until the terminal
+        ``response.done`` (completed / cancelled / failed / incomplete)
+        arrives. Returning earlier would let the enclosing ``start_turn``
+        context manager close the websocket mid-stream, truncating audio.
+
+        Best-effort semantics: a failed response or a session-level error
+        event is logged at WARNING and returns cleanly, so the caller's
+        state machine still progresses. ``interrupt()`` funnels through
+        the same drain — the server emits ``response.done`` with
+        ``status == "cancelled"``, which this loop observes and exits on.
         """
         await self._connection.response.create(
             response={
@@ -132,6 +151,24 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
                 "instructions": text,
             },
         )
+        async for event in self._connection:
+            if isinstance(event, ResponseDoneEvent):
+                status = event.response.status
+                if status in ("failed", "incomplete"):
+                    logger.warning(
+                        "realtime response ended without completing",
+                        extra={"status": status, "response_id": event.response.id},
+                    )
+                return
+            if isinstance(event, RealtimeErrorEvent):
+                logger.warning(
+                    "realtime session error during speak_text",
+                    extra={
+                        "error_type": event.error.type,
+                        "error_code": event.error.code,
+                    },
+                )
+                return
 
     async def interrupt(self) -> None:
         """Cancel the in-flight assistant response for barge-in."""

--- a/app/src/reachy_ducky_app/voice/openai_realtime.py
+++ b/app/src/reachy_ducky_app/voice/openai_realtime.py
@@ -3,17 +3,21 @@
 Wraps the OpenAI Python SDK's realtime WebSocket session behind our
 :class:`~reachy_ducky_app.voice.interface.VoiceInterface`. The SDK handles
 STT + TTS + turn-taking + barge-in at the protocol level; our job is to
-plumb the events through our narrow :class:`VoiceTurn` contract.
+plumb the events through our narrow :class:`VoiceTurn` contract and to
+shuttle raw PCM between the :class:`MicSource` / :class:`SpeakerSink`
+abstractions and the SDK's base64-framed audio events.
 
 **Not run in unit tests.** The stateful session methods require a live
 connection to OpenAI. Unit coverage is construction-shape only (API-key
-plumbing, model plumbing, export surface). One ``@pytest.mark.integration``
-smoke (gated by ``REACHY_DUCKY_RUN_INTEGRATION=1`` + ``OPENAI_API_KEY``)
-opens a real WebSocket session to validate the plumbing.
+plumbing, model plumbing, export surface) plus scripted-event drain /
+mic-pump tests that drive the turn through a fake ``AsyncRealtimeConnection``.
+One ``@pytest.mark.integration`` smoke (gated by
+``REACHY_DUCKY_RUN_INTEGRATION=1`` + ``OPENAI_API_KEY``) opens a real
+WebSocket session to validate the plumbing.
 
 Verified SDK shape (``openai==1.109.1``)
 -----------------------------------------
-The installed SDK diverges from the Phase A plan sketch in four places,
+The installed SDK diverges from the Phase A plan sketch in six places,
 so this module adapts:
 
 1. **Session open.** The plan sketch calls
@@ -37,7 +41,23 @@ so this module adapts:
    ``type`` literal is ``"conversation.item.input_audio_transcription.completed"``
    and whose ``.transcript`` attribute carries the text.
 
-4. **Response create/cancel.** ``conn.response.create(response=params)`` —
+4. **Mic in.** Raw PCM frames from the :class:`MicSource` are
+   base64-encoded and sent via
+   ``conn.input_audio_buffer.append(audio=<base64>)``. With the default
+   server-VAD ``turn_detection``, the server commits the buffer and
+   triggers transcription on its own — no explicit ``.commit()`` call is
+   needed from our side. We run the mic pump as a background task so it
+   runs concurrently with the event drain that waits for the final
+   transcription event; when the drain loop returns (or raises), the
+   pump is cancelled in ``finally``.
+
+5. **Speaker out.** Assistant TTS audio arrives as a stream of
+   ``ResponseAudioDeltaEvent`` (``response.output_audio.delta``) whose
+   ``.delta`` attribute is a base64-encoded PCM payload. We decode each
+   delta and forward the raw bytes to :meth:`SpeakerSink.play` — the
+   transport-tier implementation decides how to buffer and render.
+
+6. **Response create/cancel.** ``conn.response.create(response=params)`` —
    param field is ``output_modalities`` (not ``modalities`` as in the plan
    sketch). ``conn.response.cancel()`` — no arguments needed for the
    common barge-in case. The terminal server event for *any* response
@@ -72,17 +92,24 @@ returned a bare ``VoiceTurn`` and leaked the websocket on every turn.
 
 from __future__ import annotations
 
+import asyncio
+import base64
 import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-from openai.types.realtime import RealtimeErrorEvent, ResponseDoneEvent
+from openai.types.realtime import (
+    RealtimeErrorEvent,
+    ResponseAudioDeltaEvent,
+    ResponseDoneEvent,
+)
 from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
     ConversationItemInputAudioTranscriptionCompletedEvent,
 )
 
+from .audio_io import MicSource, SpeakerSink
 from .interface import VoiceInterface, VoiceTurn
 
 if TYPE_CHECKING:
@@ -102,8 +129,16 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
     race with the outer ``async with`` and risk double-close.
     """
 
-    def __init__(self, connection: AsyncRealtimeConnection) -> None:
+    def __init__(
+        self,
+        connection: AsyncRealtimeConnection,
+        *,
+        mic: MicSource,
+        speaker: SpeakerSink,
+    ) -> None:
         self._connection = connection
+        self._mic = mic
+        self._speaker = speaker
         self._interrupted = False
 
     @property
@@ -112,27 +147,71 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
         return self._connection
 
     async def get_user_text(self) -> str:
-        """Iterate server events until the final user transcript arrives.
+        """Pump mic frames into the session; drain events for final transcript.
 
-        Returns the ``.transcript`` attribute of the first
-        ``conversation.item.input_audio_transcription.completed`` event.
-        Blocks until that event arrives; the SDK's async iterator handles
-        framing and keep-alives.
+        Two concurrent tasks run:
+
+        * A **mic pump** that iterates :meth:`MicSource.frames`,
+          base64-encodes each raw PCM frame, and calls
+          ``connection.input_audio_buffer.append(audio=<base64>)``.
+          With server-VAD turn_detection (the SDK default) the server
+          decides when speech has ended and commits the buffer itself.
+        * The **event drain** on ``self._connection``, which returns the
+          ``.transcript`` of the first
+          ``ConversationItemInputAudioTranscriptionCompletedEvent``.
+
+        The pump is a background :class:`asyncio.Task` and is cancelled
+        in ``finally`` when the drain loop exits — whether that's because
+        transcription completed, the connection closed without a final
+        event, or an exception unwound through the drain. If the pump
+        raises (e.g. the mic hardware disconnected) the exception is
+        surfaced to the caller via the awaited task's result during
+        cleanup.
         """
-        async for event in self._connection:
-            if isinstance(event, ConversationItemInputAudioTranscriptionCompletedEvent):
-                return event.transcript
-        # Iterator terminated (connection closed) without yielding a final
-        # transcript. Surface the empty string rather than raising so the
-        # caller can decide what to do with silence.
-        return ""
+
+        async def _pump_mic() -> None:
+            async for frame in self._mic.frames():
+                b64 = base64.b64encode(frame).decode("ascii")
+                await self._connection.input_audio_buffer.append(audio=b64)
+
+        pump_task = asyncio.create_task(_pump_mic())
+        try:
+            async for event in self._connection:
+                if isinstance(event, ConversationItemInputAudioTranscriptionCompletedEvent):
+                    return event.transcript
+                # If the mic pump has failed we want to see the error
+                # rather than waiting forever for a transcript that can
+                # never arrive — surface it promptly.
+                if pump_task.done() and not pump_task.cancelled():
+                    pump_exc = pump_task.exception()
+                    if pump_exc is not None:
+                        raise pump_exc
+            # Iterator terminated (connection closed) without yielding a
+            # final transcript. Let the pump run to completion so a mic
+            # failure surfaces in place of ordinary silence — without
+            # this yield the pump may never have been scheduled.
+            try:
+                await pump_task
+            except asyncio.CancelledError:
+                pass
+            return ""
+        finally:
+            if not pump_task.done():
+                pump_task.cancel()
+                try:
+                    await pump_task
+                except asyncio.CancelledError:
+                    pass
 
     async def speak_text(self, text: str) -> None:
         """Ask the SDK to TTS-and-play ``text`` as the assistant turn.
 
         Uses ``response.create`` with ``instructions=text`` and both audio +
         text output modalities. The SDK streams audio chunks over the
-        WebSocket; the transport layer (robot's speaker) handles playback.
+        WebSocket as ``response.output_audio.delta`` events
+        (:class:`ResponseAudioDeltaEvent`); each ``.delta`` field is a
+        base64-encoded PCM payload that we decode and forward to
+        :meth:`SpeakerSink.play`.
 
         Drains the connection's event iterator until the terminal
         ``response.done`` (completed / cancelled / failed / incomplete)
@@ -152,6 +231,10 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
             },
         )
         async for event in self._connection:
+            if isinstance(event, ResponseAudioDeltaEvent):
+                pcm = base64.b64decode(event.delta)
+                await self._speaker.play(pcm)
+                continue
             if isinstance(event, ResponseDoneEvent):
                 status = event.response.status
                 if status in ("failed", "incomplete"):
@@ -183,15 +266,26 @@ class OpenAIRealtimeVoice(VoiceInterface):
     ``api_key=`` is passed explicitly. Fails fast with :class:`ValueError`
     if neither source is populated — catching a missing credential at
     startup beats a cryptic WebSocket handshake error on first use.
+
+    ``mic`` and ``speaker`` are required. Production code wires them via
+    :func:`~reachy_ducky_app.voice.audio_io.load_default_mic_source` and
+    :func:`~reachy_ducky_app.voice.audio_io.load_default_speaker_sink`
+    (today a silent mock, eventually the Reachy hardware bindings).
+    Tests can pass :class:`MockMicSource` /
+    :class:`MockSpeakerSink` directly.
     """
 
     def __init__(
         self,
         model: str = "gpt-realtime",
         *,
+        mic: MicSource,
+        speaker: SpeakerSink,
         api_key: str | None = None,
     ) -> None:
         self._model = model
+        self._mic = mic
+        self._speaker = speaker
         self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
         if not self._api_key:
             raise ValueError("OPENAI_API_KEY not set and no api_key= argument provided")
@@ -214,4 +308,8 @@ class OpenAIRealtimeVoice(VoiceInterface):
 
         client = AsyncOpenAI(api_key=self._api_key)
         async with client.realtime.connect(model=self._model) as connection:
-            yield OpenAIRealtimeVoiceTurn(connection)
+            yield OpenAIRealtimeVoiceTurn(
+                connection,
+                mic=self._mic,
+                speaker=self._speaker,
+            )

--- a/app/src/reachy_ducky_app/voice/openai_realtime.py
+++ b/app/src/reachy_ducky_app/voice/openai_realtime.py
@@ -51,17 +51,26 @@ to a menu-bar preview) but is unused here.
 
 Lifecycle
 ---------
-:meth:`OpenAIRealtimeVoice.start_turn` opens a fresh ``AsyncRealtimeConnection``
-per turn. The :class:`VoiceTurn` contract does not declare a close method, so
-callers who want deterministic teardown reach through
-:attr:`OpenAIRealtimeVoiceTurn.connection` and call ``.close()`` directly.
-This matches the Phase A plan's shape; a future extension may add
-``VoiceTurn.aclose`` to the shared contract.
+:meth:`OpenAIRealtimeVoice.start_turn` is an ``@asynccontextmanager`` that
+opens a fresh ``AsyncRealtimeConnection`` per turn via
+``async with client.realtime.connect(...)``. The outer ``async with`` in
+the caller drives the connection's ``__aexit__`` — closing the websocket
+whether the turn body returned normally or raised. Callers therefore use::
+
+    async with voice.start_turn() as turn:
+        await turn.get_user_text()
+        await turn.speak_text(reply)
+    # websocket closed here, unconditionally
+
+This structural cleanup is what fixed bug I1 — an earlier revision
+returned a bare ``VoiceTurn`` and leaked the websocket on every turn.
 """
 
 from __future__ import annotations
 
 import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
@@ -78,8 +87,11 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
     """One realtime WebSocket session = one turn.
 
     See module docstring for the verified SDK shape. ``connection`` is an
-    ``openai.resources.realtime.realtime.AsyncRealtimeConnection`` obtained
-    from ``AsyncRealtimeConnectionManager.enter()``.
+    ``openai.resources.realtime.realtime.AsyncRealtimeConnection`` yielded
+    from ``async with AsyncRealtimeConnectionManager``. Its lifetime is
+    owned by the enclosing :meth:`OpenAIRealtimeVoice.start_turn` context
+    manager — this class does not close the connection itself; that would
+    race with the outer ``async with`` and risk double-close.
     """
 
     def __init__(self, connection: AsyncRealtimeConnection) -> None:
@@ -88,7 +100,7 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
 
     @property
     def connection(self) -> AsyncRealtimeConnection:
-        """Escape hatch to the underlying SDK connection for lifecycle control."""
+        """Escape hatch to the underlying SDK connection for advanced callers."""
         return self._connection
 
     async def get_user_text(self) -> str:
@@ -147,8 +159,16 @@ class OpenAIRealtimeVoice(VoiceInterface):
         if not self._api_key:
             raise ValueError("OPENAI_API_KEY not set and no api_key= argument provided")
 
-    async def start_turn(self) -> VoiceTurn:
-        """Open a fresh realtime WebSocket and wrap it in a :class:`VoiceTurn`.
+    @asynccontextmanager
+    async def start_turn(self) -> AsyncIterator[OpenAIRealtimeVoiceTurn]:
+        """Open a fresh realtime WebSocket and yield a :class:`VoiceTurn`.
+
+        The SDK's ``client.realtime.connect(model=...)`` returns an
+        ``AsyncRealtimeConnectionManager``; entering it yields the live
+        :class:`AsyncRealtimeConnection`. We hold that manager as an
+        ``async with`` here, so when the caller's ``async with`` closes,
+        our ``finally``-equivalent drives the SDK manager's ``__aexit__``
+        and the websocket is released.
 
         Lazy-imports :class:`openai.AsyncOpenAI` so unit tests that only
         exercise construction-shape don't pay the SDK's import cost.
@@ -156,6 +176,5 @@ class OpenAIRealtimeVoice(VoiceInterface):
         from openai import AsyncOpenAI
 
         client = AsyncOpenAI(api_key=self._api_key)
-        manager = client.realtime.connect(model=self._model)
-        connection = await manager.enter()
-        return OpenAIRealtimeVoiceTurn(connection)
+        async with client.realtime.connect(model=self._model) as connection:
+            yield OpenAIRealtimeVoiceTurn(connection)

--- a/app/src/reachy_ducky_app/wake.py
+++ b/app/src/reachy_ducky_app/wake.py
@@ -1,0 +1,56 @@
+"""Wake-word detection: abstract contract + deterministic mock + factory.
+
+Phase A ships with :class:`MockWakeDetector`; Task 8.2+ swaps in an ONNX-backed
+real implementation (e.g. openWakeWord or a community Hugging Face Space
+model) without touching callers.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+import numpy.typing as npt
+
+
+class WakeDetector(ABC):
+    """Consumes raw audio chunks, returns True once per wake-word hit.
+
+    Real implementations wrap an ONNX model. :class:`MockWakeDetector` here
+    is pure Python and deterministic for tests.
+    """
+
+    @abstractmethod
+    def feed_audio(self, audio_chunk: npt.NDArray[np.int16]) -> bool:
+        """Return True when the wake word is detected in this chunk."""
+
+
+class MockWakeDetector(WakeDetector):
+    """Test double.
+
+    ``feed_audio`` always returns False; ``detect_in_text`` is a simple
+    substring check so tests can simulate "heard the phrase".
+    """
+
+    def __init__(self, trigger_on: str = "hey ducky") -> None:
+        self._trigger = trigger_on.lower()
+
+    def feed_audio(self, audio_chunk: npt.NDArray[np.int16]) -> bool:
+        del audio_chunk  # mock doesn't analyse audio
+        return False
+
+    def detect_in_text(self, text: str) -> bool:
+        return self._trigger in text.lower()
+
+
+def load_default_wake_detector() -> WakeDetector:
+    """Factory for the production wake detector.
+
+    Phase A ships a mock; a later task swaps in the ONNX-backed real one.
+    Separating load-time selection from class definition keeps the mock
+    directly constructible in unit tests without going through a factory
+    that might eventually spawn subprocesses.
+    """
+    # TODO: swap in the ONNX-backed detector (openWakeWord / community HF
+    # Space model) once Task 8.2+ lands.
+    return MockWakeDetector()

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from reachy_ducky_app.main import ReachyDuckyApp, main
+from reachy_ducky_app.voice.audio_io import MicSource, MockMicSource, MockSpeakerSink, SpeakerSink
 from reachy_ducky_app.wake import MockWakeDetector, WakeDetector
 
 
@@ -134,6 +135,54 @@ async def test_run_async_closes_daemon_client_on_shutdown(
     )
 
     fake_daemon.aclose.assert_awaited_once()
+
+
+async def test_run_async_constructs_voice_with_default_mic_and_speaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The app wires the default audio_io factories into OpenAIRealtimeVoice.
+
+    Guards the commit-3 wiring: ``_run_async`` must call
+    :func:`load_default_mic_source` and :func:`load_default_speaker_sink`
+    (the same pattern as ``load_default_wake_detector``) rather than
+    hard-coding Mock impls directly. When the hardware-backed factory
+    bodies land, ``main.py`` should require zero changes.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    mic_factory_calls = 0
+    speaker_factory_calls = 0
+
+    def _spy_mic_factory() -> MicSource:
+        nonlocal mic_factory_calls
+        mic_factory_calls += 1
+        return MockMicSource()
+
+    def _spy_speaker_factory() -> SpeakerSink:
+        nonlocal speaker_factory_calls
+        speaker_factory_calls += 1
+        return MockSpeakerSink()
+
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.load_default_mic_source",
+        _spy_mic_factory,
+    )
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.load_default_speaker_sink",
+        _spy_speaker_factory,
+    )
+
+    app = ReachyDuckyApp()
+    stop = threading.Event()
+    stop.set()
+
+    await asyncio.wait_for(
+        app._run_async(reachy_mini=object(), stop_event=stop),
+        timeout=0.5,
+    )
+
+    assert mic_factory_calls == 1
+    assert speaker_factory_calls == 1
 
 
 async def test_run_async_closes_daemon_client_even_when_turn_raises(

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from reachy_ducky_app.main import ReachyDuckyApp, main
@@ -102,3 +103,79 @@ def test_main_exits_with_stopped_event(monkeypatch: pytest.MonkeyPatch) -> None:
     # it; belt-and-braces, the stop_event.set() inside main() guarantees the
     # loop body is skipped, so this returns synchronously.
     main()
+
+
+async def test_run_async_closes_daemon_client_on_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On shutdown, the app calls ``daemon.aclose()`` to release the pool.
+
+    Regression for bug I2: pools the httpx.AsyncClient across calls, so
+    it must be drained on stop. We mock ``DaemonClient.from_env`` to
+    return a spy whose ``aclose`` is an :class:`AsyncMock`, immediately
+    stop the event, and assert ``aclose`` was awaited exactly once.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    fake_daemon = MagicMock()
+    fake_daemon.aclose = AsyncMock()
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.DaemonClient.from_env",
+        MagicMock(return_value=fake_daemon),
+    )
+
+    app = ReachyDuckyApp()
+    stop = threading.Event()
+    stop.set()
+
+    await asyncio.wait_for(
+        app._run_async(reachy_mini=object(), stop_event=stop),
+        timeout=0.5,
+    )
+
+    fake_daemon.aclose.assert_awaited_once()
+
+
+async def test_run_async_closes_daemon_client_even_when_turn_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``run_one_turn`` raises, ``daemon.aclose()`` must still be awaited.
+
+    Guards that the ``try/finally`` wraps the whole wake loop, so the
+    pool is drained on crash as well as clean shutdown.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    fake_daemon = MagicMock()
+    fake_daemon.aclose = AsyncMock()
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.DaemonClient.from_env",
+        MagicMock(return_value=fake_daemon),
+    )
+
+    class _BoomError(RuntimeError):
+        pass
+
+    async def _blowing_up(**kwargs: object) -> None:
+        raise _BoomError("turn failed")
+
+    monkeypatch.setattr("reachy_ducky_app.main.run_one_turn", _blowing_up)
+
+    stop = threading.Event()
+
+    class _OneShotApp(ReachyDuckyApp):
+        """Wake triggers once to drive the loop into ``run_one_turn``."""
+
+        def _wake_triggered(self, wake: WakeDetector) -> bool:
+            del wake
+            return True
+
+    app = _OneShotApp()
+
+    with pytest.raises(_BoomError):
+        await asyncio.wait_for(
+            app._run_async(reachy_mini=object(), stop_event=stop),
+            timeout=0.5,
+        )
+
+    fake_daemon.aclose.assert_awaited_once()

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -1,0 +1,104 @@
+"""Tests for :mod:`reachy_ducky_app.main` — the Reachy-side entry point.
+
+These tests do NOT install the ``robot`` extra (``reachy_mini`` /
+``reachy_mini_app``). The module is designed to be importable on Linux CI
+and macOS dev venvs where those hardware-only deps are absent; tests
+verify the construction path via a fake ``reachy_mini`` stand-in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from reachy_ducky_app.main import ReachyDuckyApp, main
+from reachy_ducky_app.wake import MockWakeDetector, WakeDetector
+
+
+def test_reachy_ducky_app_imports_cleanly() -> None:
+    """``ReachyDuckyApp`` + ``main`` import without the robot extra installed."""
+    assert ReachyDuckyApp is not None
+    assert callable(main)
+
+
+def test_wake_triggered_placeholder_returns_false() -> None:
+    """Baseline lock: the Phase A ``_wake_triggered`` stub always returns False."""
+    app = ReachyDuckyApp()
+    assert app._wake_triggered(MockWakeDetector()) is False
+
+
+async def test_run_async_exits_immediately_when_stop_event_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-set stop_event: ``_run_async`` must return without running any turn."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    run_one_turn_calls: list[object] = []
+
+    async def _spy_run_one_turn(**kwargs: object) -> None:
+        run_one_turn_calls.append(kwargs)
+
+    monkeypatch.setattr("reachy_ducky_app.main.run_one_turn", _spy_run_one_turn)
+
+    app = ReachyDuckyApp()
+    stop = threading.Event()
+    stop.set()
+
+    await asyncio.wait_for(
+        app._run_async(reachy_mini=object(), stop_event=stop),
+        timeout=0.5,
+    )
+
+    assert run_one_turn_calls == []
+
+
+async def test_run_async_calls_run_one_turn_when_wake_triggers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wake trigger True on first tick => exactly one ``run_one_turn`` call."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    run_one_turn_calls: list[dict[str, object]] = []
+
+    async def _spy_run_one_turn(**kwargs: object) -> None:
+        run_one_turn_calls.append(kwargs)
+
+    monkeypatch.setattr("reachy_ducky_app.main.run_one_turn", _spy_run_one_turn)
+
+    stop = threading.Event()
+
+    class _OneShotApp(ReachyDuckyApp):
+        """Trigger wake exactly once, then stop the loop on the next tick."""
+
+        def __init__(self) -> None:
+            self._calls = 0
+
+        def _wake_triggered(self, wake: WakeDetector) -> bool:
+            del wake
+            self._calls += 1
+            if self._calls == 1:
+                return True
+            stop.set()
+            return False
+
+    app = _OneShotApp()
+    await asyncio.wait_for(
+        app._run_async(reachy_mini=object(), stop_event=stop),
+        timeout=1.0,
+    )
+
+    assert len(run_one_turn_calls) == 1
+    assert "voice" in run_one_turn_calls[0]
+    assert "sm" in run_one_turn_calls[0]
+    assert "daemon" in run_one_turn_calls[0]
+    assert run_one_turn_calls[0]["project_slug"] is None
+
+
+def test_main_exits_with_stopped_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``main()`` pre-sets the stop event and returns cleanly (no hang)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    # If main() hangs, pytest's per-test timeout (or CI watchdog) will catch
+    # it; belt-and-braces, the stop_event.set() inside main() guarantees the
+    # loop body is skipped, so this returns synchronously.
+    main()

--- a/app/tests/test_audio_io.py
+++ b/app/tests/test_audio_io.py
@@ -1,0 +1,78 @@
+"""Tests for :mod:`reachy_ducky_app.voice.audio_io` — the pluggable audio I/O layer.
+
+Mirrors the :mod:`test_wake` shape: unit-test the mock impls and the
+load-default factory. The real Reachy-backed mic + speaker land later
+as a hardware-tier follow-up; when they do, those tests live in a
+hardware-marked module and these stay unit-tier.
+"""
+
+from __future__ import annotations
+
+import pytest
+from reachy_ducky_app.voice.audio_io import (
+    MicSource,
+    MockMicSource,
+    MockSpeakerSink,
+    SpeakerSink,
+    load_default_mic_source,
+    load_default_speaker_sink,
+)
+
+
+async def test_mock_mic_source_default_yields_no_frames() -> None:
+    """``MockMicSource()`` with no scripted frames terminates immediately.
+
+    Simulates a silent mic — the stream ends rather than hanging, so
+    callers that block on ``async for frame in mic.frames()`` fall
+    through cleanly when no audio arrives.
+    """
+    mic = MockMicSource()
+    collected: list[bytes] = []
+    async for frame in mic.frames():
+        collected.append(frame)
+    assert collected == []
+
+
+async def test_mock_mic_source_replays_scripted_frames_in_order() -> None:
+    """Scripted frames are yielded in the order passed to ``__init__``."""
+    mic = MockMicSource(frames=[b"f1", b"f2", b"f3"])
+    collected: list[bytes] = []
+    async for frame in mic.frames():
+        collected.append(frame)
+    assert collected == [b"f1", b"f2", b"f3"]
+
+
+async def test_mock_speaker_sink_accumulates_plays() -> None:
+    """``MockSpeakerSink.play`` records each PCM frame in call order."""
+    sink = MockSpeakerSink()
+    await sink.play(b"x")
+    await sink.play(b"y")
+    assert sink.played == [b"x", b"y"]
+
+
+def test_load_default_mic_source_returns_mic_source() -> None:
+    """Phase A: the factory returns a :class:`MicSource` (today a mock).
+
+    Isinstance check guards the contract: callers depending on the ABC
+    don't break when the factory is swapped to a hardware impl later.
+    """
+    mic = load_default_mic_source()
+    assert isinstance(mic, MicSource)
+
+
+def test_load_default_speaker_sink_returns_speaker_sink() -> None:
+    """Phase A: the factory returns a :class:`SpeakerSink` (today a mock)."""
+    sink = load_default_speaker_sink()
+    assert isinstance(sink, SpeakerSink)
+
+
+def test_mic_source_is_abstract() -> None:
+    """``MicSource`` cannot be instantiated directly — it's an ABC."""
+    with pytest.raises(TypeError):
+        MicSource()  # type: ignore[abstract]
+
+
+def test_speaker_sink_is_abstract() -> None:
+    """``SpeakerSink`` cannot be instantiated directly — it's an ABC."""
+    with pytest.raises(TypeError):
+        SpeakerSink()  # type: ignore[abstract]

--- a/app/tests/test_conversation.py
+++ b/app/tests/test_conversation.py
@@ -254,3 +254,116 @@ async def test_run_one_turn_exits_voice_turn_context_on_exception(
     # Even though the turn raised, the CM must have exited cleanly.
     assert voice.enter_count == 1
     assert voice.exit_count == 1
+
+
+class _RaisingGetUserTextTurn(MockVoiceTurn):
+    """Turn whose ``get_user_text`` always raises."""
+
+    def __init__(self) -> None:
+        super().__init__(user_text="")
+
+    async def get_user_text(self) -> str:
+        raise RuntimeError("transcription exploded")
+
+
+class _RaisingGetUserTextVoice(MockVoice):
+    """Voice whose turn raises from ``get_user_text`` (LISTENING-state raise)."""
+
+    def start_turn(self) -> AbstractAsyncContextManager[MockVoiceTurn]:
+        @asynccontextmanager
+        async def _cm() -> AsyncIterator[MockVoiceTurn]:
+            yield _RaisingGetUserTextTurn()
+
+        return _cm()
+
+
+class _RaisingSpeakTextTurn(MockVoiceTurn):
+    """Turn whose ``speak_text`` raises (so ``get_user_text`` still succeeds)."""
+
+    def __init__(self, user_text: str) -> None:
+        super().__init__(user_text=user_text)
+
+    async def speak_text(self, text: str) -> None:
+        raise RuntimeError("tts exploded")
+
+
+class _RaisingSpeakTextVoice(MockVoice):
+    """Voice whose turn raises from ``speak_text`` (LISTENING-again-state raise)."""
+
+    def start_turn(self) -> AbstractAsyncContextManager[MockVoiceTurn]:
+        user_text = self._user_text
+
+        @asynccontextmanager
+        async def _cm() -> AsyncIterator[MockVoiceTurn]:
+            yield _RaisingSpeakTextTurn(user_text)
+
+        return _cm()
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_resets_to_idle_when_get_user_text_raises(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """If ``get_user_text`` raises in LISTENING: state lands back at IDLE.
+
+    Guards against the robot's LISTENING posture persisting forever after
+    a transcription failure.
+    """
+    # No httpx_mock.add_response — the turn must raise before the brain call.
+    voice = _RaisingGetUserTextVoice(scripted_user_text="unused")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    with pytest.raises(RuntimeError, match="transcription exploded"):
+        await run_one_turn(voice=voice, sm=sm, daemon=daemon)
+
+    assert sm.state == State.IDLE
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_resets_to_idle_when_brain_query_raises(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """If ``brain_query`` raises in THINKING: state lands back at IDLE.
+
+    Previously the state machine would stay stuck at THINKING after any
+    daemon failure.
+    """
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        status_code=500,
+        json={"detail": "brain down"},
+    )
+    voice = MockVoice(scripted_user_text="hi")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await run_one_turn(voice=voice, sm=sm, daemon=daemon)
+
+    assert sm.state == State.IDLE
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_resets_to_idle_when_speak_text_raises(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """If ``speak_text`` raises in LISTENING (reply): state lands back at IDLE."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    voice = _RaisingSpeakTextVoice(scripted_user_text="hi")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    with pytest.raises(RuntimeError, match="tts exploded"):
+        await run_one_turn(voice=voice, sm=sm, daemon=daemon)
+
+    assert sm.state == State.IDLE

--- a/app/tests/test_conversation.py
+++ b/app/tests/test_conversation.py
@@ -8,28 +8,34 @@ pytest-httpx-mocked :class:`DaemonClient`. No network, no hardware.
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 from reachy_ducky_app.conversation import run_one_turn
 from reachy_ducky_app.daemon_client import DaemonClient
 from reachy_ducky_app.embodiment.motion_driver import MockMotionDriver
 from reachy_ducky_app.embodiment.state_machine import EmbodimentStateMachine
-from reachy_ducky_app.voice.interface import VoiceTurn
 from reachy_ducky_app.voice.mock import MockVoice, MockVoiceTurn
 from reachy_ducky_protocol.messages import State
 
 
 class _SpyMockVoice(MockVoice):
-    """``MockVoice`` that counts ``start_turn`` calls for no-op assertions."""
+    """``MockVoice`` that counts ``start_turn`` calls for no-op assertions.
+
+    ``start_turn`` is an async context manager, so the spy wraps ``super().
+    start_turn()`` in its own CM that bumps the counter on entry.
+    """
 
     def __init__(self, *, scripted_user_text: str) -> None:
         super().__init__(scripted_user_text=scripted_user_text)
         self.start_turn_calls: int = 0
 
-    async def start_turn(self) -> VoiceTurn:
+    def start_turn(self) -> AbstractAsyncContextManager[MockVoiceTurn]:
         self.start_turn_calls += 1
-        return await super().start_turn()
+        return super().start_turn()
 
 
 @pytest.mark.asyncio
@@ -68,14 +74,15 @@ async def test_run_one_turn_speaks_reply_text_verbatim(
     sm = EmbodimentStateMachine(driver=driver)
     daemon = DaemonClient(base_url="http://127.0.0.1:8765")
 
-    # Capture the turn by patching start_turn so we can inspect spoken_texts.
-    captured: list[VoiceTurn] = []
+    # Capture the turn by wrapping start_turn's returned context manager.
+    captured: list[MockVoiceTurn] = []
     original_start = voice.start_turn
 
-    async def spy_start() -> VoiceTurn:
-        turn = await original_start()
-        captured.append(turn)
-        return turn
+    @asynccontextmanager
+    async def spy_start() -> AsyncIterator[MockVoiceTurn]:
+        async with original_start() as turn:
+            captured.append(turn)
+            yield turn
 
     voice.start_turn = spy_start  # type: ignore[method-assign]
 
@@ -167,3 +174,83 @@ async def test_run_one_turn_records_final_idle_state(
     assert sm.state == State.IDLE  # sanity
     await run_one_turn(voice=voice, sm=sm, daemon=daemon)
     assert sm.state == State.IDLE
+
+
+class _LifecycleTrackingVoice(MockVoice):
+    """``MockVoice`` whose ``start_turn`` CM records enter/exit events.
+
+    Used to assert ``run_one_turn`` both enters AND exits the CM, on
+    happy and exception paths alike — i.e. the realtime connection is
+    released whether the turn succeeds or blows up midway.
+    """
+
+    def __init__(self, *, scripted_user_text: str) -> None:
+        super().__init__(scripted_user_text=scripted_user_text)
+        self.enter_count: int = 0
+        self.exit_count: int = 0
+
+    def start_turn(self) -> AbstractAsyncContextManager[MockVoiceTurn]:
+        parent = super().start_turn()
+
+        @asynccontextmanager
+        async def tracked() -> AsyncIterator[MockVoiceTurn]:
+            self.enter_count += 1
+            try:
+                async with parent as turn:
+                    yield turn
+            finally:
+                self.exit_count += 1
+
+        return tracked()
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_exits_voice_turn_context_on_happy_path(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Happy path: ``start_turn`` CM is entered once and exited once."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    voice = _LifecycleTrackingVoice(scripted_user_text="hi")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    await run_one_turn(voice=voice, sm=sm, daemon=daemon)
+
+    assert voice.enter_count == 1
+    assert voice.exit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_exits_voice_turn_context_on_exception(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Regression: if the daemon call raises mid-turn, the CM still exits.
+
+    This is the bug I1 is fixing — the previous implementation awaited
+    ``voice.start_turn()`` and did nothing to close the connection on
+    failure. The context-manager shape makes cleanup structural.
+    """
+    # Daemon returns a 500; `raise_for_status()` will throw inside the
+    # turn body, after start_turn has been entered.
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        status_code=500,
+        json={"detail": "boom"},
+    )
+    voice = _LifecycleTrackingVoice(scripted_user_text="hi")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await run_one_turn(voice=voice, sm=sm, daemon=daemon)
+
+    # Even though the turn raised, the CM must have exited cleanly.
+    assert voice.enter_count == 1
+    assert voice.exit_count == 1

--- a/app/tests/test_conversation.py
+++ b/app/tests/test_conversation.py
@@ -1,0 +1,169 @@
+"""Tests for :func:`run_one_turn` — the single-turn conversation orchestrator.
+
+Integration-style unit tests. Each test composes the real voice mock,
+the real motion-driver mock, the real state machine, and a
+pytest-httpx-mocked :class:`DaemonClient`. No network, no hardware.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+from reachy_ducky_app.conversation import run_one_turn
+from reachy_ducky_app.daemon_client import DaemonClient
+from reachy_ducky_app.embodiment.motion_driver import MockMotionDriver
+from reachy_ducky_app.embodiment.state_machine import EmbodimentStateMachine
+from reachy_ducky_app.voice.interface import VoiceTurn
+from reachy_ducky_app.voice.mock import MockVoice, MockVoiceTurn
+from reachy_ducky_protocol.messages import State
+
+
+class _SpyMockVoice(MockVoice):
+    """``MockVoice`` that counts ``start_turn`` calls for no-op assertions."""
+
+    def __init__(self, *, scripted_user_text: str) -> None:
+        super().__init__(scripted_user_text=scripted_user_text)
+        self.start_turn_calls: int = 0
+
+    async def start_turn(self) -> VoiceTurn:
+        self.start_turn_calls += 1
+        return await super().start_turn()
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_full_flow(httpx_mock: HTTPXMock) -> None:
+    """Happy path: LISTENING → THINKING → LISTENING (speak) → IDLE."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "you're on main", "specialist_invoked": None},
+    )
+    voice = MockVoice(scripted_user_text="what's on my branch?")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug="demo")
+
+    # Motion sequence: IDLE→LISTENING (listening), LISTENING→THINKING
+    # (thinking), THINKING→LISTENING (listening), LISTENING→IDLE (neutral).
+    assert driver.moves == ["listening", "thinking", "listening", "neutral"]
+    assert sm.state == State.IDLE
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_speaks_reply_text_verbatim(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """The daemon's reply text is passed through ``speak_text`` unchanged."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "hello world", "specialist_invoked": None},
+    )
+    voice = MockVoice(scripted_user_text="hi")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    # Capture the turn by patching start_turn so we can inspect spoken_texts.
+    captured: list[VoiceTurn] = []
+    original_start = voice.start_turn
+
+    async def spy_start() -> VoiceTurn:
+        turn = await original_start()
+        captured.append(turn)
+        return turn
+
+    voice.start_turn = spy_start  # type: ignore[method-assign]
+
+    await run_one_turn(voice=voice, sm=sm, daemon=daemon)
+
+    assert len(captured) == 1
+    turn = captured[0]
+    assert isinstance(turn, MockVoiceTurn)
+    assert turn.spoken_texts == ["hello world"]
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_passes_project_slug(httpx_mock: HTTPXMock) -> None:
+    """``project_slug`` is forwarded into the daemon request body."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    voice = MockVoice(scripted_user_text="hi")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug="demo")
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.content)
+    assert body["project_slug"] == "demo"
+    assert body["user_utterance"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_uses_primary_when_no_slug(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """``project_slug=None`` is forwarded verbatim; daemon picks primary."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    voice = MockVoice(scripted_user_text="hi")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    await run_one_turn(voice=voice, sm=sm, daemon=daemon)
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.content)
+    assert body["project_slug"] is None
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_when_muted_is_noop(httpx_mock: HTTPXMock) -> None:
+    """If sm.state is MUTED at entry: no voice turn, no daemon call."""
+    voice = _SpyMockVoice(scripted_user_text="should not fire")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    sm.transition(State.MUTED)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    # No httpx_mock.add_response — any HTTP call would fail collection assertion.
+    await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug="demo")
+
+    assert voice.start_turn_calls == 0
+    assert sm.state == State.MUTED
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_records_final_idle_state(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """After a successful turn the state machine lands in IDLE."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    voice = MockVoice(scripted_user_text="hi")
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver=driver)
+    daemon = DaemonClient(base_url="http://127.0.0.1:8765")
+
+    assert sm.state == State.IDLE  # sanity
+    await run_one_turn(voice=voice, sm=sm, daemon=daemon)
+    assert sm.state == State.IDLE

--- a/app/tests/test_daemon_client.py
+++ b/app/tests/test_daemon_client.py
@@ -256,3 +256,151 @@ async def test_5xx_raises_http_status_error(httpx_mock: HTTPXMock) -> None:
     client = DaemonClient(base_url="http://127.0.0.1:8765")
     with pytest.raises(httpx.HTTPStatusError):
         await client.health()
+
+
+@pytest.mark.asyncio
+async def test_construction_builds_one_httpx_async_client() -> None:
+    """The client holds a single pooled ``httpx.AsyncClient`` in ``_http``.
+
+    Regression for bug I2: the old implementation opened a fresh
+    ``httpx.AsyncClient`` inside each endpoint method via
+    ``async with httpx.AsyncClient(timeout=...) as http``. Over Tailscale
+    that meant a TLS handshake per call. The pooled instance eliminates
+    that cost.
+    """
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    assert isinstance(client._http, httpx.AsyncClient)
+    assert client._http.is_closed is False
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_underlying_client() -> None:
+    """``aclose()`` closes the pooled ``httpx.AsyncClient``."""
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    assert client._http.is_closed is False
+    await client.aclose()
+    assert client._http.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_idempotent() -> None:
+    """Calling ``aclose()`` twice does not raise — shutdown paths can be untidy."""
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    await client.aclose()
+    await client.aclose()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_successive_calls_reuse_pooled_client(httpx_mock: HTTPXMock) -> None:
+    """All three endpoints use ``self._http``, not a fresh client per call.
+
+    The most direct assertion is that the identity of ``client._http``
+    does not change across calls, and that the instance is still open
+    after several requests have been made through it.
+    """
+    httpx_mock.add_response(
+        method="GET",
+        url="http://127.0.0.1:8765/health",
+        json={"ok": True, "brain": "X", "memory_ready": True, "projects": []},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/specialists/plan-reviewer",
+        json={"name": "plan-reviewer", "summary": "ok", "flags": []},
+    )
+
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    pooled = client._http
+    try:
+        await client.health()
+        assert client._http is pooled
+        assert pooled.is_closed is False
+        await client.brain_query("hi")
+        assert client._http is pooled
+        assert pooled.is_closed is False
+        await client.plan_reviewer(project_slug="demo")
+        assert client._http is pooled
+        assert pooled.is_closed is False
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_brain_query_uses_sixty_second_timeout(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """``/brain/query`` preserves its 60s timeout after the pooling refactor.
+
+    Timeouts must be applied per-call (not set globally on the pooled
+    client) because each endpoint has a different budget. Verify via the
+    ``httpx.Request.extensions['timeout']`` shape that pytest-httpx
+    preserves.
+    """
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    try:
+        await client.brain_query("hi")
+    finally:
+        await client.aclose()
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    # httpx stores per-request timeout config in request.extensions["timeout"];
+    # it's a dict with connect/read/write/pool keys.
+    timeout = sent.extensions.get("timeout")
+    assert timeout is not None
+    assert timeout["read"] == pytest.approx(60.0)
+
+
+@pytest.mark.asyncio
+async def test_health_uses_two_second_timeout(httpx_mock: HTTPXMock) -> None:
+    """``/health`` preserves its 2s timeout after the pooling refactor."""
+    httpx_mock.add_response(
+        method="GET",
+        url="http://127.0.0.1:8765/health",
+        json={"ok": True, "brain": "X", "memory_ready": True, "projects": []},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    try:
+        await client.health()
+    finally:
+        await client.aclose()
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    timeout = sent.extensions.get("timeout")
+    assert timeout is not None
+    assert timeout["read"] == pytest.approx(2.0)
+
+
+@pytest.mark.asyncio
+async def test_plan_reviewer_uses_one_hundred_twenty_second_timeout(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """``/specialists/plan-reviewer`` preserves its 120s timeout after the refactor."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/specialists/plan-reviewer",
+        json={"name": "plan-reviewer", "summary": "ok", "flags": []},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    try:
+        await client.plan_reviewer(project_slug="demo")
+    finally:
+        await client.aclose()
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    timeout = sent.extensions.get("timeout")
+    assert timeout is not None
+    assert timeout["read"] == pytest.approx(120.0)

--- a/app/tests/test_daemon_client.py
+++ b/app/tests/test_daemon_client.py
@@ -1,0 +1,258 @@
+"""Tests for :class:`DaemonClient` — typed async HTTP wrapper."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+from reachy_ducky_app.daemon_client import DaemonClient
+from reachy_ducky_protocol.messages import (
+    BrainResponse,
+    HealthResponse,
+    SpecialistResponse,
+)
+
+
+def test_default_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no env and no args, the client defaults to 127.0.0.1:8765."""
+    monkeypatch.delenv("DAEMON_URL", raising=False)
+    monkeypatch.delenv("DAEMON_AUTH_TOKEN", raising=False)
+    client = DaemonClient()
+    assert client._base == "http://127.0.0.1:8765"
+    assert client._token is None
+
+
+def test_base_url_strips_trailing_slash() -> None:
+    """A trailing slash on the base URL is stripped so path joins are clean."""
+    client = DaemonClient(base_url="http://x/")
+    assert client._base == "http://x"
+
+
+def test_from_env_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``from_env`` reads ``DAEMON_URL`` and ``DAEMON_AUTH_TOKEN``."""
+    monkeypatch.setenv("DAEMON_URL", "http://mac.tailnet.ts.net:8765")
+    monkeypatch.setenv("DAEMON_AUTH_TOKEN", "tok")
+    client = DaemonClient.from_env()
+    assert client._base == "http://mac.tailnet.ts.net:8765"
+    assert client._token == "tok"
+
+
+def test_explicit_auth_token_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Constructor ``auth_token`` overrides any env-var value."""
+    monkeypatch.setenv("DAEMON_AUTH_TOKEN", "from-env")
+    client = DaemonClient(auth_token="from-arg")
+    assert client._token == "from-arg"
+
+
+def test_empty_env_token_clears(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty-string env var is treated as an explicit "no token" (matches AppConfig)."""
+    monkeypatch.setenv("DAEMON_AUTH_TOKEN", "")
+    client = DaemonClient()
+    assert client._token is None
+
+
+@pytest.mark.asyncio
+async def test_health_parses_response(httpx_mock: HTTPXMock) -> None:
+    """``/health`` deserialises to :class:`HealthResponse`."""
+    httpx_mock.add_response(
+        method="GET",
+        url="http://127.0.0.1:8765/health",
+        json={
+            "ok": True,
+            "brain": "MockBrain",
+            "memory_ready": True,
+            "projects": ["demo"],
+        },
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    resp = await client.health()
+    assert isinstance(resp, HealthResponse)
+    assert resp.ok is True
+    assert resp.brain == "MockBrain"
+    assert resp.memory_ready is True
+    assert resp.projects == ["demo"]
+
+
+@pytest.mark.asyncio
+async def test_brain_query_parses_response(httpx_mock: HTTPXMock) -> None:
+    """``/brain/query`` POSTs user_utterance and parses the reply."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "hello", "specialist_invoked": None},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    resp = await client.brain_query("hi")
+    assert isinstance(resp, BrainResponse)
+    assert resp.text == "hello"
+    assert resp.specialist_invoked is None
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    assert sent.method == "POST"
+    body = json.loads(sent.content)
+    assert body["user_utterance"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_brain_query_passes_project_slug(httpx_mock: HTTPXMock) -> None:
+    """When given, ``project_slug`` is serialised into the posted body."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    await client.brain_query("hi", project_slug="demo")
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.content)
+    assert body["project_slug"] == "demo"
+
+
+@pytest.mark.asyncio
+async def test_brain_query_forwards_none_slug(httpx_mock: HTTPXMock) -> None:
+    """``project_slug=None`` is forwarded verbatim (daemon falls back to primary)."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    await client.brain_query("hi")
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.content)
+    assert "project_slug" in body
+    assert body["project_slug"] is None
+
+
+@pytest.mark.asyncio
+async def test_plan_reviewer_parses_response(httpx_mock: HTTPXMock) -> None:
+    """``/specialists/plan-reviewer`` POSTs a :class:`SpecialistRequest`."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/specialists/plan-reviewer",
+        json={
+            "name": "plan-reviewer",
+            "summary": "looks good",
+            "flags": ["scope-creep"],
+        },
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    resp = await client.plan_reviewer(project_slug="demo")
+    assert isinstance(resp, SpecialistResponse)
+    assert resp.name == "plan-reviewer"
+    assert resp.summary == "looks good"
+    assert resp.flags == ["scope-creep"]
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.content)
+    assert body["name"] == "plan-reviewer"
+    assert body["project_slug"] == "demo"
+    assert body["branch"] is None
+
+
+@pytest.mark.asyncio
+async def test_plan_reviewer_passes_branch(httpx_mock: HTTPXMock) -> None:
+    """When given, ``branch`` is serialised into the posted body."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/specialists/plan-reviewer",
+        json={"name": "plan-reviewer", "summary": "ok", "flags": []},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    await client.plan_reviewer(project_slug="demo", branch="feature/x")
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.content)
+    assert body["branch"] == "feature/x"
+
+
+@pytest.mark.asyncio
+async def test_auth_header_sent_when_token_configured(httpx_mock: HTTPXMock) -> None:
+    """With a token configured, ``Authorization: Bearer <token>`` is sent."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://mac.tailnet.ts.net:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    client = DaemonClient(
+        base_url="http://mac.tailnet.ts.net:8765",
+        auth_token="sekret",
+    )
+    await client.brain_query("hi")
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    assert sent.headers["authorization"] == "Bearer sekret"
+
+
+@pytest.mark.asyncio
+async def test_auth_header_not_sent_without_token(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no token anywhere, no Authorization header is emitted."""
+    monkeypatch.delenv("DAEMON_AUTH_TOKEN", raising=False)
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        json={"text": "ok", "specialist_invoked": None},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    await client.brain_query("hi")
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    assert "authorization" not in {k.lower() for k in sent.headers.keys()}
+
+
+@pytest.mark.asyncio
+async def test_health_has_no_auth_header(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """``/health`` is the open route and does not send a bearer header."""
+    httpx_mock.add_response(
+        method="GET",
+        url="http://127.0.0.1:8765/health",
+        json={"ok": True, "brain": "X", "memory_ready": False, "projects": []},
+    )
+    # Token is configured but /health is open by design (works with or without).
+    # The current implementation sends the header even on /health; that's fine
+    # because the server's BearerAuthMiddleware lets /health through either
+    # way. This test documents that we don't *rely* on sending the header.
+    client = DaemonClient(base_url="http://127.0.0.1:8765", auth_token="sekret")
+    resp = await client.health()
+    assert resp.ok is True
+
+
+@pytest.mark.asyncio
+async def test_4xx_raises_http_status_error(httpx_mock: HTTPXMock) -> None:
+    """A 4xx response raises :class:`httpx.HTTPStatusError` (propagated)."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/brain/query",
+        status_code=401,
+        json={"detail": "invalid bearer token"},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.brain_query("hi")
+
+
+@pytest.mark.asyncio
+async def test_5xx_raises_http_status_error(httpx_mock: HTTPXMock) -> None:
+    """A 5xx response also propagates as :class:`httpx.HTTPStatusError`."""
+    httpx_mock.add_response(
+        method="GET",
+        url="http://127.0.0.1:8765/health",
+        status_code=503,
+        json={"detail": "unavailable"},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.health()

--- a/app/tests/test_embodiment_state_machine.py
+++ b/app/tests/test_embodiment_state_machine.py
@@ -1,0 +1,161 @@
+"""Tests for the embodiment state machine + MockMotionDriver."""
+
+from __future__ import annotations
+
+import pytest
+from reachy_ducky_app.embodiment import (
+    EmbodimentStateMachine,
+    MockMotionDriver,
+    MotionDriver,
+)
+from reachy_ducky_protocol.messages import State
+
+
+def test_motion_driver_is_abstract() -> None:
+    """MotionDriver cannot be instantiated directly — it is an ABC."""
+    with pytest.raises(TypeError):
+        MotionDriver()  # type: ignore[abstract]
+
+
+def test_initial_state_is_idle() -> None:
+    """A freshly-constructed state machine starts in IDLE with no motion emitted."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    assert sm.state == State.IDLE
+    assert driver.moves == []
+    assert driver.went_to_sleep is False
+    assert driver.woke_up is False
+
+
+def test_transition_to_listening_plays_move() -> None:
+    """IDLE -> LISTENING plays the "listening" move."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    sm.transition(State.LISTENING)
+    assert driver.moves == ["listening"]
+    assert sm.state == State.LISTENING
+
+
+def test_transition_to_thinking_plays_move() -> None:
+    """IDLE -> THINKING plays the "thinking" move."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    sm.transition(State.THINKING)
+    assert driver.moves == ["thinking"]
+    assert sm.state == State.THINKING
+
+
+def test_transition_to_idle_plays_neutral_move() -> None:
+    """LISTENING -> IDLE plays the "neutral" move."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    sm.transition(State.LISTENING)
+    sm.transition(State.IDLE)
+    assert driver.moves == ["listening", "neutral"]
+    assert sm.state == State.IDLE
+
+
+def test_transition_to_muted_goes_to_sleep() -> None:
+    """LISTENING -> MUTED calls go_to_sleep and does NOT play a move for MUTED."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    sm.transition(State.LISTENING)
+    driver.moves.clear()  # isolate the MUTED transition
+    sm.transition(State.MUTED)
+    assert driver.went_to_sleep is True
+    assert driver.moves == []
+    assert sm.state == State.MUTED
+
+
+def test_transition_from_muted_wakes_up_and_plays_target() -> None:
+    """Exiting MUTED calls wake_up THEN play_move for the target state."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    sm.transition(State.MUTED)
+    assert driver.went_to_sleep is True
+    assert driver.woke_up is False  # not yet
+
+    sm.transition(State.LISTENING)
+    # wake_up must fire before play_move so the robot is upright first.
+    assert driver.woke_up is True
+    assert driver.moves == ["listening"]
+    assert sm.state == State.LISTENING
+
+
+def test_same_state_transition_is_noop() -> None:
+    """LISTENING -> LISTENING records no new calls."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    sm.transition(State.LISTENING)
+    assert driver.moves == ["listening"]
+
+    sm.transition(State.LISTENING)
+    assert driver.moves == ["listening"]  # unchanged
+    assert driver.went_to_sleep is False
+    assert driver.woke_up is False
+
+
+def test_muted_to_muted_is_noop() -> None:
+    """MUTED -> MUTED does NOT re-call go_to_sleep."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    sm.transition(State.MUTED)
+    # Force the flag back off to prove the second transition is a no-op
+    # (rather than relying on idempotence of the bool flag itself).
+    driver.went_to_sleep = False
+    sm.transition(State.MUTED)
+    assert driver.went_to_sleep is False
+    assert sm.state == State.MUTED
+
+
+def test_state_property_reflects_current_state() -> None:
+    """After each transition, sm.state reflects the new state.
+
+    mypy's literal-narrowing would otherwise flag consecutive equality
+    checks as unreachable (it can't see that ``transition`` mutates
+    ``_state``), so each assertion goes through a fresh local.
+    """
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+
+    sm.transition(State.LISTENING)
+    after_listening: State = sm.state
+    assert after_listening == State.LISTENING
+
+    sm.transition(State.THINKING)
+    after_thinking: State = sm.state
+    assert after_thinking == State.THINKING
+
+    sm.transition(State.MUTED)
+    after_muted: State = sm.state
+    assert after_muted == State.MUTED
+
+
+def test_sequence_idle_listening_thinking_muted_idle() -> None:
+    """End-to-end sequence lockdown across every transition type."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+
+    sm.transition(State.LISTENING)
+    sm.transition(State.THINKING)
+    sm.transition(State.MUTED)
+    sm.transition(State.IDLE)
+
+    # Moves played in order: listening (on entry), thinking (mid), neutral
+    # (after wake_up on exit from MUTED). MUTED itself does not play a move.
+    assert driver.moves == ["listening", "thinking", "neutral"]
+    assert driver.went_to_sleep is True
+    assert driver.woke_up is True
+    assert sm.state == State.IDLE
+
+
+@pytest.mark.parametrize(
+    "target",
+    [State.IDLE, State.LISTENING, State.THINKING, State.MUTED],
+)
+def test_every_state_has_entry_handling(target: State) -> None:
+    """Transitioning from IDLE to every State value must not raise."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)
+    sm.transition(target)
+    assert sm.state == target

--- a/app/tests/test_gaze.py
+++ b/app/tests/test_gaze.py
@@ -1,0 +1,65 @@
+"""Tests for the pure pick_primary_face helper.
+
+``gaze_loop`` is hardware-tier (needs a real mini + mediapipe detector) and
+is exercised via ``@pytest.mark.hardware`` on the robot; these unit tests
+only cover the pure selection helper.
+"""
+
+from __future__ import annotations
+
+from reachy_ducky_app.embodiment.gaze import pick_primary_face
+
+
+def test_pick_primary_face_returns_none_for_empty_list() -> None:
+    """No detections -> None (nothing to gaze at)."""
+    assert pick_primary_face([]) is None
+
+
+def test_pick_primary_face_single_detection_returns_it() -> None:
+    """A single detection's (u, v) is returned verbatim."""
+    assert pick_primary_face([(0.5, 0.5, 0.9)]) == (0.5, 0.5)
+
+
+def test_pick_primary_face_picks_highest_confidence() -> None:
+    """Among several detections the top-score one wins regardless of position."""
+    detections: list[tuple[float, float, float]] = [
+        (0.10, 0.20, 0.55),
+        (0.42, 0.60, 0.98),  # highest score, middle-positioned
+        (0.80, 0.80, 0.70),
+    ]
+    assert pick_primary_face(detections) == (0.42, 0.60)
+
+
+def test_pick_primary_face_ties_broken_by_list_order() -> None:
+    """Equal confidences: the first detection wins (documented + locked in)."""
+    detections: list[tuple[float, float, float]] = [
+        (0.30, 0.30, 0.80),
+        (0.70, 0.70, 0.80),
+    ]
+    assert pick_primary_face(detections) == (0.30, 0.30)
+
+
+def test_pick_primary_face_ignores_position_only_score_matters() -> None:
+    """A far-off-center face with higher confidence beats a centered weaker one."""
+    detections: list[tuple[float, float, float]] = [
+        (0.50, 0.50, 0.40),  # centered but low score
+        (0.05, 0.05, 0.85),  # far corner, high score
+    ]
+    assert pick_primary_face(detections) == (0.05, 0.05)
+
+
+def test_pick_primary_face_accepts_boundary_values() -> None:
+    """Detections at the image corners (0.0 and 1.0) are returned unchanged."""
+    detections: list[tuple[float, float, float]] = [
+        (0.0, 0.0, 0.5),
+        (1.0, 1.0, 0.5),
+    ]
+    # Tie on score -> first wins.
+    assert pick_primary_face(detections) == (0.0, 0.0)
+
+    # Bump the second's confidence: it wins, and the corner coords round-trip.
+    detections_with_winner: list[tuple[float, float, float]] = [
+        (0.0, 0.0, 0.5),
+        (1.0, 1.0, 0.9),
+    ]
+    assert pick_primary_face(detections_with_winner) == (1.0, 1.0)

--- a/app/tests/test_gaze.py
+++ b/app/tests/test_gaze.py
@@ -1,13 +1,15 @@
-"""Tests for the pure pick_primary_face helper.
+"""Tests for the pure pick_primary_face helper and ``gaze_loop``'s fps guard.
 
 ``gaze_loop`` is hardware-tier (needs a real mini + mediapipe detector) and
 is exercised via ``@pytest.mark.hardware`` on the robot; these unit tests
-only cover the pure selection helper.
+cover the pure selection helper and the entry-guard validation of ``fps``.
 """
 
 from __future__ import annotations
 
-from reachy_ducky_app.embodiment.gaze import pick_primary_face
+import pytest
+from reachy_ducky_app.embodiment.gaze import gaze_loop, pick_primary_face
+from reachy_ducky_app.embodiment.motion_driver import MockMotionDriver
 
 
 def test_pick_primary_face_returns_none_for_empty_list() -> None:
@@ -63,3 +65,37 @@ def test_pick_primary_face_accepts_boundary_values() -> None:
         (1.0, 1.0, 0.9),
     ]
     assert pick_primary_face(detections_with_winner) == (1.0, 1.0)
+
+
+@pytest.mark.asyncio
+async def test_gaze_loop_rejects_zero_fps() -> None:
+    """``fps=0`` must raise before any work (previously ZeroDivisionError)."""
+    driver = MockMotionDriver()
+    with pytest.raises(ValueError, match="must be positive"):
+        await gaze_loop(None, driver, fps=0)
+
+
+@pytest.mark.asyncio
+async def test_gaze_loop_rejects_negative_fps() -> None:
+    """Negative ``fps`` must raise (previously: tight loop, no error)."""
+    driver = MockMotionDriver()
+    with pytest.raises(ValueError, match="must be positive"):
+        await gaze_loop(None, driver, fps=-1)
+
+
+@pytest.mark.asyncio
+async def test_gaze_loop_guard_accepts_small_positive_fps() -> None:
+    """Positive ``fps`` is not rejected by the guard.
+
+    ``mini=None`` means the loop eventually fails with ``AttributeError``
+    when it hits ``mini.media.get_frame()`` — that's fine. The guard's
+    job is to *not* reject positive floats with the "must be positive"
+    ValueError; any downstream exception proves the guard let us through.
+    """
+    driver = MockMotionDriver()
+    with pytest.raises(Exception) as exc_info:
+        await gaze_loop(None, driver, fps=0.1)
+    # The guard must not be the thing that raised here.
+    assert not (
+        isinstance(exc_info.value, ValueError) and "must be positive" in str(exc_info.value)
+    )

--- a/app/tests/test_mute.py
+++ b/app/tests/test_mute.py
@@ -1,0 +1,62 @@
+"""Tests for the hard mic-gate (MuteGate)."""
+
+from __future__ import annotations
+
+import numpy as np
+from reachy_ducky_app.mute import MuteGate
+
+
+def test_gate_default_unmuted() -> None:
+    """A freshly-constructed MuteGate starts unmuted."""
+    gate = MuteGate()
+    assert gate.muted is False
+
+
+def test_gate_passes_audio_when_unmuted() -> None:
+    """When unmuted, process() returns the chunk unchanged (same values)."""
+    gate = MuteGate()
+    chunk = np.array([1, 2, 3, -4, -5], dtype=np.int16)
+    out = gate.process(chunk)
+    assert np.array_equal(out, chunk)
+
+
+def test_gate_zeros_audio_when_muted() -> None:
+    """When muted, process() returns an all-zero array with the same shape+dtype."""
+    gate = MuteGate()
+    gate.set_muted(True)
+    chunk = np.array([1, 2, 3, -4, -5], dtype=np.int16)
+    out = gate.process(chunk)
+    assert np.array_equal(out, np.zeros(5, dtype=np.int16))
+
+
+def test_gate_toggle_flips_state() -> None:
+    """toggle() flips the mute flag each call."""
+    gate = MuteGate()
+    gate.toggle()
+    assert gate.muted is True
+    gate.toggle()
+    assert gate.muted is False
+
+
+def test_gate_set_muted_true_then_false() -> None:
+    """set_muted moves the gate between states deterministically."""
+    gate = MuteGate()
+    gate.set_muted(True)
+    assert gate.muted is True
+    gate.set_muted(False)
+    assert gate.muted is False
+
+
+def test_gate_preserves_dtype_and_shape() -> None:
+    """process() output matches input in dtype and shape regardless of mute state."""
+    chunk = np.arange(16, dtype=np.int16)
+
+    gate = MuteGate()
+    out_unmuted = gate.process(chunk)
+    assert out_unmuted.dtype == np.int16
+    assert out_unmuted.shape == chunk.shape
+
+    gate.set_muted(True)
+    out_muted = gate.process(chunk)
+    assert out_muted.dtype == np.int16
+    assert out_muted.shape == chunk.shape

--- a/app/tests/test_voice_interface.py
+++ b/app/tests/test_voice_interface.py
@@ -19,18 +19,35 @@ def test_voice_turn_is_abstract() -> None:
 
 
 async def test_mock_voice_starts_turn_returning_voice_turn_instance() -> None:
-    """MockVoice.start_turn returns a concrete VoiceTurn (MockVoiceTurn)."""
+    """MockVoice.start_turn yields a concrete VoiceTurn (MockVoiceTurn) via async-with."""
     voice = MockVoice(scripted_user_text="hello")
-    turn = await voice.start_turn()
-    assert isinstance(turn, VoiceTurn)
+    async with voice.start_turn() as turn:
+        assert isinstance(turn, VoiceTurn)
+        assert isinstance(turn, MockVoiceTurn)
+
+
+async def test_mock_voice_start_turn_is_async_context_manager() -> None:
+    """``start_turn`` returns an object usable with ``async with``.
+
+    Guards against regressions where the method becomes a bare coroutine
+    returning a VoiceTurn — which would leak any resource the production
+    implementation holds (e.g. the OpenAI realtime WebSocket).
+    """
+    voice = MockVoice(scripted_user_text="x")
+    cm = voice.start_turn()
+    # Must be an async context manager, not a coroutine.
+    assert hasattr(cm, "__aenter__")
+    assert hasattr(cm, "__aexit__")
+    turn = await cm.__aenter__()
     assert isinstance(turn, MockVoiceTurn)
+    await cm.__aexit__(None, None, None)
 
 
 async def test_mock_voice_turn_delivers_scripted_user_text() -> None:
     """get_user_text returns the text the MockVoice was scripted with."""
     voice = MockVoice(scripted_user_text="hi ducky")
-    turn = await voice.start_turn()
-    assert await turn.get_user_text() == "hi ducky"
+    async with voice.start_turn() as turn:
+        assert await turn.get_user_text() == "hi ducky"
 
 
 async def test_mock_voice_turn_records_spoken_text() -> None:

--- a/app/tests/test_voice_interface.py
+++ b/app/tests/test_voice_interface.py
@@ -1,0 +1,62 @@
+"""Tests for the abstract voice layer and its scripted mock."""
+
+from __future__ import annotations
+
+import pytest
+from reachy_ducky_app.voice import MockVoice, MockVoiceTurn, VoiceInterface, VoiceTurn
+
+
+def test_voice_interface_is_abstract() -> None:
+    """VoiceInterface cannot be instantiated directly — it is an ABC."""
+    with pytest.raises(TypeError):
+        VoiceInterface()  # type: ignore[abstract]
+
+
+def test_voice_turn_is_abstract() -> None:
+    """VoiceTurn cannot be instantiated directly — it is an ABC."""
+    with pytest.raises(TypeError):
+        VoiceTurn()  # type: ignore[abstract]
+
+
+async def test_mock_voice_starts_turn_returning_voice_turn_instance() -> None:
+    """MockVoice.start_turn returns a concrete VoiceTurn (MockVoiceTurn)."""
+    voice = MockVoice(scripted_user_text="hello")
+    turn = await voice.start_turn()
+    assert isinstance(turn, VoiceTurn)
+    assert isinstance(turn, MockVoiceTurn)
+
+
+async def test_mock_voice_turn_delivers_scripted_user_text() -> None:
+    """get_user_text returns the text the MockVoice was scripted with."""
+    voice = MockVoice(scripted_user_text="hi ducky")
+    turn = await voice.start_turn()
+    assert await turn.get_user_text() == "hi ducky"
+
+
+async def test_mock_voice_turn_records_spoken_text() -> None:
+    """speak_text appends to spoken_texts for side-effect assertions."""
+    turn = MockVoiceTurn(user_text="ignored")
+    await turn.speak_text("reply")
+    assert turn.spoken_texts == ["reply"]
+
+
+async def test_mock_voice_turn_records_multiple_speaks() -> None:
+    """Multiple speak_text calls accumulate in call order."""
+    turn = MockVoiceTurn(user_text="ignored")
+    await turn.speak_text("first")
+    await turn.speak_text("second")
+    await turn.speak_text("third")
+    assert turn.spoken_texts == ["first", "second", "third"]
+
+
+async def test_mock_voice_turn_interrupt_sets_flag() -> None:
+    """interrupt() sets the .interrupted flag so barge-in is observable."""
+    turn = MockVoiceTurn(user_text="ignored")
+    await turn.interrupt()
+    assert turn.interrupted is True
+
+
+def test_mock_voice_turn_interrupt_default_false() -> None:
+    """A fresh MockVoiceTurn starts with interrupted == False."""
+    turn = MockVoiceTurn(user_text="ignored")
+    assert turn.interrupted is False

--- a/app/tests/test_voice_openai_realtime.py
+++ b/app/tests/test_voice_openai_realtime.py
@@ -1,0 +1,102 @@
+"""Tests for :class:`OpenAIRealtimeVoice`.
+
+Unit tests cover construction-shape only. The stateful WebSocket methods
+(``get_user_text``, ``speak_text``, ``interrupt``) require a live OpenAI
+session and are exercised by the ``@pytest.mark.integration`` smoke at
+the bottom of this file, which is gated by ``REACHY_DUCKY_RUN_INTEGRATION``
++ ``OPENAI_API_KEY``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from reachy_ducky_app.voice.openai_realtime import OpenAIRealtimeVoice
+
+
+def test_construction_reads_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env-var path: OPENAI_API_KEY set, no kwarg → constructs cleanly."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    voice = OpenAIRealtimeVoice()
+    assert voice._api_key == "sk-from-env"
+
+
+def test_construction_accepts_explicit_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit kwarg wins over env var (and over its absence)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    voice = OpenAIRealtimeVoice(api_key="sk-explicit")
+    assert voice._api_key == "sk-explicit"
+
+
+def test_construction_prefers_explicit_api_key_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both sources are present, the explicit kwarg wins."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    voice = OpenAIRealtimeVoice(api_key="sk-explicit")
+    assert voice._api_key == "sk-explicit"
+
+
+def test_construction_raises_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env var and no kwarg → ValueError at construction (fail fast)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        OpenAIRealtimeVoice()
+
+
+def test_construction_passes_model_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """model= is stored verbatim on _model for start_turn to forward."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-any")
+    voice = OpenAIRealtimeVoice(model="gpt-realtime-preview-2025")
+    assert voice._model == "gpt-realtime-preview-2025"
+
+
+def test_construction_default_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default model is 'gpt-realtime' when not overridden."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-any")
+    voice = OpenAIRealtimeVoice()
+    assert voice._model == "gpt-realtime"
+
+
+def test_module_exports_openai_realtime_voice() -> None:
+    """OpenAIRealtimeVoice is exported at the voice package root."""
+    from reachy_ducky_app.voice import OpenAIRealtimeVoice as Exported
+
+    assert Exported is OpenAIRealtimeVoice
+
+
+def test_module_exports_openai_realtime_voice_turn() -> None:
+    """OpenAIRealtimeVoiceTurn is also exported at the voice package root."""
+    from reachy_ducky_app.voice import OpenAIRealtimeVoiceTurn
+    from reachy_ducky_app.voice.openai_realtime import (
+        OpenAIRealtimeVoiceTurn as Direct,
+    )
+
+    assert OpenAIRealtimeVoiceTurn is Direct
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_openai_realtime_smoke() -> None:
+    """Live smoke: open a real realtime WebSocket session.
+
+    Gated by ``REACHY_DUCKY_RUN_INTEGRATION=1`` AND ``OPENAI_API_KEY``.
+    Same pattern as the Task 2.3 Claude OAuth smoke: verify construction
+    + session-open succeed against the real API. We do not feed audio
+    (that needs a mic) and we do not wait for transcripts — scope is
+    strictly "does session-open work."
+    """
+    if not os.environ.get("REACHY_DUCKY_RUN_INTEGRATION"):
+        pytest.skip("set REACHY_DUCKY_RUN_INTEGRATION=1 to run")
+    if not os.environ.get("OPENAI_API_KEY"):
+        pytest.skip("OPENAI_API_KEY not set")
+    voice = OpenAIRealtimeVoice()
+    turn = await voice.start_turn()
+    assert turn is not None
+    # Clean up the WebSocket so the test process exits cleanly. VoiceTurn
+    # doesn't expose a close method, so reach through to the SDK connection.
+    from reachy_ducky_app.voice.openai_realtime import OpenAIRealtimeVoiceTurn
+
+    assert isinstance(turn, OpenAIRealtimeVoiceTurn)
+    await turn.connection.close()

--- a/app/tests/test_voice_openai_realtime.py
+++ b/app/tests/test_voice_openai_realtime.py
@@ -2,15 +2,17 @@
 
 Construction-shape tests and fake-connection drain tests live here. The
 drain tests feed scripted ``AsyncRealtimeConnection`` event streams into
-:meth:`OpenAIRealtimeVoiceTurn.speak_text` to prove it consumes events
-until the terminal ``response.done`` arrives without needing a real
-WebSocket. The ``@pytest.mark.integration`` smoke at the bottom covers
-the live-session path.
+:meth:`OpenAIRealtimeVoiceTurn.speak_text` and
+:meth:`OpenAIRealtimeVoiceTurn.get_user_text` to prove the event drain
+and mic-pump loops work without needing a real WebSocket. The
+``@pytest.mark.integration`` smoke at the bottom covers the live-session
+path.
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import os
 from collections.abc import AsyncIterator
@@ -18,9 +20,18 @@ from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from openai.types.realtime import RealtimeErrorEvent, ResponseDoneEvent
+from openai.types.realtime import (
+    RealtimeErrorEvent,
+    ResponseAudioDeltaEvent,
+    ResponseDoneEvent,
+)
 from openai.types.realtime.realtime_error import RealtimeError
 from openai.types.realtime.realtime_response import RealtimeResponse
+from reachy_ducky_app.voice.audio_io import (
+    MicSource,
+    MockMicSource,
+    MockSpeakerSink,
+)
 from reachy_ducky_app.voice.openai_realtime import (
     OpenAIRealtimeVoice,
     OpenAIRealtimeVoiceTurn,
@@ -30,11 +41,12 @@ from reachy_ducky_app.voice.openai_realtime import (
 class _FakeConnection:
     """Scripted stand-in for ``openai`` ``AsyncRealtimeConnection``.
 
-    Drives ``speak_text`` through a deterministic event sequence. The
-    iterator records which events were consumed (``observed``) so tests
-    can assert the drain went all the way to the terminal event and no
-    further. ``response.create`` / ``response.cancel`` are ``AsyncMock``s
-    so tests can assert the outbound side-effects.
+    Drives ``speak_text`` and ``get_user_text`` through a deterministic
+    event sequence. The iterator records which events were consumed
+    (``observed``) so tests can assert the drain went all the way to
+    the terminal event and no further. ``response.create`` /
+    ``response.cancel`` and ``input_audio_buffer.append`` are
+    ``AsyncMock`` s so tests can assert the outbound side-effects.
     """
 
     def __init__(self, events: list[Any]) -> None:
@@ -43,14 +55,49 @@ class _FakeConnection:
         self.response = MagicMock()
         self.response.create = AsyncMock()
         self.response.cancel = AsyncMock()
+        self.input_audio_buffer = MagicMock()
+        self.input_audio_buffer.append = AsyncMock()
 
     def __aiter__(self) -> AsyncIterator[Any]:
         return self._drain()
 
     async def _drain(self) -> AsyncIterator[Any]:
+        # Yield control before producing each event so concurrent tasks
+        # (e.g. the mic pump inside ``get_user_text``) get a scheduling
+        # slice. Real ``AsyncRealtimeConnection`` iteration awaits a
+        # websocket recv per event, which naturally yields; a synchronous
+        # generator would starve co-tasks and mis-model the SDK.
         for event in self._events:
+            await asyncio.sleep(0)
             self.observed.append(event)
             yield event
+
+
+class _InfiniteMicSource(MicSource):
+    """Mic stub that yields silence forever until cancelled.
+
+    Used to verify the pump-task cancellation path in
+    :meth:`OpenAIRealtimeVoiceTurn.get_user_text`: if the drain loop
+    fails to cancel the pump, this source keeps yielding and the test
+    times out.
+    """
+
+    def __init__(self) -> None:
+        self.yielded: int = 0
+
+    async def frames(self) -> AsyncIterator[bytes]:
+        while True:
+            self.yielded += 1
+            yield b"silence"
+            await asyncio.sleep(0)
+
+
+class _RaisingMicSource(MicSource):
+    """Mic stub that yields one frame then raises — exercises error propagation."""
+
+    async def frames(self) -> AsyncIterator[bytes]:
+        yield b"first"
+        raise RuntimeError("mic lost")
 
 
 def _make_response_done(
@@ -75,17 +122,59 @@ def _make_error_event(message: str = "boom") -> RealtimeErrorEvent:
     )
 
 
+def _make_audio_delta(pcm: bytes, *, event_id: str = "ev_audio") -> ResponseAudioDeltaEvent:
+    """Build a minimal ``ResponseAudioDeltaEvent`` whose base64 delta decodes to ``pcm``."""
+    return ResponseAudioDeltaEvent(
+        content_index=0,
+        delta=base64.b64encode(pcm).decode("ascii"),
+        event_id=event_id,
+        item_id="item_1",
+        output_index=0,
+        response_id="resp_1",
+        type="response.output_audio.delta",
+    )
+
+
+def _make_transcription_completed(
+    transcript: str,
+) -> Any:
+    """Build a minimal ``ConversationItemInputAudioTranscriptionCompletedEvent``.
+
+    Imported inside the helper so the top-level import list stays short;
+    the class name is long enough already. ``usage`` is required by the
+    SDK model — we supply a zero-duration stub since tests don't assert
+    on billing data.
+    """
+    from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
+        ConversationItemInputAudioTranscriptionCompletedEvent,
+        UsageTranscriptTextUsageDuration,
+    )
+
+    return ConversationItemInputAudioTranscriptionCompletedEvent(
+        content_index=0,
+        event_id="ev_t",
+        item_id="item_1",
+        transcript=transcript,
+        type="conversation.item.input_audio_transcription.completed",
+        usage=UsageTranscriptTextUsageDuration(seconds=0.0, type="duration"),
+    )
+
+
 def test_construction_reads_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Env-var path: OPENAI_API_KEY set, no kwarg → constructs cleanly."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
-    voice = OpenAIRealtimeVoice()
+    voice = OpenAIRealtimeVoice(mic=MockMicSource(), speaker=MockSpeakerSink())
     assert voice._api_key == "sk-from-env"
 
 
 def test_construction_accepts_explicit_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """Explicit kwarg wins over env var (and over its absence)."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    voice = OpenAIRealtimeVoice(api_key="sk-explicit")
+    voice = OpenAIRealtimeVoice(
+        mic=MockMicSource(),
+        speaker=MockSpeakerSink(),
+        api_key="sk-explicit",
+    )
     assert voice._api_key == "sk-explicit"
 
 
@@ -94,7 +183,11 @@ def test_construction_prefers_explicit_api_key_over_env(
 ) -> None:
     """When both sources are present, the explicit kwarg wins."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
-    voice = OpenAIRealtimeVoice(api_key="sk-explicit")
+    voice = OpenAIRealtimeVoice(
+        mic=MockMicSource(),
+        speaker=MockSpeakerSink(),
+        api_key="sk-explicit",
+    )
     assert voice._api_key == "sk-explicit"
 
 
@@ -102,21 +195,35 @@ def test_construction_raises_without_api_key(monkeypatch: pytest.MonkeyPatch) ->
     """No env var and no kwarg → ValueError at construction (fail fast)."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with pytest.raises(ValueError, match="OPENAI_API_KEY"):
-        OpenAIRealtimeVoice()
+        OpenAIRealtimeVoice(mic=MockMicSource(), speaker=MockSpeakerSink())
 
 
 def test_construction_passes_model_through(monkeypatch: pytest.MonkeyPatch) -> None:
     """model= is stored verbatim on _model for start_turn to forward."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-any")
-    voice = OpenAIRealtimeVoice(model="gpt-realtime-preview-2025")
+    voice = OpenAIRealtimeVoice(
+        mic=MockMicSource(),
+        speaker=MockSpeakerSink(),
+        model="gpt-realtime-preview-2025",
+    )
     assert voice._model == "gpt-realtime-preview-2025"
 
 
 def test_construction_default_model(monkeypatch: pytest.MonkeyPatch) -> None:
     """Default model is 'gpt-realtime' when not overridden."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-any")
-    voice = OpenAIRealtimeVoice()
+    voice = OpenAIRealtimeVoice(mic=MockMicSource(), speaker=MockSpeakerSink())
     assert voice._model == "gpt-realtime"
+
+
+def test_construction_stores_mic_and_speaker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mic + speaker are stored on the voice instance for start_turn to forward."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-any")
+    mic = MockMicSource()
+    speaker = MockSpeakerSink()
+    voice = OpenAIRealtimeVoice(mic=mic, speaker=speaker)
+    assert voice._mic is mic
+    assert voice._speaker is speaker
 
 
 def test_module_exports_openai_realtime_voice() -> None:
@@ -171,7 +278,9 @@ async def test_start_turn_enters_and_exits_sdk_connect_manager(
 
     monkeypatch.setattr("openai.AsyncOpenAI", _fake_async_openai)
 
-    voice = OpenAIRealtimeVoice(model="gpt-realtime-test")
+    mic = MockMicSource()
+    speaker = MockSpeakerSink()
+    voice = OpenAIRealtimeVoice(mic=mic, speaker=speaker, model="gpt-realtime-test")
 
     async with voice.start_turn() as turn:
         # Manager entered; connection yielded as the turn's underlying connection.
@@ -179,6 +288,9 @@ async def test_start_turn_enters_and_exits_sdk_connect_manager(
         connect_manager.__aexit__.assert_not_awaited()
         assert isinstance(turn, OpenAIRealtimeVoiceTurn)
         assert turn.connection is fake_connection
+        # Turn forwards mic + speaker from the voice factory.
+        assert turn._mic is mic
+        assert turn._speaker is speaker
 
     # After the async-with in this test exits: manager must have been exited.
     connect_manager.__aexit__.assert_awaited_once()
@@ -208,7 +320,7 @@ async def test_start_turn_exits_sdk_connect_manager_on_exception(
 
     monkeypatch.setattr("openai.AsyncOpenAI", _fake_async_openai)
 
-    voice = OpenAIRealtimeVoice()
+    voice = OpenAIRealtimeVoice(mic=MockMicSource(), speaker=MockSpeakerSink())
 
     class _BoomError(RuntimeError):
         pass
@@ -219,6 +331,155 @@ async def test_start_turn_exits_sdk_connect_manager_on_exception(
 
     connect_manager.__aenter__.assert_awaited_once()
     connect_manager.__aexit__.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_user_text_pumps_mic_frames_as_base64_append_events() -> None:
+    """Mic frames are base64-encoded and sent via ``input_audio_buffer.append``.
+
+    The original P1 bug: ``get_user_text`` iterated server events without
+    ever pushing audio in, so the transcription event could never arrive.
+    Now the method spawns a concurrent pump task that drains the mic
+    source and calls ``append(audio=<base64>)`` for each frame.
+    """
+    mic = MockMicSource(frames=[b"f1", b"f2"])
+    speaker = MockSpeakerSink()
+    connection = _FakeConnection(events=[_make_transcription_completed("hi")])
+
+    turn = OpenAIRealtimeVoiceTurn(connection, mic=mic, speaker=speaker)  # type: ignore[arg-type]
+
+    result = await asyncio.wait_for(turn.get_user_text(), timeout=1.0)
+
+    assert result == "hi"
+    # Both scripted frames were appended, in order, base64-encoded.
+    assert connection.input_audio_buffer.append.await_count == 2
+    connection.input_audio_buffer.append.assert_any_await(
+        audio=base64.b64encode(b"f1").decode("ascii")
+    )
+    connection.input_audio_buffer.append.assert_any_await(
+        audio=base64.b64encode(b"f2").decode("ascii")
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_user_text_cancels_mic_pump_on_transcription() -> None:
+    """When transcription arrives, the mic pump task must be cancelled.
+
+    Uses an infinite mic source: if the pump is left running after
+    ``get_user_text`` returns, the test coroutine never sees cancellation
+    and the outer ``asyncio.wait_for`` backstop fires. The real
+    correctness signal is that the test completes under the timeout.
+    """
+    mic = _InfiniteMicSource()
+    speaker = MockSpeakerSink()
+    connection = _FakeConnection(events=[_make_transcription_completed("done")])
+
+    turn = OpenAIRealtimeVoiceTurn(connection, mic=mic, speaker=speaker)  # type: ignore[arg-type]
+
+    result = await asyncio.wait_for(turn.get_user_text(), timeout=1.0)
+
+    assert result == "done"
+    # Side-effect verification: at least one frame was pumped before cancellation.
+    assert connection.input_audio_buffer.append.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_get_user_text_propagates_mic_errors() -> None:
+    """A failing mic source surfaces its exception from ``get_user_text``.
+
+    We do not silently swallow mic-layer errors — they indicate a real
+    hardware-tier problem and the caller (the conversation loop) needs
+    to see them so the state machine can recover or abort.
+    """
+    mic = _RaisingMicSource()
+    speaker = MockSpeakerSink()
+    # Connection yields no events: the drain loop will wait forever unless
+    # the mic-pump exception propagates. We rely on the pump's error
+    # reaching the outer coroutine.
+    connection = _FakeConnection(events=[])
+
+    turn = OpenAIRealtimeVoiceTurn(connection, mic=mic, speaker=speaker)  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="mic lost"):
+        await asyncio.wait_for(turn.get_user_text(), timeout=1.0)
+
+    # The one pre-raise frame was pumped, proving the pump ran before failing.
+    connection.input_audio_buffer.append.assert_awaited_once_with(
+        audio=base64.b64encode(b"first").decode("ascii")
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_user_text_returns_empty_on_empty_event_stream() -> None:
+    """Connection closes before transcription arrives: return ``""`` cleanly.
+
+    Covers the "mic went silent, server closed" edge. The drain loop
+    runs to exhaustion and the method returns an empty string rather
+    than raising, so the caller can decide how to treat silence.
+    """
+    mic = MockMicSource()
+    speaker = MockSpeakerSink()
+    connection = _FakeConnection(events=[])
+
+    turn = OpenAIRealtimeVoiceTurn(connection, mic=mic, speaker=speaker)  # type: ignore[arg-type]
+
+    result = await asyncio.wait_for(turn.get_user_text(), timeout=1.0)
+
+    assert result == ""
+    # Nothing to pump from a default MockMicSource; 0 appends is correct.
+    assert connection.input_audio_buffer.append.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_speak_text_pipes_audio_deltas_to_speaker() -> None:
+    """Happy path: ``response.output_audio.delta`` payloads reach ``speaker.play``.
+
+    The original P1 bug: ``speak_text`` drained to ``response.done`` but
+    ignored ``response.output_audio.delta`` events, so the robot's
+    speaker never heard the TTS audio. Now each delta is base64-decoded
+    and forwarded to ``speaker.play(pcm)``.
+    """
+    delta1 = _make_audio_delta(b"pcm1", event_id="a1")
+    delta2 = _make_audio_delta(b"pcm2", event_id="a2")
+    done = _make_response_done("completed")
+    connection = _FakeConnection(events=[delta1, delta2, done])
+
+    speaker = MockSpeakerSink()
+    turn = OpenAIRealtimeVoiceTurn(
+        connection,  # type: ignore[arg-type]
+        mic=MockMicSource(),
+        speaker=speaker,
+    )
+
+    await turn.speak_text("hi")
+
+    connection.response.create.assert_awaited_once()
+    assert speaker.played == [b"pcm1", b"pcm2"]
+    # Drain consumed all three events and stopped at the terminal one.
+    assert connection.observed == [delta1, delta2, done]
+
+
+@pytest.mark.asyncio
+async def test_speak_text_ignores_non_delta_events_while_piping_audio() -> None:
+    """Deltas interleaved with non-audio events: only deltas reach the speaker."""
+    delta1 = _make_audio_delta(b"A")
+    interstitial = MagicMock(name="unrelated_event")
+    delta2 = _make_audio_delta(b"B")
+    done = _make_response_done("completed")
+    connection = _FakeConnection(events=[delta1, interstitial, delta2, done])
+
+    speaker = MockSpeakerSink()
+    turn = OpenAIRealtimeVoiceTurn(
+        connection,  # type: ignore[arg-type]
+        mic=MockMicSource(),
+        speaker=speaker,
+    )
+
+    await turn.speak_text("hi")
+
+    connection.response.create.assert_awaited_once()
+    assert speaker.played == [b"A", b"B"]
+    assert connection.observed == [delta1, interstitial, delta2, done]
 
 
 @pytest.mark.asyncio
@@ -234,7 +495,11 @@ async def test_speak_text_drains_events_until_response_done() -> None:
     done = _make_response_done("completed")
     connection = _FakeConnection(events=[interstitial, done])
 
-    turn = OpenAIRealtimeVoiceTurn(connection)  # type: ignore[arg-type]
+    turn = OpenAIRealtimeVoiceTurn(
+        connection,  # type: ignore[arg-type]
+        mic=MockMicSource(),
+        speaker=MockSpeakerSink(),
+    )
 
     await turn.speak_text("hi")
 
@@ -261,7 +526,11 @@ async def test_speak_text_returns_on_failed_response_and_logs(
     failed = _make_response_done("failed")
     connection = _FakeConnection(events=[failed])
 
-    turn = OpenAIRealtimeVoiceTurn(connection)  # type: ignore[arg-type]
+    turn = OpenAIRealtimeVoiceTurn(
+        connection,  # type: ignore[arg-type]
+        mic=MockMicSource(),
+        speaker=MockSpeakerSink(),
+    )
 
     with caplog.at_level(logging.WARNING, logger="reachy_ducky_app.voice.openai_realtime"):
         await turn.speak_text("hi")
@@ -282,7 +551,11 @@ async def test_speak_text_returns_on_session_error_event(
     err = _make_error_event("connection lost")
     connection = _FakeConnection(events=[err])
 
-    turn = OpenAIRealtimeVoiceTurn(connection)  # type: ignore[arg-type]
+    turn = OpenAIRealtimeVoiceTurn(
+        connection,  # type: ignore[arg-type]
+        mic=MockMicSource(),
+        speaker=MockSpeakerSink(),
+    )
 
     with caplog.at_level(logging.WARNING, logger="reachy_ducky_app.voice.openai_realtime"):
         await turn.speak_text("hi")
@@ -303,7 +576,11 @@ async def test_speak_text_returns_on_cancelled_response() -> None:
     cancelled = _make_response_done("cancelled")
     connection = _FakeConnection(events=[cancelled])
 
-    turn = OpenAIRealtimeVoiceTurn(connection)  # type: ignore[arg-type]
+    turn = OpenAIRealtimeVoiceTurn(
+        connection,  # type: ignore[arg-type]
+        mic=MockMicSource(),
+        speaker=MockSpeakerSink(),
+    )
 
     async def _drive_speak() -> None:
         await turn.speak_text("hi")
@@ -338,6 +615,6 @@ async def test_openai_realtime_smoke() -> None:
         pytest.skip("set REACHY_DUCKY_RUN_INTEGRATION=1 to run")
     if not os.environ.get("OPENAI_API_KEY"):
         pytest.skip("OPENAI_API_KEY not set")
-    voice = OpenAIRealtimeVoice()
+    voice = OpenAIRealtimeVoice(mic=MockMicSource(), speaker=MockSpeakerSink())
     async with voice.start_turn() as turn:
         assert isinstance(turn, OpenAIRealtimeVoiceTurn)

--- a/app/tests/test_voice_openai_realtime.py
+++ b/app/tests/test_voice_openai_realtime.py
@@ -10,9 +10,13 @@ the bottom of this file, which is gated by ``REACHY_DUCKY_RUN_INTEGRATION``
 from __future__ import annotations
 
 import os
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from reachy_ducky_app.voice.openai_realtime import OpenAIRealtimeVoice
+from reachy_ducky_app.voice.openai_realtime import (
+    OpenAIRealtimeVoice,
+    OpenAIRealtimeVoiceTurn,
+)
 
 
 def test_construction_reads_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -76,6 +80,94 @@ def test_module_exports_openai_realtime_voice_turn() -> None:
     assert OpenAIRealtimeVoiceTurn is Direct
 
 
+@pytest.mark.asyncio
+async def test_start_turn_enters_and_exits_sdk_connect_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``start_turn`` must both enter *and* exit the SDK's connect() CM.
+
+    Regression for bug I1 (websocket leak): the old code called
+    ``manager.enter()`` and never closed the connection. With the
+    async-context-manager shape, the outer ``async with`` in the caller
+    drives ``__aexit__`` on the SDK manager, releasing the websocket.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    # Fake AsyncRealtimeConnection: minimal surface start_turn touches is
+    # `.session.update(...)`. The turn object stores it untouched.
+    fake_connection = MagicMock(name="AsyncRealtimeConnection")
+    fake_connection.session = MagicMock()
+    fake_connection.session.update = AsyncMock()
+
+    # Fake AsyncRealtimeConnectionManager: an async context manager.
+    connect_manager = MagicMock(name="AsyncRealtimeConnectionManager")
+    connect_manager.__aenter__ = AsyncMock(return_value=fake_connection)
+    connect_manager.__aexit__ = AsyncMock(return_value=None)
+
+    # Fake AsyncOpenAI: its .realtime.connect(model=...) returns the CM.
+    fake_realtime = MagicMock()
+    fake_realtime.connect = MagicMock(return_value=connect_manager)
+    fake_client = MagicMock()
+    fake_client.realtime = fake_realtime
+
+    def _fake_async_openai(*, api_key: str) -> MagicMock:
+        assert api_key == "sk-test"
+        return fake_client
+
+    monkeypatch.setattr("openai.AsyncOpenAI", _fake_async_openai)
+
+    voice = OpenAIRealtimeVoice(model="gpt-realtime-test")
+
+    async with voice.start_turn() as turn:
+        # Manager entered; connection yielded as the turn's underlying connection.
+        connect_manager.__aenter__.assert_awaited_once()
+        connect_manager.__aexit__.assert_not_awaited()
+        assert isinstance(turn, OpenAIRealtimeVoiceTurn)
+        assert turn.connection is fake_connection
+
+    # After the async-with in this test exits: manager must have been exited.
+    connect_manager.__aexit__.assert_awaited_once()
+    fake_realtime.connect.assert_called_once_with(model="gpt-realtime-test")
+
+
+@pytest.mark.asyncio
+async def test_start_turn_exits_sdk_connect_manager_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exception inside the ``async with`` body must still close the CM."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    fake_connection = MagicMock(name="AsyncRealtimeConnection")
+    fake_connection.session = MagicMock()
+    fake_connection.session.update = AsyncMock()
+
+    connect_manager = MagicMock(name="AsyncRealtimeConnectionManager")
+    connect_manager.__aenter__ = AsyncMock(return_value=fake_connection)
+    connect_manager.__aexit__ = AsyncMock(return_value=None)
+
+    fake_realtime = MagicMock()
+    fake_realtime.connect = MagicMock(return_value=connect_manager)
+    fake_client = MagicMock()
+    fake_client.realtime = fake_realtime
+
+    def _fake_async_openai(*, api_key: str) -> MagicMock:
+        return fake_client
+
+    monkeypatch.setattr("openai.AsyncOpenAI", _fake_async_openai)
+
+    voice = OpenAIRealtimeVoice()
+
+    class _BoomError(RuntimeError):
+        pass
+
+    with pytest.raises(_BoomError):
+        async with voice.start_turn():
+            raise _BoomError("explode mid-turn")
+
+    connect_manager.__aenter__.assert_awaited_once()
+    connect_manager.__aexit__.assert_awaited_once()
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_openai_realtime_smoke() -> None:
@@ -85,18 +177,13 @@ async def test_openai_realtime_smoke() -> None:
     Same pattern as the Task 2.3 Claude OAuth smoke: verify construction
     + session-open succeed against the real API. We do not feed audio
     (that needs a mic) and we do not wait for transcripts — scope is
-    strictly "does session-open work."
+    strictly "does session-open work." The ``async with`` drives
+    teardown of the SDK connection so the test process exits cleanly.
     """
     if not os.environ.get("REACHY_DUCKY_RUN_INTEGRATION"):
         pytest.skip("set REACHY_DUCKY_RUN_INTEGRATION=1 to run")
     if not os.environ.get("OPENAI_API_KEY"):
         pytest.skip("OPENAI_API_KEY not set")
     voice = OpenAIRealtimeVoice()
-    turn = await voice.start_turn()
-    assert turn is not None
-    # Clean up the WebSocket so the test process exits cleanly. VoiceTurn
-    # doesn't expose a close method, so reach through to the SDK connection.
-    from reachy_ducky_app.voice.openai_realtime import OpenAIRealtimeVoiceTurn
-
-    assert isinstance(turn, OpenAIRealtimeVoiceTurn)
-    await turn.connection.close()
+    async with voice.start_turn() as turn:
+        assert isinstance(turn, OpenAIRealtimeVoiceTurn)

--- a/app/tests/test_voice_openai_realtime.py
+++ b/app/tests/test_voice_openai_realtime.py
@@ -100,6 +100,21 @@ class _RaisingMicSource(MicSource):
         raise RuntimeError("mic lost")
 
 
+class _ImmediateRaisingMicSource(MicSource):
+    """Mic stub that raises synchronously on first access, before any ``yield``.
+
+    Unlike :class:`_RaisingMicSource`, this variant's generator body reaches
+    ``raise`` without any intervening ``await``, so the pump task completes
+    deterministically within its first scheduling slice. Used to exercise
+    the exact race Augment flagged: pump is ``done()`` with an exception
+    stored by the time ``get_user_text`` returns an early transcript.
+    """
+
+    async def frames(self) -> AsyncIterator[bytes]:
+        raise RuntimeError("mic dead")
+        yield b""  # pragma: no cover — unreachable; keeps the function an async generator
+
+
 def _make_response_done(
     status: Literal["completed", "cancelled", "failed", "incomplete", "in_progress"] = (
         "completed"
@@ -407,6 +422,37 @@ async def test_get_user_text_propagates_mic_errors() -> None:
     connection.input_audio_buffer.append.assert_awaited_once_with(
         audio=base64.b64encode(b"first").decode("ascii")
     )
+
+
+@pytest.mark.asyncio
+async def test_get_user_text_surfaces_mic_error_over_early_transcript_return() -> None:
+    """Finally retrieves a completed pump task's exception even on early return.
+
+    Augment PR #13 finding (medium): if the mic pump fails and a transcription
+    event arrives, the early ``return event.transcript`` path fires before the
+    inner pump-done check on line 185. The ``finally`` block must
+    unconditionally retrieve the pump task's stored exception — otherwise the
+    mic failure is silently swallowed (Python emits "Task exception was never
+    retrieved") and the caller gets a stale transcript from a broken mic.
+
+    A hardware-tier mic failure should supersede a stale transcript, so
+    ``get_user_text`` must exit with the ``RuntimeError``, not return ``"hi"``.
+    """
+    mic = _ImmediateRaisingMicSource()
+    speaker = MockSpeakerSink()
+    # Single transcription event. _ImmediateRaisingMicSource raises without
+    # any intervening await, so by the time the drain's pre-yield
+    # ``await asyncio.sleep(0)`` completes, pump_task is deterministically
+    # ``done()`` with RuntimeError stored.
+    connection = _FakeConnection(events=[_make_transcription_completed("hi")])
+
+    turn = OpenAIRealtimeVoiceTurn(connection, mic=mic, speaker=speaker)  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="mic dead"):
+        await asyncio.wait_for(turn.get_user_text(), timeout=1.0)
+
+    # Pump raised before any append could fire.
+    assert connection.input_audio_buffer.append.await_count == 0
 
 
 @pytest.mark.asyncio

--- a/app/tests/test_voice_openai_realtime.py
+++ b/app/tests/test_voice_openai_realtime.py
@@ -93,11 +93,10 @@ async def test_start_turn_enters_and_exits_sdk_connect_manager(
     """
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
-    # Fake AsyncRealtimeConnection: minimal surface start_turn touches is
-    # `.session.update(...)`. The turn object stores it untouched.
+    # Fake AsyncRealtimeConnection: start_turn does not touch any of its
+    # attrs — it just yields it as the turn's .connection. A plain
+    # MagicMock is enough.
     fake_connection = MagicMock(name="AsyncRealtimeConnection")
-    fake_connection.session = MagicMock()
-    fake_connection.session.update = AsyncMock()
 
     # Fake AsyncRealtimeConnectionManager: an async context manager.
     connect_manager = MagicMock(name="AsyncRealtimeConnectionManager")
@@ -138,8 +137,6 @@ async def test_start_turn_exits_sdk_connect_manager_on_exception(
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     fake_connection = MagicMock(name="AsyncRealtimeConnection")
-    fake_connection.session = MagicMock()
-    fake_connection.session.update = AsyncMock()
 
     connect_manager = MagicMock(name="AsyncRealtimeConnectionManager")
     connect_manager.__aenter__ = AsyncMock(return_value=fake_connection)

--- a/app/tests/test_voice_openai_realtime.py
+++ b/app/tests/test_voice_openai_realtime.py
@@ -1,22 +1,78 @@
 """Tests for :class:`OpenAIRealtimeVoice`.
 
-Unit tests cover construction-shape only. The stateful WebSocket methods
-(``get_user_text``, ``speak_text``, ``interrupt``) require a live OpenAI
-session and are exercised by the ``@pytest.mark.integration`` smoke at
-the bottom of this file, which is gated by ``REACHY_DUCKY_RUN_INTEGRATION``
-+ ``OPENAI_API_KEY``.
+Construction-shape tests and fake-connection drain tests live here. The
+drain tests feed scripted ``AsyncRealtimeConnection`` event streams into
+:meth:`OpenAIRealtimeVoiceTurn.speak_text` to prove it consumes events
+until the terminal ``response.done`` arrives without needing a real
+WebSocket. The ``@pytest.mark.integration`` smoke at the bottom covers
+the live-session path.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
+from collections.abc import AsyncIterator
+from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from openai.types.realtime import RealtimeErrorEvent, ResponseDoneEvent
+from openai.types.realtime.realtime_error import RealtimeError
+from openai.types.realtime.realtime_response import RealtimeResponse
 from reachy_ducky_app.voice.openai_realtime import (
     OpenAIRealtimeVoice,
     OpenAIRealtimeVoiceTurn,
 )
+
+
+class _FakeConnection:
+    """Scripted stand-in for ``openai`` ``AsyncRealtimeConnection``.
+
+    Drives ``speak_text`` through a deterministic event sequence. The
+    iterator records which events were consumed (``observed``) so tests
+    can assert the drain went all the way to the terminal event and no
+    further. ``response.create`` / ``response.cancel`` are ``AsyncMock``s
+    so tests can assert the outbound side-effects.
+    """
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = list(events)
+        self.observed: list[Any] = []
+        self.response = MagicMock()
+        self.response.create = AsyncMock()
+        self.response.cancel = AsyncMock()
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self._drain()
+
+    async def _drain(self) -> AsyncIterator[Any]:
+        for event in self._events:
+            self.observed.append(event)
+            yield event
+
+
+def _make_response_done(
+    status: Literal["completed", "cancelled", "failed", "incomplete", "in_progress"] = (
+        "completed"
+    ),
+) -> ResponseDoneEvent:
+    """Build a minimal ``ResponseDoneEvent`` with the given response status."""
+    return ResponseDoneEvent(
+        event_id="ev_done",
+        response=RealtimeResponse(id="resp_1", status=status),
+        type="response.done",
+    )
+
+
+def _make_error_event(message: str = "boom") -> RealtimeErrorEvent:
+    """Build a minimal session-level ``RealtimeErrorEvent``."""
+    return RealtimeErrorEvent(
+        event_id="ev_err",
+        error=RealtimeError(type="server_error", message=message),
+        type="error",
+    )
 
 
 def test_construction_reads_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -163,6 +219,107 @@ async def test_start_turn_exits_sdk_connect_manager_on_exception(
 
     connect_manager.__aenter__.assert_awaited_once()
     connect_manager.__aexit__.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_speak_text_drains_events_until_response_done() -> None:
+    """Happy path: ``speak_text`` returns only after ``ResponseDoneEvent``.
+
+    Regression for the post-I1 bug where ``speak_text`` returned as soon
+    as ``response.create`` was awaited, so the outer async-with closed
+    the websocket before the server finished streaming audio. The drain
+    loop must consume all intermediate events and stop on ``response.done``.
+    """
+    interstitial = MagicMock(name="response.audio.delta")
+    done = _make_response_done("completed")
+    connection = _FakeConnection(events=[interstitial, done])
+
+    turn = OpenAIRealtimeVoiceTurn(connection)  # type: ignore[arg-type]
+
+    await turn.speak_text("hi")
+
+    connection.response.create.assert_awaited_once()
+    payload = connection.response.create.await_args.kwargs["response"]
+    assert payload == {
+        "output_modalities": ["audio", "text"],
+        "instructions": "hi",
+    }
+    # Drain consumed both events and stopped at the terminal one.
+    assert connection.observed == [interstitial, done]
+
+
+@pytest.mark.asyncio
+async def test_speak_text_returns_on_failed_response_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Server-side response failure: ``speak_text`` logs and returns.
+
+    Best-effort TTS semantics — the state machine progresses even if the
+    Realtime API reports a failed response. We still want a breadcrumb
+    in the log so a debug session can see why audio went quiet.
+    """
+    failed = _make_response_done("failed")
+    connection = _FakeConnection(events=[failed])
+
+    turn = OpenAIRealtimeVoiceTurn(connection)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.WARNING, logger="reachy_ducky_app.voice.openai_realtime"):
+        await turn.speak_text("hi")
+
+    connection.response.create.assert_awaited_once()
+    assert connection.observed == [failed]
+    assert any(
+        "realtime response" in record.message.lower() and record.levelno == logging.WARNING
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_speak_text_returns_on_session_error_event(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Session-level ``error`` event: log and return (no hang, no raise)."""
+    err = _make_error_event("connection lost")
+    connection = _FakeConnection(events=[err])
+
+    turn = OpenAIRealtimeVoiceTurn(connection)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.WARNING, logger="reachy_ducky_app.voice.openai_realtime"):
+        await turn.speak_text("hi")
+
+    connection.response.create.assert_awaited_once()
+    assert connection.observed == [err]
+
+
+@pytest.mark.asyncio
+async def test_speak_text_returns_on_cancelled_response() -> None:
+    """Concurrent ``interrupt()`` triggers a cancel; the server emits
+    ``response.done`` with ``status == "cancelled"``; ``speak_text`` returns.
+
+    This is how barge-in works end-to-end: the drain loop observes the
+    terminal event the server sent in response to our cancel, rather
+    than consulting ``self._interrupted`` directly.
+    """
+    cancelled = _make_response_done("cancelled")
+    connection = _FakeConnection(events=[cancelled])
+
+    turn = OpenAIRealtimeVoiceTurn(connection)  # type: ignore[arg-type]
+
+    async def _drive_speak() -> None:
+        await turn.speak_text("hi")
+
+    async def _drive_interrupt() -> None:
+        # Yield once so speak_text gets a chance to await response.create
+        # before we fire the cancel — mirrors realistic ordering.
+        await asyncio.sleep(0)
+        await turn.interrupt()
+
+    await asyncio.gather(_drive_speak(), _drive_interrupt())
+
+    connection.response.create.assert_awaited_once()
+    connection.response.cancel.assert_awaited_once()
+    assert turn._interrupted is True
+    assert connection.observed == [cancelled]
 
 
 @pytest.mark.integration

--- a/app/tests/test_wake.py
+++ b/app/tests/test_wake.py
@@ -1,0 +1,54 @@
+"""Tests for the wake-word detector interface, mock, and factory."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from reachy_ducky_app.wake import (
+    MockWakeDetector,
+    WakeDetector,
+    load_default_wake_detector,
+)
+
+
+def test_wake_detector_is_abstract() -> None:
+    """WakeDetector cannot be instantiated directly — it is an ABC."""
+    with pytest.raises(TypeError):
+        WakeDetector()  # type: ignore[abstract]
+
+
+def test_mock_detector_feed_audio_returns_false_for_any_chunk() -> None:
+    """MockWakeDetector.feed_audio ignores audio and returns False by design."""
+    det = MockWakeDetector()
+    assert det.feed_audio(np.zeros(16, dtype=np.int16)) is False
+
+
+def test_mock_detector_detect_in_text_triggers_on_keyword() -> None:
+    """detect_in_text returns True when the trigger phrase appears in text."""
+    det = MockWakeDetector(trigger_on="hey ducky")
+    assert det.detect_in_text("hey ducky, how are you?") is True
+
+
+def test_mock_detector_detect_in_text_case_insensitive() -> None:
+    """detect_in_text matches regardless of case (both sides lowered)."""
+    det = MockWakeDetector(trigger_on="Hey Ducky")
+    assert det.detect_in_text("HEY DUCKY listen up") is True
+
+
+def test_mock_detector_detect_in_text_negative() -> None:
+    """detect_in_text returns False when the trigger phrase is absent."""
+    det = MockWakeDetector(trigger_on="hey ducky")
+    assert det.detect_in_text("good morning world") is False
+
+
+def test_mock_detector_custom_trigger_word() -> None:
+    """A custom trigger word is honoured by detect_in_text."""
+    det = MockWakeDetector(trigger_on="quack attack")
+    assert det.detect_in_text("initiating quack attack now") is True
+    assert det.detect_in_text("hey ducky") is False
+
+
+def test_load_default_returns_mock_for_now() -> None:
+    """Phase A lock-in: the default factory returns the mock detector."""
+    det = load_default_wake_detector()
+    assert isinstance(det, MockWakeDetector)

--- a/docs/testing/2026-04-21-phase-a-e2e-procedure.md
+++ b/docs/testing/2026-04-21-phase-a-e2e-procedure.md
@@ -1,6 +1,6 @@
 # Phase A End-to-End Smoke Procedure
 
-Last verified against `m8-voice` @ `2a753fe`. Adapt when tasks after M11.2 land.
+> This procedure mirrors the tree on `m8-voice` as of 2026-04-22. Re-verify after every merge.
 
 This procedure walks a teammate through bringing up the three Phase A
 surfaces (Mac daemon, Mac menu-bar, Reachy Mini app) and exercising the
@@ -15,8 +15,8 @@ code-level override.
 
 - `claude login` — run on the Mac. `ClaudeSDKBrain` uses the locally
   installed Claude CLI's OAuth credentials via `claude_agent_sdk`.
-  (`CLAUDE_CODE_OAUTH_TOKEN` is a CI-only path used by
-  `.github/workflows/integration.yml`; local runs do NOT need it.)
+  (`CLAUDE_CODE_OAUTH_TOKEN` is a CI-only path used by the GitHub
+  workflows under `.github/workflows/`; local runs do NOT need it.)
 - `gh auth login` — only if you plan to manually inspect GitHub via
   `gh`. The daemon itself reaches GitHub via `github-mcp-server`, not
   `gh`.
@@ -138,9 +138,7 @@ Verification (reading `menubar/src/reachy_ducky_menubar/main.py` +
   (<code>)` for a reachable-but-broken daemon). Restart the daemon
   and the glyph returns to `🦆`.
 
-The menu-bar poller only drives IDLE ↔ MUTED locally; `LISTENING`
-and `THINKING` glyphs exist in `state_icon.py` but nothing pushes
-those states over the wire in Phase A. See "Known gaps".
+See "Known gaps" §2.
 
 ## 3. Start the Reachy app on the robot
 
@@ -217,6 +215,9 @@ Workarounds for smoke-verifying the daemon + voice path without wake:
 poll loop (`main.py::_poll_loop`) only writes the local IDLE /
 MUTED state. There is no `/state` push from the robot or daemon.
 
+- TODO (follow-up issue): Menu-bar `DAEMON_URL` should become
+  env-overridable; currently hardcoded.
+
 ### 3. Reachy dashboard install is unverified
 
 `app/reachy_mini_app.yaml` declares `app_class:
@@ -241,7 +242,7 @@ not the plan's draft. A follow-up issue should update the plan.
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Menu-bar shows `🦆⚠` "daemon unreachable" | Daemon not running, or bound to a different host/port than `http://127.0.0.1:8765` | Start the daemon; or set `_DAEMON_URL_DEFAULT` (currently hardcoded — see menubar/src/reachy_ducky_menubar/main.py). |
+| Menu-bar shows `🦆⚠` "daemon unreachable" | Daemon not running, or bound to a different host/port than `http://127.0.0.1:8765` | Start the daemon; or edit `menubar/src/reachy_ducky_menubar/main.py:24` — `DAEMON_URL` is not yet env-overridable in Phase A. |
 | `curl /brain/query` returns `401 {"detail":"missing bearer token"}` | `REACHY_DUCKY_AUTH_TOKEN` is set on the daemon; your curl didn't send `Authorization: Bearer <token>` | Add the header, or unset the env var and restart the daemon. |
 | `curl /brain/query` returns `401 {"detail":"invalid bearer token"}` | Token mismatch between daemon and caller | Re-source `~/.reachy-ducky/.env` in both shells. |
 | `curl /brain/query` returns `400 {"detail":"no project_slug in request and no primary project configured"}` | Wizard was not run, or no `primary = true` project in `config.toml` | Re-run `uv run reachy-ducky init`, or edit `~/.reachy-ducky/config.toml`. |
@@ -252,3 +253,23 @@ not the plan's draft. A follow-up issue should update the plan.
 | `uv run reachy-ducky-menubar` crashes with `ModuleNotFoundError: rumps` | `macos` extra not installed | `uv sync --all-packages --extra macos`. |
 | `OpenAIRealtimeVoice` raises `ValueError: OPENAI_API_KEY not set` on the robot | Env var missing in the robot-side process | Export `OPENAI_API_KEY` before starting the app. |
 | Realtime session opens but hangs up immediately after user speech | Schema drift between the `openai` SDK version and `voice/openai_realtime.py`'s assumed event names | Confirm `openai==1.109.x`; see module docstring for the verified event shape. |
+
+## Tailing logs
+
+The daemon logs to stdout. For long smoke sessions, start it under
+`2>&1 | tee /tmp/reachy-ducky-daemon.log` (or similar) so failure
+modes can be cross-referenced with the log after the fact.
+
+## Clean shutdown
+
+Ctrl-C the daemon in its terminal; quit the menu-bar app from its
+own menu; stop the Reachy app from the dashboard (or SSH the robot
+and terminate the python process).
+
+## Done checklist
+
+- [ ] `/health` returns `ok: true` and the expected brain state
+- [ ] Menu-bar icon shows `🦆` (unmuted) and toggles to `🦆🔇` / back
+- [ ] Protected-route curl with bearer token succeeds
+- [ ] Daemon process exits cleanly on Ctrl-C
+- [ ] (Deferred until Known gaps close) Robot app instantiates from the Reachy dashboard and plays `listening` → `thinking` moves end-to-end

--- a/docs/testing/2026-04-21-phase-a-e2e-procedure.md
+++ b/docs/testing/2026-04-21-phase-a-e2e-procedure.md
@@ -1,0 +1,254 @@
+# Phase A End-to-End Smoke Procedure
+
+Last verified against `m8-voice` @ `2a753fe`. Adapt when tasks after M11.2 land.
+
+This procedure walks a teammate through bringing up the three Phase A
+surfaces (Mac daemon, Mac menu-bar, Reachy Mini app) and exercising the
+wire between them. Phase A wake detection and Reachy dashboard install
+are NOT yet fully wired — see "Known gaps" below; a full "say 'Hey
+Ducky', get a spoken reply" demo is not achievable today without a
+code-level override.
+
+## 0. Prereqs
+
+### Accounts / logins
+
+- `claude login` — run on the Mac. `ClaudeSDKBrain` uses the locally
+  installed Claude CLI's OAuth credentials via `claude_agent_sdk`.
+  (`CLAUDE_CODE_OAUTH_TOKEN` is a CI-only path used by
+  `.github/workflows/integration.yml`; local runs do NOT need it.)
+- `gh auth login` — only if you plan to manually inspect GitHub via
+  `gh`. The daemon itself reaches GitHub via `github-mcp-server`, not
+  `gh`.
+
+### Runtimes on the Mac
+
+- `uv` installed (`brew install uv`).
+- Node.js 20+ on `PATH` (`brew install node@20`). Required for
+  `npx -y github-mcp-server` which the Pattern B brain spawns
+  (declared in `.mcp.json`).
+
+### Env vars (Mac daemon side)
+
+- `GITHUB_PERSONAL_ACCESS_TOKEN` — `repo:read` + `pull_requests:read`
+  + `issues:read`. Required for the `mcp__github__*` tool surface when
+  a project sets `github_repo`. Read from process env at daemon start
+  by `build_brain_options` and forwarded into the MCP subprocess.
+- `REACHY_DUCKY_AUTH_TOKEN` — optional bearer token. When set, every
+  daemon route except `/health`, `/docs`, and `/openapi.json` requires
+  `Authorization: Bearer <token>`. `reachy-ducky init` writes this to
+  `~/.reachy-ducky/.env` at 0600 if you supply one during the wizard.
+
+### Env vars (Reachy side)
+
+- `OPENAI_API_KEY` — required. `OpenAIRealtimeVoice.__init__` fails
+  fast with `ValueError` if unset.
+- `DAEMON_URL` — e.g. `http://<mac>.tailnet.ts.net:8765`. Defaults to
+  `http://127.0.0.1:8765`, which is only right if daemon + app share a
+  host.
+- `DAEMON_AUTH_TOKEN` — must match `REACHY_DUCKY_AUTH_TOKEN` if the
+  daemon has one set.
+
+### One-time first-run wizard
+
+```bash
+cd reachy-ducky
+uv sync --all-packages --group dev
+uv run reachy-ducky init
+```
+
+The wizard writes `~/.reachy-ducky/config.toml` (bind host/port,
+memory root, project list) and a 0600 `~/.reachy-ducky/.env` (auth
+token, GitHub PAT). At least one project is required; mark one as
+primary.
+
+## 1. Start the daemon
+
+```bash
+cd reachy-ducky
+# Load secrets written by `reachy-ducky init`:
+set -a; source ~/.reachy-ducky/.env; set +a
+uv run reachy-ducky-daemon
+```
+
+Expected on stdout: `uvicorn` banner listening on the host/port chosen
+in the wizard (defaults: `127.0.0.1:8765`). If `host` is off-loopback
+and no `auth_token` is set, the daemon logs a loud warning — treat
+that as a bug you need to fix before continuing.
+
+### Health check (open route)
+
+```bash
+curl -s http://127.0.0.1:8765/health | jq
+```
+
+Expected body shape (from `HealthResponse` in
+`protocol/src/reachy_ducky_protocol/messages.py`):
+
+```json
+{
+  "ok": true,
+  "brain": "unbuilt",
+  "memory_ready": true,
+  "projects": ["<your-slug>"]
+}
+```
+
+`brain` is `"unbuilt"` on a fresh boot (lazy build — no
+`ClaudeSDKBrain` has been constructed yet), `"none"` if no primary
+project is configured, or the class name (`"ClaudeSDKBrain"`) once a
+brain has been materialised by a request.
+
+### Protected-route sanity check (only when `REACHY_DUCKY_AUTH_TOKEN` is set)
+
+```bash
+curl -s -X POST http://127.0.0.1:8765/brain/query \
+  -H "Authorization: Bearer $REACHY_DUCKY_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_utterance":"ping"}' | jq
+```
+
+Expected: `200` with `{"text": "...", "specialist_invoked": null}`.
+Omitting the header should return `401 {"detail":"missing bearer
+token"}`.
+
+If no primary project is configured the daemon returns
+`400 {"detail":"no project_slug in request and no primary project
+configured"}`; add `"project_slug":"<slug>"` to the body. An unknown
+slug returns `404 {"detail":"unknown project: <slug>"}`.
+
+## 2. Start the menu-bar app
+
+macOS only. Install the optional extra first:
+
+```bash
+uv sync --all-packages --extra macos
+uv run reachy-ducky-menubar
+```
+
+Verification (reading `menubar/src/reachy_ducky_menubar/main.py` +
+`state_icon.py`):
+
+- Idle glyph: `🦆`.
+- Status item reads `Status: idle`.
+- Click "Mute" — glyph becomes `🦆🔇`, status reads `Status: muted`,
+  menu item shows a check. Click again to unmute.
+- Stop the daemon. Within ~2s the glyph changes to `🦆⚠` and status
+  reads `Status: daemon unreachable` (or `Status: daemon error
+  (<code>)` for a reachable-but-broken daemon). Restart the daemon
+  and the glyph returns to `🦆`.
+
+The menu-bar poller only drives IDLE ↔ MUTED locally; `LISTENING`
+and `THINKING` glyphs exist in `state_icon.py` but nothing pushes
+those states over the wire in Phase A. See "Known gaps".
+
+## 3. Start the Reachy app on the robot
+
+Install the robot-side deps (SSH into the robot):
+
+```bash
+ssh <robot>
+cd reachy-ducky
+uv sync --all-packages --extra robot
+export OPENAI_API_KEY=sk-...
+export DAEMON_URL=http://<mac-host>:8765
+export DAEMON_AUTH_TOKEN=<same as REACHY_DUCKY_AUTH_TOKEN on the Mac>
+```
+
+Start path: the on-robot Pollen dashboard (`http://<robot>:8000`)
+instantiates `ReachyDuckyApp` from `app_class:
+reachy_ducky_app.main.ReachyDuckyApp` declared in
+`app/reachy_mini_app.yaml`. Publishing to HF Space + one-click install
+from the dashboard is the intended flow but is not yet demonstrably
+wired end-to-end; see "Known gaps".
+
+## 4. Interact — intended golden path
+
+The orchestrated turn (from `app/src/reachy_ducky_app/conversation.py`
+`run_one_turn` + `app/src/reachy_ducky_app/embodiment/state_machine.py`):
+
+1. Wake trigger fires.
+2. `sm.transition(LISTENING)` → `play_move("listening")`.
+3. `voice.start_turn()` → `turn.get_user_text()` blocks for a final
+   transcript event from OpenAI Realtime.
+4. `sm.transition(THINKING)` → `play_move("thinking")`.
+5. `daemon.brain_query(text)` → Mac daemon's `/brain/query`.
+6. `sm.transition(LISTENING)` — the robot looks at the user WHILE
+   Ducky speaks (not during thinking).
+7. `turn.speak_text(reply)` → OpenAI Realtime TTS over the same
+   WebSocket.
+8. `sm.transition(IDLE)` → `play_move("neutral")`.
+
+A mute toggle anywhere flips the state machine to `MUTED`, which
+calls `driver.go_to_sleep()` (the visible "off" posture). Exiting
+`MUTED` calls `driver.wake_up()` before the next `play_move`. The
+menu-bar mute is a local UI control; Phase A does NOT propagate
+mute from the menu bar to the robot.
+
+Phase A cannot be driven through wake word today — see "Known
+gaps" §1.
+
+## Known gaps
+
+### 1. Wake detection is a no-op in Phase A
+
+`app/src/reachy_ducky_app/wake.py` ships `MockWakeDetector` as the
+default. `load_default_wake_detector()` returns it, and
+`ReachyDuckyApp._wake_triggered()` returns `False` unconditionally.
+No audio pump is wired.
+
+Consequence: saying "Hey Ducky" into the robot's mic does nothing.
+A turn is only invoked if you subclass `ReachyDuckyApp` and override
+`_wake_triggered` (the test suite does this in
+`app/tests/test_app_main.py::test_run_async_calls_run_one_turn_when_wake_triggers`).
+
+Workarounds for smoke-verifying the daemon + voice path without wake:
+
+- Run `uv run pytest app -q` on the Mac — the unit suite exercises
+  `run_one_turn` end-to-end with `MockVoice` + `MockMotionDriver`
+  + `httpx_mock` against a local `DaemonClient`.
+- From any shell on the Mac, POST to `/brain/query` directly
+  (see §1 "Protected-route sanity check"); that exercises the brain
+  and tool surface without the robot in the loop.
+
+### 2. Menu-bar never shows `LISTENING` / `THINKING`
+
+`state_icon.py` defines `🦆👂` and `🦆💭` but the menu-bar's
+poll loop (`main.py::_poll_loop`) only writes the local IDLE /
+MUTED state. There is no `/state` push from the robot or daemon.
+
+### 3. Reachy dashboard install is unverified
+
+`app/reachy_mini_app.yaml` declares `app_class:
+reachy_ducky_app.main.ReachyDuckyApp` and `app/README.md` has the HF
+Space frontmatter, but we have NOT yet published to HF Spaces and
+one-click-installed on a real robot. The app package exposes no
+`reachy_mini_apps` entry-point in `app/pyproject.toml` either — the
+YAML `app_class` field is the sole registration mechanism. Treat
+step 3 of this procedure as untested until someone walks the publish
+path on hardware.
+
+### 4. Plan-doc draft has drifted
+
+The Phase A plan's §12.1 draft suggested the daemon console script
+`reachy-ducky-daemon` would log `uvicorn listening on
+127.0.0.1:8765`, mentioned a non-existent `reachy-ducky-app`
+command, and hand-wrote a menu-bar mute spec that differs from the
+live glyph set. Follow this procedure (which mirrors the code),
+not the plan's draft. A follow-up issue should update the plan.
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Menu-bar shows `🦆⚠` "daemon unreachable" | Daemon not running, or bound to a different host/port than `http://127.0.0.1:8765` | Start the daemon; or set `_DAEMON_URL_DEFAULT` (currently hardcoded — see menubar/src/reachy_ducky_menubar/main.py). |
+| `curl /brain/query` returns `401 {"detail":"missing bearer token"}` | `REACHY_DUCKY_AUTH_TOKEN` is set on the daemon; your curl didn't send `Authorization: Bearer <token>` | Add the header, or unset the env var and restart the daemon. |
+| `curl /brain/query` returns `401 {"detail":"invalid bearer token"}` | Token mismatch between daemon and caller | Re-source `~/.reachy-ducky/.env` in both shells. |
+| `curl /brain/query` returns `400 {"detail":"no project_slug in request and no primary project configured"}` | Wizard was not run, or no `primary = true` project in `config.toml` | Re-run `uv run reachy-ducky init`, or edit `~/.reachy-ducky/config.toml`. |
+| `curl /brain/query` returns `404 {"detail":"unknown project: <slug>"}` | Slug in request body doesn't appear in the loaded project list | Check `/health`'s `projects` field; fix the slug or add the project. |
+| Daemon logs `ClaudeSDKError: not authenticated` (or similar) on first query | `claude login` never run on the Mac | Run `claude login`; re-run the query. |
+| Daemon brain errors mentioning `github-mcp-server` | Node.js missing, or `GITHUB_PERSONAL_ACCESS_TOKEN` unset for a project with `github_repo` | `brew install node@20`; export the PAT; restart the daemon. |
+| `uv run reachy-ducky-menubar` crashes with `ImportError: reachy-ducky-menubar is macOS-only` | Running on Linux | Menubar is macOS-only by design; there's nothing to run on Linux. |
+| `uv run reachy-ducky-menubar` crashes with `ModuleNotFoundError: rumps` | `macos` extra not installed | `uv sync --all-packages --extra macos`. |
+| `OpenAIRealtimeVoice` raises `ValueError: OPENAI_API_KEY not set` on the robot | Env var missing in the robot-side process | Export `OPENAI_API_KEY` before starting the app. |
+| Realtime session opens but hangs up immediately after user speech | Schema drift between the `openai` SDK version and `voice/openai_realtime.py`'s assumed event names | Confirm `openai==1.109.x`; see module docstring for the verified event shape. |

--- a/docs/testing/2026-04-21-phase-a-e2e-procedure.md
+++ b/docs/testing/2026-04-21-phase-a-e2e-procedure.md
@@ -215,8 +215,12 @@ Workarounds for smoke-verifying the daemon + voice path without wake:
 poll loop (`main.py::_poll_loop`) only writes the local IDLE /
 MUTED state. There is no `/state` push from the robot or daemon.
 
-- TODO (follow-up issue): Menu-bar `DAEMON_URL` should become
-  env-overridable; currently hardcoded.
+- TODO (follow-up issue): Menu-bar daemon URL should become
+  env-overridable; currently hardcoded as `_DAEMON_URL_DEFAULT`
+  at `menubar/src/reachy_ducky_menubar/main.py:24`. Note this is
+  distinct from the Reachy-side `DAEMON_URL` env var (`daemon_client.py`)
+  which the robot process does read — same conceptual value, two
+  different wiring stories.
 
 ### 3. Reachy dashboard install is unverified
 
@@ -242,7 +246,7 @@ not the plan's draft. A follow-up issue should update the plan.
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Menu-bar shows `🦆⚠` "daemon unreachable" | Daemon not running, or bound to a different host/port than `http://127.0.0.1:8765` | Start the daemon; or edit `menubar/src/reachy_ducky_menubar/main.py:24` — `DAEMON_URL` is not yet env-overridable in Phase A. |
+| Menu-bar shows `🦆⚠` "daemon unreachable" | Daemon not running, or bound to a different host/port than `http://127.0.0.1:8765` | Start the daemon; or edit `_DAEMON_URL_DEFAULT` in `menubar/src/reachy_ducky_menubar/main.py:24` — the menu-bar URL is not yet env-overridable in Phase A. |
 | `curl /brain/query` returns `401 {"detail":"missing bearer token"}` | `REACHY_DUCKY_AUTH_TOKEN` is set on the daemon; your curl didn't send `Authorization: Bearer <token>` | Add the header, or unset the env var and restart the daemon. |
 | `curl /brain/query` returns `401 {"detail":"invalid bearer token"}` | Token mismatch between daemon and caller | Re-source `~/.reachy-ducky/.env` in both shells. |
 | `curl /brain/query` returns `400 {"detail":"no project_slug in request and no primary project configured"}` | Wizard was not run, or no `primary = true` project in `config.toml` | Re-run `uv run reachy-ducky init`, or edit `~/.reachy-ducky/config.toml`. |

--- a/docs/testing/2026-04-21-phase-a-e2e-procedure.md
+++ b/docs/testing/2026-04-21-phase-a-e2e-procedure.md
@@ -193,7 +193,6 @@ gaps" §1.
 `app/src/reachy_ducky_app/wake.py` ships `MockWakeDetector` as the
 default. `load_default_wake_detector()` returns it, and
 `ReachyDuckyApp._wake_triggered()` returns `False` unconditionally.
-No audio pump is wired.
 
 Consequence: saying "Hey Ducky" into the robot's mic does nothing.
 A turn is only invoked if you subclass `ReachyDuckyApp` and override
@@ -208,6 +207,20 @@ Workarounds for smoke-verifying the daemon + voice path without wake:
 - From any shell on the Mac, POST to `/brain/query` directly
   (see §1 "Protected-route sanity check"); that exercises the brain
   and tool surface without the robot in the loop.
+
+### 1b. Default audio I/O is silent mocks
+
+The voice layer is now structurally wired end-to-end — mic frames flow
+into `input_audio_buffer.append`, transcription events drive
+`get_user_text`, and `response.audio.delta` events are piped to
+`SpeakerSink.play()`. But `load_default_mic_source()` /
+`load_default_speaker_sink()` return `MockMicSource()` /
+`MockSpeakerSink()` today (silent mic, dropping speaker).
+
+Consequence: even once wake fires, the robot has no real mic input and
+no audible replies until `ReachyMicSource` / `ReachySpeakerSink` land
+(tracked as follow-up). Unit tests drive the full event flow with
+`MockMicSource(frames=[...])` + `MockSpeakerSink()` captures.
 
 ### 2. Menu-bar never shows `LISTENING` / `THINKING`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,16 @@ markers = [
 # that ship no stubs. Prefer real typing when available.
 #   rumps: macOS-only menu-bar lib, no stubs / py.typed. Used only from
 #          menubar.main via a lazy import behind `sys.platform == "darwin"`.
+#   mediapipe: face-detection backend used by app.embodiment.gaze; the
+#          upstream wheel ships no stubs / py.typed marker. The heavy
+#          import is deferred into gaze_loop (hardware-tier only), but
+#          mypy still needs this entry to resolve the module reference.
 [[tool.mypy.overrides]]
 module = "rumps"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "mediapipe"
 ignore_missing_imports = true
 
 # Pyright config lives in ./pyrightconfig.json (takes precedence over


### PR DESCRIPTION
## Summary

Reachy-side of Phase A — the app package, lifecycle docs, and networking guide. 18 commits, 27 files, ~2301 LOC. Every commit passed per-task spec + code-quality review; final cross-task sweep review surfaced two real resource-lifecycle bugs (I1, I2) that are also fixed here.

**M8 — Voice layer** (4 commits): `VoiceInterface` ABC + `MockVoice`, `OpenAIRealtimeVoice` (Realtime API), `WakeDetector` ABC + `MockWakeDetector`, `MuteGate`.

**M9 — Embodiment** (2): `MotionDriver` ABC + `ReachyMotionDriver`, `EmbodimentStateMachine` (IDLE / LISTENING / THINKING / MUTED transitions), face-tracking gaze helper.

**M10 — App orchestration** (2): async `DaemonClient` + `run_one_turn` single-turn conversation orchestrator.

**M11 — Entry point** (2): `ReachyDuckyApp` class + `main()`, HF Space metadata.

**M12 — E2E smoke doc** (3): `docs/testing/2026-04-21-phase-a-e2e-procedure.md` — full procedure with known gaps called out honestly.

**M13 — README** (3): Run, Development, Networking & auth (Tailscale-primary + bearer-token fallback).

**Resource-lifecycle fixes from sweep review** (2):
- **I1** — `VoiceInterface.start_turn()` is now an async context manager; Realtime websocket closes cleanly at turn end (was leaking per turn).
- **I2** — `DaemonClient` pools one `httpx.AsyncClient` across calls with `aclose()`; `ReachyDuckyApp._run_async` closes it in try/finally on shutdown (was N handshakes for N turns).

## Test plan

- [x] `uv run pytest -q` — 473 passed, 3 skipped (up from 464 pre-fix; +9 new tests for I1/I2 lifecycle)
- [x] `uv run mypy --strict daemon/src app/src menubar/src protocol/src` — clean (38 files)
- [x] `uv run mypy --strict daemon/tests protocol/tests menubar/tests app/tests` — clean (tests held to the same bar)
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean
- [x] `uv run bandit -ll -r daemon/src app/src menubar/src protocol/src` — clean
- [x] Lefthook pre-commit + pre-push hooks green on every commit
- [ ] Full E2E smoke procedure (`docs/testing/2026-04-21-phase-a-e2e-procedure.md`) run against real Reachy Mini hardware — **deferred until Known gaps §1 (wake word) + §3 (HF Space publish) close**

## Known gaps (tracked as follow-up issues)

Documented in `docs/testing/2026-04-21-phase-a-e2e-procedure.md` and the root README:

- Wake-word detection is a `MockWakeDetector` stub in Phase A; saying "Hey Ducky" does nothing today. A real detector is Phase B work.
- HF Space publish + on-robot install path is unverified; the YAML + README frontmatter are in place but nobody has walked the publish flow on hardware.
- Menu-bar mute is local UI only — does not propagate to the robot. When the audio pump lands, it should bind `MuteGate.set_muted(True)` at the same seam that fires `EmbodimentStateMachine.transition(MUTED)`.
- Menu-bar `_DAEMON_URL_DEFAULT` is hardcoded; not yet env-overridable.
- Cross-subpackage integration test (app ↔ daemon contract) doesn't exist; daemon schema drift won't be caught by CI until someone runs the E2E procedure by hand.

## Follow-ups from sweep review (to be opened as issues)

- **I3** — Repo-root `tests/` for cross-subpackage contract tests
- **I4** — Wake loop busy-spins at ~20Hz; should become `asyncio.Event` wait when real wake lands
- **I5** — HF Space metadata in two files (`reachy_mini_app.yaml` + README frontmatter); drift risk
- **I6** — `ReachyMotionDriver` SDK method names silenced with 6 `# type: ignore`; needs hardware-tier test
- **I7** — `_wake_triggered` deletes its `wake` param; wire or remove
- **M1** — `BrainRequest.include_tools` is wire-present but unused on both ends
- **M2** — No project-slug selector in the on-robot app
- **M3** — Mute coordination: bind `MuteGate.set_muted` to state-machine MUTED
- **M4** — `pyright` / `mypy` divergence on openai SDK private imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)