### PR TITLE
Enable Dependabot for uv + github-actions (#11)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot: auto-PRs for outdated dependencies.
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # Python deps across the uv workspace (root + daemon/app/menubar/protocol).
+  # Dependabot's `uv` ecosystem reads pyproject.toml + uv.lock.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions workflow deps (actions/checkout, astral-sh/setup-uv, etc.).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

One-file infra change: adds `.github/dependabot.yml`.

- **Python (`uv` ecosystem)**: weekly scans across the workspace root, reading `pyproject.toml` + `uv.lock`. Minor/patch updates grouped into one PR; major updates get individual PRs. Limit 10 open.
- **GitHub Actions**: weekly pin bumps, grouped. Limit 5 open.

Closes #11. Unblocks auto-PRs for the [11 vulnerabilities GitHub flagged](https://github.com/Obsidian-Owl/reachy-ducky/security/dependabot) against `main`.

Milestone: [v0.1.0 cleanup](https://github.com/Obsidian-Owl/reachy-ducky/milestone/1).

## Test plan

- [x] YAML valid (verified by GitHub's Dependabot config parser on push; errors surface as a notification on the repo)
- [ ] Dependabot runs within 24h and files its first batch of PRs
- [ ] Vulnerability count on the default-branch security panel decreases as those PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)