### PR TITLE
Make pyright CLI clean across workspace (#21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ uv run pytest -q                     # unit tests (default tier)
 uv run ruff check --fix .            # lint + autofix
 uv run ruff format .                 # format
 uv run mypy --strict daemon/src app/src menubar/src protocol/src
+uv run pyright                       # second opinion on types; use CLI, not IDE diagnostics
 uv run bandit -r daemon/src app/src menubar/src protocol/src -ll
 lefthook run pre-commit --all-files
 npx gitnexus analyze --skip-agents-md   # refresh code index (incremental by default)

--- a/app/src/reachy_ducky_app/embodiment/gaze.py
+++ b/app/src/reachy_ducky_app/embodiment/gaze.py
@@ -62,7 +62,12 @@ async def gaze_loop(mini: object, driver: MotionDriver, *, fps: float = 5.0) -> 
 
     import mediapipe as mp
 
-    detector = mp.solutions.face_detection.FaceDetection(min_detection_confidence=0.5)
+    # mediapipe ships no py.typed marker; `mp.solutions` is a runtime-only
+    # attribute that pyright can't verify. Matches the mypy override for
+    # `mediapipe` in the root pyproject.toml.
+    detector = mp.solutions.face_detection.FaceDetection(  # pyright: ignore[reportAttributeAccessIssue]
+        min_detection_confidence=0.5
+    )
     period = 1.0 / fps
     try:
         while True:

--- a/app/tests/test_reachy_sdk_contract.py
+++ b/app/tests/test_reachy_sdk_contract.py
@@ -66,7 +66,9 @@ def test_reachy_mini_class_exposes_required_method(method_name: str) -> None:
     Side-effect proof: the ``hasattr`` consults the class's attribute
     table, which reflects the actual installed SDK version's surface.
     """
-    from reachy_mini import ReachyMini
+    # reachy-mini is installed only with `--extra robot` (robot + CI).
+    # Default dev venvs don't have it; pyright flags the missing import.
+    from reachy_mini import ReachyMini  # pyright: ignore[reportMissingImports]
 
     assert hasattr(ReachyMini, method_name), (
         f"reachy-mini SDK missing `{method_name}`. "

--- a/daemon/tests/test_brain_plans_mcp.py
+++ b/daemon/tests/test_brain_plans_mcp.py
@@ -507,14 +507,20 @@ async def test_read_plan_handler_returns_error_on_null_byte_in_path(
 def test_find_plans_tool_signature_has_no_project_root(tmp_path: Path) -> None:
     """find_plans tool input schema exposes no project_root — LLM cannot forge scope."""
     find_plans, _read_plan_tool = _make_plans_tools(tmp_path)
-    assert "project_root" not in find_plans.input_schema
+    # input_schema is typed `type | dict[str, Any]` by the SDK; `in` only
+    # works on the dict case, so narrow before testing membership.
+    schema = find_plans.input_schema
+    assert isinstance(schema, dict)
+    assert "project_root" not in schema
 
 
 def test_read_plan_tool_signature_has_no_project_root(tmp_path: Path) -> None:
     """read_plan exposes only rel_path — LLM cannot forge scope."""
     _find_plans, read_plan_tool = _make_plans_tools(tmp_path)
-    assert "project_root" not in read_plan_tool.input_schema
-    assert "rel_path" in read_plan_tool.input_schema
+    schema = read_plan_tool.input_schema
+    assert isinstance(schema, dict)
+    assert "project_root" not in schema
+    assert "rel_path" in schema
 
 
 async def test_find_plans_tool_scoped_to_root(tmp_path: Path) -> None:

--- a/menubar/src/reachy_ducky_menubar/main.py
+++ b/menubar/src/reachy_ducky_menubar/main.py
@@ -38,8 +38,9 @@ def main() -> None:
     # marker. Mypy silencing lives in the root pyproject.toml's
     # [[tool.mypy.overrides]] section (module = "rumps") so the behaviour is
     # consistent whether rumps is installed (macOS CI) or not (Linux CI,
-    # default dev venv).
-    import rumps
+    # default dev venv). Pyright doesn't support per-module ignore config,
+    # so silence inline for the CLI too.
+    import rumps  # pyright: ignore[reportMissingImports]
 
     app = _build_app(rumps)
     app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,17 @@ markers = [
 ]
 
 # Mypy per-module overrides. Keep this list short — one-liners for deps
-# that ship no stubs. Prefer real typing when available.
+# that ship no stubs OR that only install with an optional extra.
 #   rumps: macOS-only menu-bar lib, no stubs / py.typed. Used only from
 #          menubar.main via a lazy import behind `sys.platform == "darwin"`.
 #   mediapipe: face-detection backend used by app.embodiment.gaze; the
 #          upstream wheel ships no stubs / py.typed marker. The heavy
 #          import is deferred into gaze_loop (hardware-tier only), but
 #          mypy still needs this entry to resolve the module reference.
+#   reachy_mini: robot SDK, only installed under `--extra robot`. Present
+#          in CI for the sdk-contract job (app/tests/test_reachy_sdk_contract.py);
+#          absent in a default dev venv. Matches the inline pyright
+#          ignore on the same import.
 [[tool.mypy.overrides]]
 module = "rumps"
 ignore_missing_imports = true
@@ -51,6 +55,13 @@ ignore_missing_imports = true
 module = "mediapipe"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "reachy_mini"
+ignore_missing_imports = true
+
 # Pyright config lives in ./pyrightconfig.json (takes precedence over
 # [tool.pyright] here; pyrightconfig.json is more reliably live-reloaded
-# by IDE language servers).
+# by IDE language servers). Pyright doesn't support per-module
+# ignore_missing_imports like mypy; the inline `# pyright: ignore[...]`
+# comments at each optional-dep import site serve the same purpose —
+# grep for `reportMissingImports` to find them.


### PR DESCRIPTION
## Summary

Reframing #21: the stated "openai SDK private submodule imports" divergence isn't a real project issue — `uv run pyright` already resolves them cleanly. The IDE diagnostics we'd been seeing were from a language-server instance running without our pyrightconfig. This PR fixes the **actual** pyright-only findings (that mypy missed) instead.

Four narrow fixes:

1. **`daemon/tests/test_brain_plans_mcp.py:510,516-517`** — `"x" in tool.input_schema` operator error. `input_schema` is typed `type | dict[str, Any]`; `in` only works on the dict case. Narrowed via `isinstance(schema, dict)` before membership checks.

2. **`menubar/src/reachy_ducky_menubar/main.py:42`** — `import rumps` needs `# pyright: ignore[reportMissingImports]` (Pyright has no per-module ignore config like mypy's `[[tool.mypy.overrides]]`).

3. **`app/src/reachy_ducky_app/embodiment/gaze.py:65`** — `mp.solutions.face_detection` attribute access silenced with `# pyright: ignore[reportAttributeAccessIssue]`.

4. **`app/tests/test_reachy_sdk_contract.py:71`** — `from reachy_mini import ReachyMini` silenced with `# pyright: ignore` + matching `[[tool.mypy.overrides]]` entry added to pyproject.toml so it's clean locally (without `--extra robot`).

CLAUDE.md's quick-start now includes `uv run pyright` as a second opinion on types, with a note that the CLI is authoritative — IDE noise ≠ real findings.

Closes #21. Milestone: [v0.1.0 cleanup](https://github.com/Obsidian-Owl/reachy-ducky/milestone/1) — fourth of five.

## Test plan

- [x] `uv run pytest -q` — 499 passed, 3 skipped, 4 deselected (unit tier unchanged)
- [x] `uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests app/tests` — 68 files, no issues
- [x] `uv run pyright` — **0 errors, 0 warnings** (full workspace)
- [x] Lefthook pre-commit: gitleaks + ruff + bandit + mypy all green

## Notes for reviewers

Each `# pyright: ignore[...]` comment has a brief inline rationale. Grep `reportMissingImports|reportAttributeAccessIssue` to find them all — small surface, easy to audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)