### PR TITLE
Coverage threshold + CI drift fix + Augment #42 follow-up (#10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
         run: uv run mypy --strict daemon/src app/src menubar/src protocol/src
 
       - name: Mypy (strict) — tests
-        # Match the local lefthook behaviour so a test that fails locally
-        # can never slip through CI. Tests are production-grade per
-        # .claude/rules/testing-standards.md.
-        run: uv run mypy --strict daemon/tests protocol/tests menubar/tests
+        # Tests are production-grade per .claude/rules/testing-standards.md.
+        # Keep in lockstep with the lefthook pre-push ``mypy-full`` target so
+        # a test that fails locally can never slip through CI.
+        run: uv run mypy --strict daemon/tests protocol/tests menubar/tests app/tests
 
       - name: Bandit (security)
         run: uv run bandit -ll -r daemon/src app/src menubar/src protocol/src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,11 @@ jobs:
       - name: Bandit (security)
         run: uv run bandit -ll -r daemon/src app/src menubar/src protocol/src
 
-      - name: Pytest (unit tier)
-        run: uv run pytest -q
+      - name: Pytest (unit tier) with coverage
+        # Coverage floor + report formats: `term-missing` for the job log;
+        # `xml` for future upload to Codecov / artifact inspection. The
+        # `fail_under` threshold lives in pyproject.toml's
+        # [tool.coverage.report] so the same floor applies locally.
+        run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml
         env:
           PYTHONDONTWRITEBYTECODE: "1"

--- a/daemon/tests/test_brain_plans_mcp.py
+++ b/daemon/tests/test_brain_plans_mcp.py
@@ -9,6 +9,7 @@ through ``create_sdk_mcp_server`` with the right names/descriptions.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 from reachy_ducky_daemon.brain.plans_mcp import (
@@ -18,6 +19,22 @@ from reachy_ducky_daemon.brain.plans_mcp import (
     _read_plan,
     plans_mcp_server,
 )
+
+
+def _require_dict_schema(schema: Any, *, tool_name: str) -> dict[str, Any]:
+    """Narrow a tool's ``input_schema`` to the dict case or fail fast.
+
+    The SDK types ``input_schema`` as ``type | dict[str, Any]``. Our plans
+    tools construct with dicts, but relying on ``assert isinstance`` to
+    narrow is brittle under ``python -O`` and leaks a confusing ``TypeError``
+    on ``"x" in schema`` if the SDK ever returns the class variant. Use
+    ``pytest.fail`` so the failure mode is a clear, optimization-independent
+    test failure.
+    """
+    if not isinstance(schema, dict):
+        pytest.fail(f"{tool_name} input_schema is {type(schema).__name__}, expected dict")
+    return schema
+
 
 # ---------------------------------------------------------------------------
 # _list_plans
@@ -507,18 +524,18 @@ async def test_read_plan_handler_returns_error_on_null_byte_in_path(
 def test_find_plans_tool_signature_has_no_project_root(tmp_path: Path) -> None:
     """find_plans tool input schema exposes no project_root — LLM cannot forge scope."""
     find_plans, _read_plan_tool = _make_plans_tools(tmp_path)
-    # input_schema is typed `type | dict[str, Any]` by the SDK; `in` only
-    # works on the dict case, so narrow before testing membership.
-    schema = find_plans.input_schema
-    assert isinstance(schema, dict)
+    # ``input_schema`` is typed ``type | dict[str, Any]`` by the SDK; ``in``
+    # only works on the dict case. Explicit fail (not ``assert isinstance``)
+    # so this works under ``python -O`` and gives a clear message if the SDK
+    # ever returns a Pydantic class instead of a dict.
+    schema = _require_dict_schema(find_plans.input_schema, tool_name="find_plans")
     assert "project_root" not in schema
 
 
 def test_read_plan_tool_signature_has_no_project_root(tmp_path: Path) -> None:
     """read_plan exposes only rel_path — LLM cannot forge scope."""
     _find_plans, read_plan_tool = _make_plans_tools(tmp_path)
-    schema = read_plan_tool.input_schema
-    assert isinstance(schema, dict)
+    schema = _require_dict_schema(read_plan_tool.input_schema, tool_name="read_plan")
     assert "project_root" not in schema
     assert "rel_path" in schema
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,8 +32,10 @@ pre-push:
 
     mypy-full:
       # Whole-project strict pass; cheap for a small repo, catches cross-file
-      # errors that per-file staged runs miss.
-      run: uv run mypy --strict daemon/src app/src menubar/src protocol/src
+      # errors that per-file staged runs miss. Includes tests so local
+      # pre-push parity matches ``ci.yml``'s two mypy steps (src + tests) —
+      # prevents "local passes, CI fails" surprise on test-only changes.
+      run: uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests
 
     gitleaks-history:
       # Scans history on push to catch anything that slipped past pre-commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,11 @@ branch = true
 relative_files = true
 
 [tool.coverage.report]
-# Threshold locks the current baseline (91% at the time this landed)
-# with a small buffer for measurement variance and import-time
-# branching we can't stably exercise. Bump when we're consistently
-# >93% so regressions are caught before they widen.
+# Threshold locks the current baseline (90.61% combined statements +
+# branches at the time this landed; the table's rounded per-row 91%
+# is a different aggregate). 0.61pp buffer absorbs measurement
+# variance from new tests and import-time branching we can't stably
+# exercise. Bump when we're consistently >93%.
 fail_under = 90
 show_missing = true
 skip_covered = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,31 @@ ignore_missing_imports = true
 # ignore_missing_imports like mypy; the inline `# pyright: ignore[...]`
 # comments at each optional-dep import site serve the same purpose —
 # grep for `reportMissingImports` to find them.
+
+[tool.coverage.run]
+# Coverage tracks only the shipped source trees — tests themselves
+# execute to completion by definition and inflate the numerator. The
+# four subpackages' src/ dirs are the units we actually ship.
+source = ["daemon/src", "app/src", "menubar/src", "protocol/src"]
+branch = true
+relative_files = true
+
+[tool.coverage.report]
+# Threshold locks the current baseline (91% at the time this landed)
+# with a small buffer for measurement variance and import-time
+# branching we can't stably exercise. Bump when we're consistently
+# >93% so regressions are caught before they widen.
+fail_under = 90
+show_missing = true
+skip_covered = false
+exclude_also = [
+    # Pure typing imports never run.
+    "if TYPE_CHECKING:",
+    # ABCs by contract.
+    "raise NotImplementedError",
+    # Programmatic opt-outs for genuinely unreachable or
+    # platform-specific branches — grep these to audit.
+    "pragma: no cover",
+    # CLI entry points covered by integration/hardware tiers, not unit.
+    "if __name__ == .__main__.:",
+]


### PR DESCRIPTION
## Summary

Last `v0.1.0 cleanup` milestone item, bundled with drift fixes from a local/remote audit and the unmerged Augment finding on #42.

- **80e1704** `chore(ci): include app/tests in mypy strict` — drift fix: CI's `Mypy (strict) — tests` step skipped `app/tests` (only `daemon/tests protocol/tests menubar/tests`), and lefthook's pre-push `mypy-full` skipped tests entirely. Both now cover the full 8-path set (4 src + 4 tests) so local ≡ CI.
- **f65cd21** `test(daemon): raise on non-dict tool schema via pytest.fail helper` — Augment's low-severity finding from PR #42. `assert isinstance(schema, dict)` for narrowing is brittle under `python -O`; replaced with `_require_dict_schema` helper that uses `pytest.fail` for optimization-independent behaviour.
- **3f1c3f6** `test(ci): enforce 90% coverage floor in pytest CI step` — **closes #10**. Measured baseline 90.61% (statements + branches across 4 src trees), locked floor at 90% with a 0.61pp buffer. Config in `pyproject.toml`, applied via `--cov` in CI.

## Why now

- Drift fix came out of a post-#42 "is local/remote in sync" audit ([triggered by your feedback](https://github.com/Obsidian-Owl/reachy-ducky/pull/42) that I merged without reviewing bot comments). Found two mypy-path gaps + confirmed no branch drift — the 3 stale local branches were pruned separately.
- Augment's finding was real low severity; folding it here instead of a one-line standalone PR.
- Coverage floor caps the `v0.1.0 cleanup` milestone. Next up: triage the 6 Dependabot PRs on main.

## Test plan

- [x] `uv run pytest -q --cov` — 499 passed, 3 skipped, **90.61% coverage** (above 90% floor)
- [x] `uv run mypy --strict` on the full 8-path set (4 src + 4 tests) — 71 files, 0 issues
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] Lefthook pre-commit + pre-push hooks run on each commit (gitleaks + ruff + bandit + mypy)

## Notes for reviewers

**Coverage threshold rationale:** 90% is the current floor, not an aspiration. When total is consistently >93%, bump the threshold in a follow-up. Grep `pragma: no cover` to audit opt-outs (currently zero in-repo).

**CI drift finding:** the `app/tests` gap meant CI had been green while locally I'd been running the full suite manually. Next time I should run `uv run mypy --strict daemon/tests protocol/tests menubar/tests app/tests` explicitly to match CI's scope OR use lefthook's pre-push hook (now updated to do exactly that).

## Milestone

[v0.1.0 cleanup](https://github.com/Obsidian-Owl/reachy-ducky/milestone/1) — **fifth and final** item. After this merges, cleanup milestone is done and the 6 Dependabot PRs on deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)