### PR TITLE
deps: pytest-asyncio 0.25.3 → 1.3.0 (supersedes #38)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ members = ["daemon", "app", "menubar", "protocol"]
 [dependency-groups]
 dev = [
     "pytest>=8,<9",
-    "pytest-asyncio>=0.23,<0.26",
+    "pytest-asyncio>=1.3.0,<2",
     "pytest-httpx>=0.30,<0.35",
     "pytest-cov>=7.1.0,<8",
     "ruff>=0.15.11,<0.16",

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ dev = [
     { name = "bandit", specifier = ">=1.9.4,<1.10" },
     { name = "mypy", specifier = ">=1.20.2,<1.21" },
     { name = "pytest", specifier = ">=8,<9" },
-    { name = "pytest-asyncio", specifier = ">=0.23,<0.26" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8" },
     { name = "pytest-httpx", specifier = ">=0.30,<0.35" },
     { name = "ruff", specifier = ">=0.15.11,<0.16" },
@@ -2863,14 +2863,15 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.25.3"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Final Dependabot triage PR. Lands the pytest-asyncio 0.25.3 → 1.3.0 bump (#38). Dependabot's branch conflicted on `pyproject.toml` + `uv.lock` against post-#44/#45 main, so cherry-picked the intent onto a fresh branch.

Closes #38.

## Why now

Last of the six Dependabot PRs from the initial wave. pytest-asyncio's 0.x → 1.x transition is an API-stabilization release — primarily deprecation cleanup, not breaking-behavior change for users on the `asyncio_mode = "auto"` config we've had since Phase A.

## Test plan

Full quality-first sweep, with specific attention to the asyncio-mode migration risk:

- [x] `uv sync` — pytest-asyncio 0.25.3 → 1.3.0 cleanly
- [x] `uv run pytest -q` — **499 passed, 3 skipped, no deprecation warnings**
- [x] `asyncio_mode = "auto"` config still valid (auto-mode has been the default since 0.21; preserved in 1.x)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 71 files already formatted
- [x] `uv run mypy --strict` on 8 paths — 71 files, 0 issues
- [x] `uv run pyright` — 0 errors, 0 warnings, 0 informations
- [x] `uv run bandit -ll -r daemon/src app/src menubar/src protocol/src` — 0 findings
- [x] `uv run pytest -q --cov` — 90.61% coverage (above 90 floor)

## Notes for reviewers

No code changes. `[tool.pytest.ini_options]` already has `asyncio_mode = "auto"` and `addopts = "-m 'not sim and not sdk'"`; both are 1.x-compatible. Our async fixtures use standard `@pytest_asyncio.fixture` / `async def test_*` patterns that haven't changed across the 0→1 boundary.

## Related

Last of six Dependabot triage PRs. After merge:
- Dependabot PRs remaining: **0**
- v0.1.0 cleanup milestone closed ✓
- Next session will start `pr-reviewer` specialist (Phase B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)