### PR TITLE
Add PR + issue templates (#12)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Keep it short — one problem per issue.
+  - type: textarea
+    id: what
+    attributes:
+      label: What went wrong
+      description: A few sentences describing the actual behaviour.
+      placeholder: |
+        e.g. "daemon crashes on `/brain/query` when the project slug
+        contains a hyphen"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: How do I trigger it? Minimal repro preferred.
+      placeholder: |
+        1. `uv run reachy-ducky-daemon`
+        2. `curl -X POST /brain/query -d '{"project_slug":"my-repo",...}'`
+        3. Daemon logs: ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      placeholder: e.g. "200 OK with a BrainResponse"
+    validations:
+      required: false
+  - type: input
+    id: component
+    attributes:
+      label: Which component?
+      description: daemon / app / menubar / protocol / CI / other
+      placeholder: daemon
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, relevant package versions. `uv --version` and `python --version` are good starters.
+      placeholder: |
+        - macOS 15.1, Python 3.12.9
+        - `uv` 0.5.30
+        - reachy-mini 1.6.4 (if relevant)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Allow blank issues — templates are a nudge, not a wall. For quick
+# tracking notes or drive-by thoughts, a blank issue is often right.
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose an enhancement or new capability
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, check the milestones page — the work may already be
+        scoped. https://github.com/Obsidian-Owl/reachy-ducky/milestones
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you solving?
+      description: Describe the user-facing need, not the implementation. "Why" before "what".
+      placeholder: |
+        e.g. "When I have multiple repos open in different worktrees,
+        Ducky can't tell which one I'm asking about, so it pulls context
+        from the wrong project."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution
+      description: One or two paragraphs on the approach you have in mind. Pseudocode / config / protocol sketches welcome.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other ways did you consider? Why did you pick the one above?
+    validations:
+      required: false
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risks / trade-offs
+      description: Anything this would break, slow down, or make harder? Security / privacy implications?
+    validations:
+      required: false
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Suggested milestone
+      options:
+        - Backlog (unsized)
+        - v0.1.0 cleanup
+        - v0.1.0 release plumbing
+        - v0.1.0 hardware bring-up
+        - Post-v0.1.0 / Phase B
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Thanks for contributing to Reachy Ducky. This template is a hint, not a wall — feel free to delete sections that don't apply to your PR.
+-->
+
+## Summary
+
+<!-- What does this PR do? One to three bullets. If it closes an issue, write "Closes #N". -->
+
+## Why now
+
+<!-- Optional: the motivating context. Why is this worth merging at this moment vs. deferring? Especially useful for non-obvious trade-offs. -->
+
+## Test plan
+
+- [ ] `uv run pytest -q` — unit tier green
+- [ ] `uv run mypy --strict daemon/src app/src menubar/src protocol/src` — type clean
+- [ ] `uv run ruff check .` + `uv run ruff format --check .` — lint/format clean
+- [ ] Lefthook `pre-commit` + `pre-push` hooks pass locally
+- [ ] (If touching the daemon) bandit clean
+- [ ] (If touching Reachy app code) hardware / sim smoke where applicable
+
+## Known gaps or follow-ups
+
+<!-- Anything deliberately deferred? Cross-link follow-up issues. If nothing, delete this section. -->
+
+## Notes for reviewers
+
+<!-- Heads up on anything non-obvious: architectural trade-offs, trickier bits of the diff, hardware/API gotchas. If nothing, delete. -->


### PR DESCRIPTION
## Summary

Four small `.github/` config files: PR template + bug/feature issue forms + config (blank issues allowed).

Closes #12.

## Why now

Bot-feedback loops (Codex, Augment, Claude-review) read the PR body and produce better suggestions when the shape is predictable. Converged on a house style across PRs #13/#32/#39; codifying it as a template means every future PR starts from the same skeleton and doesn't reinvent the checklist.

The issue forms are a nudge — `blank_issues_enabled: true` leaves the quick-tracking-note path open (we file a lot of those).

## Test plan

- [x] YAML valid for all three `ISSUE_TEMPLATE/*.yml` files
- [x] Lefthook pre-commit hooks pass (just gitleaks scans these .md/.yml files)
- [ ] GitHub renders the PR template (this PR is its own smoke test — you're reading it)
- [ ] Bug / feature forms appear under "New issue" after merge

## Related

Milestone: [v0.1.0 cleanup](https://github.com/Obsidian-Owl/reachy-ducky/milestone/1). Third of five; remaining are #21 (pyright/mypy divergence) + #10 (coverage threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)