### PR TITLE
feat(specialists): pr-reviewer — Phase B synthesis specialist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ On the robot only: `uv sync --all-packages --extra robot` additionally installs 
 The thinking brain spawns external MCP servers:
 
 - **Node.js 20+** — required for `npx -y github-mcp-server` (declared in `.mcp.json`).
-- **`GITHUB_PERSONAL_ACCESS_TOKEN`** env var — `repo:read` + `pull_requests:read` + `issues:read` scopes are sufficient for read-only operation.
+- **`gh` CLI (2.x)** — required by the `pr-reviewer` specialist for deterministic pre-fetch (`gh pr view`, `gh pr diff`, `gh api`). Authenticates via `GH_TOKEN` (reuse `GITHUB_PERSONAL_ACCESS_TOKEN`) or an interactive `gh auth login`.
+- **`GITHUB_PERSONAL_ACCESS_TOKEN`** env var — `repo:read` + `pull_requests:read` + `issues:read` scopes are sufficient for read-only operation. Shared by `github-mcp-server` (brain tool surface) and `gh` (pr-reviewer pre-fetch).
 - **`REACHY_DUCKY_AUTH_TOKEN`** — bearer token if exposing the daemon over LAN; see `.claude/rules/` and the design doc §5.
 
 Live-Claude integration tests run via `.github/workflows/integration.yml` (PR-with-`integration`-label or weekly cron) using the `CLAUDE_CODE_OAUTH_TOKEN` org secret.

--- a/app/src/reachy_ducky_app/daemon_client.py
+++ b/app/src/reachy_ducky_app/daemon_client.py
@@ -123,3 +123,32 @@ class DaemonClient:
         )
         r.raise_for_status()
         return SpecialistResponse.model_validate(r.json())
+
+    async def pr_reviewer(
+        self,
+        *,
+        project_slug: str,
+        pr_number: int | None = None,
+    ) -> SpecialistResponse:
+        """POST ``/specialists/pr-reviewer`` and get a PR-digest envelope.
+
+        ``pr_number=None`` opts into the daemon's auto-detect path
+        (``git rev-parse`` + ``gh pr list --head`` on the project's
+        checkout). Supply an explicit number to target a specific PR.
+        120s timeout mirrors plan-reviewer: the brain runs one query
+        but the pre-fetch graph (metadata + diff + comments + CI) can
+        add real latency on a chatty PR.
+        """
+        req = SpecialistRequest(
+            name="pr-reviewer",
+            project_slug=project_slug,
+            pr_number=pr_number,
+        )
+        r = await self._http.post(
+            f"{self._base}/specialists/pr-reviewer",
+            json=req.model_dump(),
+            headers=self._headers(),
+            timeout=120.0,
+        )
+        r.raise_for_status()
+        return SpecialistResponse.model_validate(r.json())

--- a/app/tests/test_daemon_client.py
+++ b/app/tests/test_daemon_client.py
@@ -159,6 +159,51 @@ async def test_plan_reviewer_parses_response(httpx_mock: HTTPXMock) -> None:
 
 
 @pytest.mark.asyncio
+async def test_pr_reviewer_explicit_pr_number(httpx_mock: HTTPXMock) -> None:
+    """``/specialists/pr-reviewer`` POSTs SpecialistRequest with pr_number set."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/specialists/pr-reviewer",
+        json={
+            "name": "pr-reviewer",
+            "summary": "CI green, one Augment thread open — push a fix then merge.",
+            "flags": ["ci-green", "has-unresolved-comments"],
+        },
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    resp = await client.pr_reviewer(project_slug="demo", pr_number=42)
+
+    assert isinstance(resp, SpecialistResponse)
+    assert resp.name == "pr-reviewer"
+    assert "ci-green" in resp.flags
+    assert "has-unresolved-comments" in resp.flags
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.content)
+    assert body["name"] == "pr-reviewer"
+    assert body["project_slug"] == "demo"
+    assert body["pr_number"] == 42
+
+
+@pytest.mark.asyncio
+async def test_pr_reviewer_defaults_pr_number_to_none(httpx_mock: HTTPXMock) -> None:
+    """Omitting ``pr_number`` sends ``pr_number: null`` — the daemon's auto-detect path."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://127.0.0.1:8765/specialists/pr-reviewer",
+        json={"name": "pr-reviewer", "summary": "no-op", "flags": []},
+    )
+    client = DaemonClient(base_url="http://127.0.0.1:8765")
+    await client.pr_reviewer(project_slug="demo")
+
+    sent = httpx_mock.get_request()
+    assert sent is not None
+    body = json.loads(sent.content)
+    assert body["pr_number"] is None
+
+
+@pytest.mark.asyncio
 async def test_plan_reviewer_passes_branch(httpx_mock: HTTPXMock) -> None:
     """When given, ``branch`` is serialised into the posted body."""
     httpx_mock.add_response(

--- a/daemon/src/reachy_ducky_daemon/brain/registry.py
+++ b/daemon/src/reachy_ducky_daemon/brain/registry.py
@@ -83,6 +83,18 @@ class BrainRegistry:
             raise KeyError(slug)
         return self._projects[slug].path
 
+    def project_for(self, slug: str) -> Project:
+        """Return the full :class:`Project` for ``slug`` (no brain build).
+
+        The ``/specialists/pr-reviewer`` route needs ``github_repo`` in
+        addition to ``path``; keeping a single lookup instead of two
+        keeps the registry's immutability contract simple (one KeyError
+        path, one project instance).
+        """
+        if slug not in self._projects:
+            raise KeyError(slug)
+        return self._projects[slug]
+
     def primary_slug(self) -> str | None:
         """Return the ``primary=True`` project slug, or ``None`` if none configured."""
         return self._primary_slug

--- a/daemon/src/reachy_ducky_daemon/server.py
+++ b/daemon/src/reachy_ducky_daemon/server.py
@@ -29,6 +29,7 @@ from starlette.types import ASGIApp
 from .brain.registry import BrainRegistry
 from .memory.layout import ensure_layout
 from .specialists.plan_reviewer import PlanReviewer
+from .specialists.pr_reviewer import PRReviewer
 
 # /docs and /openapi.json are open by intent. In the Tailscale-primary
 # deployment envelope the schema disclosure is an acceptable trade for
@@ -128,6 +129,33 @@ def create_app(
                 detail=f"unknown project: {req.project_slug}",
             ) from None
         return await PlanReviewer(brain=brain, repo=repo).review()
+
+    @app.post("/specialists/pr-reviewer", response_model=SpecialistResponse)
+    async def pr_reviewer_route(req: SpecialistRequest) -> SpecialistResponse:
+        try:
+            brain = registry.brain_for(req.project_slug)
+            project = registry.project_for(req.project_slug)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"unknown project: {req.project_slug}",
+            ) from None
+        if not project.github_repo:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"project '{req.project_slug}' has no github_repo configured — "
+                    "pr-reviewer needs owner/repo to target the GitHub API"
+                ),
+            )
+        # Project.__post_init__ already validated the 'owner/repo' shape.
+        owner, repo_name = project.github_repo.split("/", 1)
+        return await PRReviewer(
+            brain=brain,
+            repo=project.path,
+            owner=owner,
+            repo_name=repo_name,
+        ).review(pr_number=req.pr_number)
 
     return app
 

--- a/daemon/src/reachy_ducky_daemon/server.py
+++ b/daemon/src/reachy_ducky_daemon/server.py
@@ -132,8 +132,12 @@ def create_app(
 
     @app.post("/specialists/pr-reviewer", response_model=SpecialistResponse)
     async def pr_reviewer_route(req: SpecialistRequest) -> SpecialistResponse:
+        # Validate project configuration BEFORE touching the brain factory so
+        # misconfiguration rejections (404 unknown-slug, 400 missing github_repo)
+        # stay cheap and side-effect-free. Brain construction is documented as
+        # pure config assembly today (brain/registry.py), but the invariant
+        # is only as solid as the docstring — order matters if that changes.
         try:
-            brain = registry.brain_for(req.project_slug)
             project = registry.project_for(req.project_slug)
         except KeyError:
             raise HTTPException(
@@ -150,6 +154,7 @@ def create_app(
             )
         # Project.__post_init__ already validated the 'owner/repo' shape.
         owner, repo_name = project.github_repo.split("/", 1)
+        brain = registry.brain_for(req.project_slug)
         return await PRReviewer(
             brain=brain,
             repo=project.path,

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -21,9 +21,14 @@ import json
 import subprocess  # nosec B404 — list-form read-only gh only; no shell
 from pathlib import Path
 
+from reachy_ducky_protocol.messages import BrainRequest, SpecialistResponse
+
+from reachy_ducky_daemon.brain.interface import BrainInterface
+
 __all__ = [
     "_GH_TIMEOUT_SECONDS",
     "_PR_VIEW_FIELDS",
+    "PRReviewer",
     "_assemble_diagnostic_prompt",
     "_assemble_prompt",
     "_current_branch",
@@ -35,6 +40,8 @@ __all__ = [
     "_find_pr_for_branch",
     "_run_gh",
 ]
+
+_SPECIALIST_NAME = "pr-reviewer"
 
 _DIRECTIVE = (
     "Synthesize a short PR digest for the developer. Be terse and "
@@ -427,3 +434,118 @@ def _assemble_diagnostic_prompt(
     parts.append("=== TASK ===")
     parts.append(_DIAGNOSTIC_DIRECTIVE)
     return "\n".join(parts)
+
+
+class PRReviewer:
+    """Hybrid specialist: pre-load PR surfaces + brain synthesis.
+
+    Matches the :class:`PlanReviewer` shape — deterministic pre-fetch in
+    Python, exactly one ``brain.query()`` call per :meth:`review`, wrap
+    the reply as :class:`SpecialistResponse`.
+
+    ``owner`` and ``repo_name`` are passed explicitly rather than parsed
+    from ``Project.github_repo`` inside the specialist — the caller
+    (the server route) already holds the project config and splitting
+    the string is its concern, not the specialist's.
+
+    Invocation contract:
+
+    * ``review(pr_number=N)`` → explicit: fetch that PR.
+    * ``review(pr_number=None)`` → auto-detect: ``git rev-parse`` →
+      ``gh pr list --head <branch>`` → fetch if found.
+    * No PR found (for any reason) → diagnostic prompt; brain is
+      expected to investigate with its tool surface and return an
+      actionable explanation rather than a review-of-nothing.
+
+    Exactly one ``brain.query()`` call fires per :meth:`review` invocation
+    regardless of which path is taken.
+    """
+
+    def __init__(
+        self,
+        *,
+        brain: BrainInterface,
+        repo: Path,
+        owner: str,
+        repo_name: str,
+    ) -> None:
+        self._brain = brain
+        self._repo = repo
+        self._owner = owner
+        self._repo_name = repo_name
+
+    async def review(self, *, pr_number: int | None = None) -> SpecialistResponse:
+        """Run the full review cycle for the resolved PR (or diagnostic path)."""
+        resolved_pr, branch, branch_err, find_err = self._resolve_pr(pr_number)
+
+        if resolved_pr is None:
+            return await self._diagnostic_response(
+                branch=branch, branch_error=branch_err, find_error=find_err
+            )
+
+        pr_meta, meta_err = _fetch_pr_metadata(resolved_pr, cwd=self._repo)
+        if not pr_meta:
+            # Resolved a number but couldn't fetch — surface the reason.
+            return await self._diagnostic_response(
+                branch=branch,
+                branch_error=None,
+                find_error=meta_err or f"could not fetch PR #{resolved_pr}",
+            )
+
+        diff, _diff_err = _fetch_diff(resolved_pr, cwd=self._repo)
+        comments, _c_err = _fetch_review_comments(
+            owner=self._owner,
+            repo=self._repo_name,
+            pr_number=resolved_pr,
+            cwd=self._repo,
+        )
+        head_sha = pr_meta.get("headRefOid")
+        if isinstance(head_sha, str) and head_sha:
+            check_runs, _ci_err = _fetch_check_runs(
+                owner=self._owner,
+                repo=self._repo_name,
+                head_sha=head_sha,
+                cwd=self._repo,
+            )
+        else:
+            check_runs = []
+
+        prompt = _assemble_prompt(pr=pr_meta, diff=diff, comments=comments, check_runs=check_runs)
+        flags = _derive_flags(pr=pr_meta, comments=comments, check_runs=check_runs)
+        brain_resp = await self._brain.query(BrainRequest(user_utterance=prompt))
+        return SpecialistResponse(name=_SPECIALIST_NAME, summary=brain_resp.text, flags=flags)
+
+    async def _diagnostic_response(
+        self,
+        *,
+        branch: str,
+        branch_error: str | None,
+        find_error: str | None,
+    ) -> SpecialistResponse:
+        """Dispatch the diagnostic prompt and wrap the brain's reply."""
+        prompt = _assemble_diagnostic_prompt(
+            branch=branch or "unknown",
+            branch_error=branch_error,
+            find_error=find_error,
+        )
+        flags = _derive_flags(pr={}, comments=[], check_runs=[])
+        brain_resp = await self._brain.query(BrainRequest(user_utterance=prompt))
+        return SpecialistResponse(name=_SPECIALIST_NAME, summary=brain_resp.text, flags=flags)
+
+    def _resolve_pr(self, pr_number: int | None) -> tuple[int | None, str, str | None, str | None]:
+        """Return ``(pr, branch, branch_error, find_error)`` per the resolution order.
+
+        Explicit ``pr_number`` short-circuits the auto-detect path. The
+        ``branch`` slot is ``"(explicit)"`` in that case — a sentinel
+        the diagnostic path never sees but which keeps the return shape
+        uniform.
+        """
+        if pr_number is not None:
+            return pr_number, "(explicit)", None, None
+
+        branch, branch_err = _current_branch(self._repo)
+        if branch_err is not None:
+            return None, branch, branch_err, None
+
+        pr, find_err = _find_pr_for_branch(branch=branch, cwd=self._repo)
+        return pr, branch, None, find_err

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -1,0 +1,43 @@
+"""``PRReviewer`` — the Phase B PR-digest specialist.
+
+Pattern A (per ``plan_reviewer.py``): Python deterministically pre-loads
+PR context via ``gh`` CLI subprocess, assembles a single prompt,
+dispatches to the brain once, wraps the reply. The brain's full tool
+surface (``mcp__github__*``, Read/Grep/Glob, gated Bash) remains
+available for follow-up questions via ``/brain/query`` but does not run
+inside this specialist.
+
+Read-only by construction: only ``gh`` subcommands that produce no side
+effects are invoked (``pr view``, ``pr diff``, ``pr list``, ``api`` GETs).
+The PAT the CLI uses is scoped ``repo:read + pull_requests:read +
+issues:read`` — even if an unexpected verb reached ``gh``, GitHub would
+403 it. No new ``PreToolUse`` gate at the specialist layer; see
+``docs/plans/2026-04-23-pr-reviewer-specialist.md`` for the threat model.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 — list-form read-only gh only; no shell
+from pathlib import Path
+
+__all__ = ["_GH_TIMEOUT_SECONDS", "_run_gh"]
+
+_GH_TIMEOUT_SECONDS = 30.0
+
+
+def _run_gh(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a read-only ``gh`` subcommand and return the completed process.
+
+    ``check=False`` so the caller can inspect ``returncode`` and surface
+    ``stderr`` as diagnostic context in the assembled prompt — an
+    individual ``gh`` hiccup should not abort the whole review. List-form
+    args per ``.claude/rules/python-standards.md``.
+    """
+    return subprocess.run(  # noqa: S603  # nosec B603 B607 — list form, read-only gh only; gh resolved via PATH is the intended portable behaviour
+        ["gh", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=_GH_TIMEOUT_SECONDS,
+    )

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -17,12 +17,39 @@ issues:read`` — even if an unexpected verb reached ``gh``, GitHub would
 
 from __future__ import annotations
 
+import json
 import subprocess  # nosec B404 — list-form read-only gh only; no shell
 from pathlib import Path
 
-__all__ = ["_GH_TIMEOUT_SECONDS", "_run_gh"]
+__all__ = [
+    "_GH_TIMEOUT_SECONDS",
+    "_PR_VIEW_FIELDS",
+    "_fetch_pr_metadata",
+    "_run_gh",
+]
 
 _GH_TIMEOUT_SECONDS = 30.0
+
+# Fields we request from ``gh pr view --json``. Kept as a module-level
+# constant so the test pinning the argv contract can reference it.
+_PR_VIEW_FIELDS = ",".join(
+    [
+        "number",
+        "title",
+        "body",
+        "state",
+        "mergeable",
+        "author",
+        "headRefName",
+        "baseRefName",
+        "url",
+        "labels",
+        "files",
+        "reviewDecision",
+        "headRefOid",
+        "closingIssuesReferences",
+    ]
+)
 
 
 def _run_gh(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -41,3 +68,34 @@ def _run_gh(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         text=True,
         timeout=_GH_TIMEOUT_SECONDS,
     )
+
+
+def _fetch_pr_metadata(
+    pr_number: int,
+    cwd: Path,
+) -> tuple[dict[str, object], str | None]:
+    """Return ``(metadata_dict, error_string_or_None)`` for one PR.
+
+    Invokes ``gh pr view <num> --json <fields>`` and parses the JSON
+    output. On non-zero exit or malformed JSON, returns ``({}, error)``
+    so the caller can surface the diagnostic in the prompt without
+    aborting the whole review (same pattern as
+    ``plan_reviewer._capture_diff``).
+    """
+    try:
+        proc = _run_gh(
+            ["pr", "view", str(pr_number), "--json", _PR_VIEW_FIELDS],
+            cwd=cwd,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {}, f"gh pr view {pr_number} failed: {exc}"
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        return {}, f"gh pr view {pr_number} failed: {stderr}"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return {}, f"gh pr view {pr_number} emitted unparseable JSON: {exc}"
+    if not isinstance(parsed, dict):
+        return {}, f"gh pr view {pr_number} returned non-object JSON"
+    return parsed, None

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -24,6 +24,8 @@ from pathlib import Path
 __all__ = [
     "_GH_TIMEOUT_SECONDS",
     "_PR_VIEW_FIELDS",
+    "_assemble_diagnostic_prompt",
+    "_assemble_prompt",
     "_current_branch",
     "_derive_flags",
     "_fetch_check_runs",
@@ -33,6 +35,26 @@ __all__ = [
     "_find_pr_for_branch",
     "_run_gh",
 ]
+
+_DIRECTIVE = (
+    "Synthesize a short PR digest for the developer. Be terse and "
+    "referentially precise — cite file paths + line numbers, bot names, "
+    "CI job names. Cover: (1) does the diff match the PR body / linked "
+    "issues, (2) which bot comments are legit vs noisy, (3) CI & "
+    "merge-readiness, (4) your risk call (safe to merge / push a fix / "
+    "split). Do NOT re-review the diff line by line — Augment and Codex "
+    "already did. You are the synthesis layer; stay one level above their "
+    "output."
+)
+
+_DIAGNOSTIC_DIRECTIVE = (
+    "No open PR was found for this branch. Use mcp__github__list_pull_requests "
+    "(try state=all), git log / git show, and git status via the gated Bash "
+    "tool to investigate. Was there a merged or closed PR for this branch? "
+    "Is the branch even pushed to the remote? Are we actually checked out on "
+    "the branch the user thinks we are? Return a short, actionable "
+    "explanation — not an apology."
+)
 
 # GitHub check-run conclusion values that indicate failure. Used by
 # ``_derive_flags`` to emit the ``ci-red`` flag. ``cancelled`` and
@@ -318,3 +340,90 @@ def _derive_flags(
         flags.append("merge-conflict")
 
     return flags
+
+
+def _assemble_prompt(
+    pr: dict[str, object],
+    diff: str,
+    comments: list[dict[str, object]],
+    check_runs: list[dict[str, object]],
+) -> str:
+    """Build the review prompt.
+
+    Mirrors ``plan_reviewer._assemble_prompt``'s layout: stable section
+    headers (``=== FOO ===``) give the brain fixed attention anchors;
+    the synthesis directive sits last, closest to where generation
+    begins. Comment entries include author login + file:line so a
+    follow-up "tell me about that Augment comment" has anchors the
+    brain can ``Read`` directly.
+    """
+    parts: list[str] = []
+    parts.append(f"PR #{pr.get('number')}: {pr.get('title', '(no title)')}")
+    parts.append(f"Branch: {pr.get('headRefName')} → {pr.get('baseRefName')}")
+    url = pr.get("url")
+    if url:
+        parts.append(f"URL: {url}")
+    parts.append("")
+
+    parts.append("=== PR BODY ===")
+    body = pr.get("body")
+    parts.append(str(body) if body else "(empty)")
+    parts.append("")
+
+    parts.append("=== DIFF ===")
+    parts.append(diff if diff.strip() else "(empty diff)")
+    parts.append("")
+
+    parts.append("=== REVIEW COMMENTS ===")
+    if not comments:
+        parts.append("(no line-level review comments)")
+    else:
+        for c in comments:
+            user = c.get("user")
+            login = user.get("login", "unknown") if isinstance(user, dict) else "unknown"
+            path = c.get("path", "?")
+            line = c.get("line", "?")
+            body = c.get("body", "")
+            parts.append(f"--- {login} on {path}:{line} ---")
+            parts.append(str(body))
+    parts.append("")
+
+    parts.append("=== CI / CHECK RUNS ===")
+    if not check_runs:
+        parts.append("(no check runs)")
+    else:
+        for r in check_runs:
+            name = r.get("name", "?")
+            status = r.get("status", "?")
+            conclusion = r.get("conclusion", "?")
+            parts.append(f"- {name}: {status} / {conclusion}")
+    parts.append("")
+
+    parts.append("=== TASK ===")
+    parts.append(_DIRECTIVE)
+    return "\n".join(parts)
+
+
+def _assemble_diagnostic_prompt(
+    branch: str,
+    branch_error: str | None,
+    find_error: str | None,
+) -> str:
+    """Build the no-PR-found prompt.
+
+    Brain is expected to dig with its tool surface (``mcp__github__*``,
+    gated ``git`` Bash, Read/Grep/Glob) and explain *why* there's no PR
+    rather than hand back a review of nothing. Mirrors the "error as
+    prompt diagnostic" pattern from ``plan_reviewer._capture_diff``.
+    """
+    parts: list[str] = [f"Branch: {branch}"]
+    if branch_error is not None:
+        parts.append(f"(branch diagnostic: {branch_error})")
+    if find_error is not None:
+        parts.append(f"(lookup diagnostic: {find_error})")
+    parts.append("")
+    parts.append(f"No open PR was found for branch '{branch}'.")
+    parts.append("")
+    parts.append("=== TASK ===")
+    parts.append(_DIAGNOSTIC_DIRECTIVE)
+    return "\n".join(parts)

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -25,6 +25,7 @@ __all__ = [
     "_GH_TIMEOUT_SECONDS",
     "_PR_VIEW_FIELDS",
     "_current_branch",
+    "_derive_flags",
     "_fetch_check_runs",
     "_fetch_diff",
     "_fetch_pr_metadata",
@@ -32,6 +33,12 @@ __all__ = [
     "_find_pr_for_branch",
     "_run_gh",
 ]
+
+# GitHub check-run conclusion values that indicate failure. Used by
+# ``_derive_flags`` to emit the ``ci-red`` flag. ``cancelled`` and
+# ``timed_out`` count as failures for merge-readiness (you can't
+# confirm passage); ``neutral`` and ``skipped`` do not.
+_FAILURE_CONCLUSIONS = frozenset({"failure", "cancelled", "timed_out", "action_required"})
 
 _GH_TIMEOUT_SECONDS = 30.0
 
@@ -257,3 +264,57 @@ def _find_pr_for_branch(
     if not isinstance(number, int):
         return None, "gh pr list returned non-int PR number"
     return number, None
+
+
+def _derive_flags(
+    pr: dict[str, object],
+    comments: list[dict[str, object]],
+    check_runs: list[dict[str, object]],
+) -> list[str]:
+    """Compute objective machine-tags from pre-fetched PR data.
+
+    Deliberately emits *only* facts derivable without an LLM — the risk
+    inferences (``risk:scope-creep``, ``recommend:push-fix``) live in
+    the brain's summary prose. Flags are stable across brain-output
+    evolution and safe for the menu-bar / phase-C interruption tiers to
+    branch on directly.
+
+    CI-state precedence mirrors GitHub's own UI: **failure wins over
+    pending**. Any ``failure`` / ``cancelled`` / ``timed_out`` /
+    ``action_required`` conclusion yields ``ci-red`` even if other runs
+    are still in progress; pending-without-failure yields
+    ``ci-pending``; all-success yields ``ci-green``. Zero check-runs
+    emits no ``ci-*`` flag (absence of signal ≠ green).
+    """
+    if not pr:
+        return ["no-pr-found"]
+
+    flags: list[str] = []
+
+    if check_runs:
+        has_failure = any(
+            isinstance(r, dict) and r.get("conclusion") in _FAILURE_CONCLUSIONS for r in check_runs
+        )
+        has_pending = any(
+            isinstance(r, dict)
+            and (
+                r.get("status") == "in_progress"
+                or r.get("status") == "queued"
+                or (r.get("conclusion") is None and r.get("status") != "completed")
+            )
+            for r in check_runs
+        )
+        if has_failure:
+            flags.append("ci-red")
+        elif has_pending:
+            flags.append("ci-pending")
+        else:
+            flags.append("ci-green")
+
+    if comments:
+        flags.append("has-unresolved-comments")
+
+    if pr.get("mergeable") == "CONFLICTING":
+        flags.append("merge-conflict")
+
+    return flags

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -24,6 +24,7 @@ from pathlib import Path
 __all__ = [
     "_GH_TIMEOUT_SECONDS",
     "_PR_VIEW_FIELDS",
+    "_fetch_diff",
     "_fetch_pr_metadata",
     "_run_gh",
 ]
@@ -99,3 +100,20 @@ def _fetch_pr_metadata(
     if not isinstance(parsed, dict):
         return {}, f"gh pr view {pr_number} returned non-object JSON"
     return parsed, None
+
+
+def _fetch_diff(pr_number: int, cwd: Path) -> tuple[str, str | None]:
+    """Return ``(diff_text, error_or_None)`` from ``gh pr diff <num>``.
+
+    The GitHub API's diff endpoint would need manual pagination + merge
+    for very large PRs; ``gh pr diff`` handles that for us. Output is
+    the raw unified-diff text ready to drop into the assembled prompt.
+    """
+    try:
+        proc = _run_gh(["pr", "diff", str(pr_number)], cwd=cwd)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "", f"gh pr diff {pr_number} failed: {exc}"
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        return "", f"gh pr diff {pr_number} failed: {stderr}"
+    return proc.stdout, None

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -24,10 +24,12 @@ from pathlib import Path
 __all__ = [
     "_GH_TIMEOUT_SECONDS",
     "_PR_VIEW_FIELDS",
+    "_current_branch",
     "_fetch_check_runs",
     "_fetch_diff",
     "_fetch_pr_metadata",
     "_fetch_review_comments",
+    "_find_pr_for_branch",
     "_run_gh",
 ]
 
@@ -186,3 +188,72 @@ def _fetch_check_runs(
     if not isinstance(runs, list):
         return [], f"gh api {endpoint} returned check_runs of unexpected type"
     return [r for r in runs if isinstance(r, dict)], None
+
+
+def _current_branch(cwd: Path) -> tuple[str, str | None]:
+    """Return ``(branch_name, error_or_None)`` for the checkout at ``cwd``.
+
+    Mirrors ``plan_reviewer._current_branch`` (plan_reviewer.py:89). Kept
+    duplicated rather than factored out because the two specialists
+    should not import private helpers across modules — if a third
+    specialist needs it, promote to a shared ``specialists/_subprocess``
+    module at that point.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603  # nosec B603 B607 — list form, read-only git only
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "unknown", f"git rev-parse failed: {exc}"
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        return "unknown", f"git rev-parse failed: {stderr}"
+    return proc.stdout.strip() or "unknown", None
+
+
+def _find_pr_for_branch(
+    branch: str,
+    cwd: Path,
+) -> tuple[int | None, str | None]:
+    """Return ``(pr_number_or_None, error_or_None)`` for ``branch``'s open PR.
+
+    Uses ``gh pr list --head <branch> --state open --json number`` — the
+    repo context is inferred from the ``cwd``'s upstream remote the same
+    way ``gh pr view`` infers it.
+
+    **Distinguishing "no PR" from "couldn't ask":** a successful
+    ``gh`` call returning an empty list yields ``(None, None)``; a
+    subprocess or non-zero exit yields ``(None, error_string)``. The
+    orchestrator needs this distinction to decide between "graceful
+    no-PR digest" and "real diagnostic".
+    """
+    try:
+        proc = _run_gh(
+            ["pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+            cwd=cwd,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"gh pr list --head {branch} failed: {exc}"
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        return None, f"gh pr list --head {branch} failed: {stderr}"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return None, f"gh pr list emitted unparseable JSON: {exc}"
+    if not isinstance(parsed, list):
+        return None, "gh pr list returned non-list JSON"
+    if not parsed:
+        return None, None
+    first = parsed[0]
+    if not isinstance(first, dict) or "number" not in first:
+        return None, "gh pr list returned unexpected entry shape"
+    number = first["number"]
+    if not isinstance(number, int):
+        return None, "gh pr list returned non-int PR number"
+    return number, None

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -24,6 +24,7 @@ from pathlib import Path
 __all__ = [
     "_GH_TIMEOUT_SECONDS",
     "_PR_VIEW_FIELDS",
+    "_fetch_check_runs",
     "_fetch_diff",
     "_fetch_pr_metadata",
     "_fetch_review_comments",
@@ -152,3 +153,36 @@ def _fetch_review_comments(
         return [], f"gh api {endpoint} returned non-list JSON (unexpected shape)"
     # Narrow the element type — every list entry should be a JSON object.
     return [c for c in parsed if isinstance(c, dict)], None
+
+
+def _fetch_check_runs(
+    owner: str,
+    repo: str,
+    head_sha: str,
+    cwd: Path,
+) -> tuple[list[dict[str, object]], str | None]:
+    """Return ``(check_runs_list, error_or_None)`` for the PR's head commit.
+
+    GitHub wraps check-runs in ``{total_count, check_runs: [...]}``;
+    unwrap to the list for caller convenience. Status + conclusion per
+    run drive the objective ``ci-green`` / ``ci-red`` / ``ci-pending``
+    flags the orchestrator emits.
+    """
+    endpoint = f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs"
+    try:
+        proc = _run_gh(["api", endpoint], cwd=cwd)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return [], f"gh api {endpoint} failed: {exc}"
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        return [], f"gh api {endpoint} failed: {stderr}"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return [], f"gh api {endpoint} emitted unparseable JSON: {exc}"
+    if not isinstance(parsed, dict) or "check_runs" not in parsed:
+        return [], f"gh api {endpoint} returned unexpected shape"
+    runs = parsed["check_runs"]
+    if not isinstance(runs, list):
+        return [], f"gh api {endpoint} returned check_runs of unexpected type"
+    return [r for r in runs if isinstance(r, dict)], None

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -354,6 +354,10 @@ def _assemble_prompt(
     diff: str,
     comments: list[dict[str, object]],
     check_runs: list[dict[str, object]],
+    *,
+    diff_error: str | None = None,
+    comments_error: str | None = None,
+    check_runs_error: str | None = None,
 ) -> str:
     """Build the review prompt.
 
@@ -363,6 +367,16 @@ def _assemble_prompt(
     begins. Comment entries include author login + file:line so a
     follow-up "tell me about that Augment comment" has anchors the
     brain can ``Read`` directly.
+
+    Fetch-error plumbing: when ``gh`` fails on any of the three
+    secondary surfaces (diff, comments, check-runs), the orchestrator
+    passes the error string through the matching ``*_error`` kwarg.
+    The prompt prepends a ``(diagnostic: ...)`` line inside the
+    affected section so the brain can distinguish "nothing there" from
+    "couldn't see what was there" — silent degradation of fetch errors
+    into empty values was a real correctness risk (brain's risk call
+    could say "safe to merge, no diff" on a PR whose diff we couldn't
+    read).
     """
     parts: list[str] = []
     parts.append(f"PR #{pr.get('number')}: {pr.get('title', '(no title)')}")
@@ -378,10 +392,14 @@ def _assemble_prompt(
     parts.append("")
 
     parts.append("=== DIFF ===")
+    if diff_error is not None:
+        parts.append(f"(diagnostic: {diff_error})")
     parts.append(diff if diff.strip() else "(empty diff)")
     parts.append("")
 
     parts.append("=== REVIEW COMMENTS ===")
+    if comments_error is not None:
+        parts.append(f"(diagnostic: {comments_error})")
     if not comments:
         parts.append("(no line-level review comments)")
     else:
@@ -396,6 +414,8 @@ def _assemble_prompt(
     parts.append("")
 
     parts.append("=== CI / CHECK RUNS ===")
+    if check_runs_error is not None:
+        parts.append(f"(diagnostic: {check_runs_error})")
     if not check_runs:
         parts.append("(no check runs)")
     else:
@@ -492,16 +512,17 @@ class PRReviewer:
                 find_error=meta_err or f"could not fetch PR #{resolved_pr}",
             )
 
-        diff, _diff_err = _fetch_diff(resolved_pr, cwd=self._repo)
-        comments, _c_err = _fetch_review_comments(
+        diff, diff_err = _fetch_diff(resolved_pr, cwd=self._repo)
+        comments, comments_err = _fetch_review_comments(
             owner=self._owner,
             repo=self._repo_name,
             pr_number=resolved_pr,
             cwd=self._repo,
         )
         head_sha = pr_meta.get("headRefOid")
+        check_runs_err: str | None
         if isinstance(head_sha, str) and head_sha:
-            check_runs, _ci_err = _fetch_check_runs(
+            check_runs, check_runs_err = _fetch_check_runs(
                 owner=self._owner,
                 repo=self._repo_name,
                 head_sha=head_sha,
@@ -509,8 +530,20 @@ class PRReviewer:
             )
         else:
             check_runs = []
+            # PR metadata fetched successfully but lacks a head SHA — surface
+            # as a diagnostic so the brain knows CI silence is "we didn't ask",
+            # not "no CI configured".
+            check_runs_err = "PR metadata did not include headRefOid — check-runs not fetched"
 
-        prompt = _assemble_prompt(pr=pr_meta, diff=diff, comments=comments, check_runs=check_runs)
+        prompt = _assemble_prompt(
+            pr=pr_meta,
+            diff=diff,
+            comments=comments,
+            check_runs=check_runs,
+            diff_error=diff_err,
+            comments_error=comments_err,
+            check_runs_error=check_runs_err,
+        )
         flags = _derive_flags(pr=pr_meta, comments=comments, check_runs=check_runs)
         brain_resp = await self._brain.query(BrainRequest(user_utterance=prompt))
         return SpecialistResponse(name=_SPECIALIST_NAME, summary=brain_resp.text, flags=flags)

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -26,6 +26,7 @@ __all__ = [
     "_PR_VIEW_FIELDS",
     "_fetch_diff",
     "_fetch_pr_metadata",
+    "_fetch_review_comments",
     "_run_gh",
 ]
 
@@ -117,3 +118,37 @@ def _fetch_diff(pr_number: int, cwd: Path) -> tuple[str, str | None]:
         stderr = proc.stderr.strip() or "non-zero exit"
         return "", f"gh pr diff {pr_number} failed: {stderr}"
     return proc.stdout, None
+
+
+def _fetch_review_comments(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    cwd: Path,
+) -> tuple[list[dict[str, object]], str | None]:
+    """Return ``(comments_list, error_or_None)`` via ``gh api ... --paginate``.
+
+    Line-level review comments are where Augment and Codex bots post
+    their critiques. Issue-style PR comments live at a separate endpoint
+    and are intentionally not fetched here — the digest focuses on
+    structured line-level concerns, not general PR chatter.
+
+    ``--paginate`` stitches multi-page responses transparently so large
+    PRs with many review threads don't silently drop trailing comments.
+    """
+    endpoint = f"/repos/{owner}/{repo}/pulls/{pr_number}/comments"
+    try:
+        proc = _run_gh(["api", endpoint, "--paginate"], cwd=cwd)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return [], f"gh api {endpoint} failed: {exc}"
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        return [], f"gh api {endpoint} failed: {stderr}"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return [], f"gh api {endpoint} emitted unparseable JSON: {exc}"
+    if not isinstance(parsed, list):
+        return [], f"gh api {endpoint} returned non-list JSON (unexpected shape)"
+    # Narrow the element type — every list entry should be a JSON object.
+    return [c for c in parsed if isinstance(c, dict)], None

--- a/daemon/tests/fixtures/gh_api_check_runs.json
+++ b/daemon/tests/fixtures/gh_api_check_runs.json
@@ -1,0 +1,8 @@
+{
+  "total_count": 3,
+  "check_runs": [
+    {"name": "ruff", "status": "completed", "conclusion": "success"},
+    {"name": "mypy", "status": "completed", "conclusion": "failure"},
+    {"name": "pytest", "status": "in_progress", "conclusion": null}
+  ]
+}

--- a/daemon/tests/fixtures/gh_api_comments.json
+++ b/daemon/tests/fixtures/gh_api_comments.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 1,
+    "user": {"login": "augment-code[bot]"},
+    "path": "src/upload.py",
+    "line": 42,
+    "body": "This retry loop lacks a jitter term — will synchronize on multi-client failures."
+  },
+  {
+    "id": 2,
+    "user": {"login": "codex[bot]"},
+    "path": "src/auth.py",
+    "line": 7,
+    "body": "Potential timing-attack surface on the comparison."
+  }
+]

--- a/daemon/tests/fixtures/gh_pr_view_happy.json
+++ b/daemon/tests/fixtures/gh_pr_view_happy.json
@@ -1,0 +1,16 @@
+{
+  "number": 42,
+  "title": "feat: add retry logic",
+  "body": "Closes #15. Adds exponential backoff to the upload path.",
+  "state": "OPEN",
+  "mergeable": "MERGEABLE",
+  "author": {"login": "macattak"},
+  "headRefName": "feat-retry",
+  "baseRefName": "main",
+  "url": "https://github.com/Obsidian-Owl/reachy-ducky/pull/42",
+  "labels": [],
+  "files": [{"path": "src/upload.py", "additions": 20, "deletions": 3}],
+  "reviewDecision": "CHANGES_REQUESTED",
+  "headRefOid": "abc123def456",
+  "closingIssuesReferences": [{"number": 15, "title": "Upload flake on slow connections"}]
+}

--- a/daemon/tests/test_brain_registry.py
+++ b/daemon/tests/test_brain_registry.py
@@ -186,3 +186,29 @@ def test_factory_receives_project(tmp_path: Path) -> None:
     assert len(received) == 1
     assert received[0].slug == "demo"
     assert received[0].github_repo == "Obsidian-Owl/demo"
+
+
+def test_project_for_returns_project(tmp_path: Path) -> None:
+    """``project_for`` returns the full Project — route needs github_repo, not just path."""
+    project = Project(
+        slug="demo",
+        path=tmp_path,
+        github_repo="Obsidian-Owl/demo",
+        primary=True,
+    )
+    reg = BrainRegistry(projects=[project], build_brain=lambda _: MockBrain())
+
+    fetched = reg.project_for("demo")
+    assert fetched.slug == "demo"
+    assert fetched.github_repo == "Obsidian-Owl/demo"
+    assert reg.built_slugs() == []  # project lookup must NOT trigger a brain build
+
+
+def test_project_for_raises_on_unknown_slug(tmp_path: Path) -> None:
+    """Unknown slug raises :class:`KeyError` (HTTP layer maps to 404, same as the others)."""
+    reg = BrainRegistry(
+        projects=[Project(slug="demo", path=tmp_path)],
+        build_brain=lambda _: MockBrain(),
+    )
+    with pytest.raises(KeyError):
+        reg.project_for("nope")

--- a/daemon/tests/test_server_specialists.py
+++ b/daemon/tests/test_server_specialists.py
@@ -1,9 +1,12 @@
-"""Tests for the FastAPI server's POST /specialists/plan-reviewer endpoint."""
+"""Tests for the FastAPI server's POST /specialists/* endpoints."""
 
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 from reachy_ducky_daemon.brain.interface import BrainInterface
@@ -139,3 +142,175 @@ def test_plan_reviewer_endpoint_invokes_brain_once(tmp_path: Path) -> None:
     assert len(brain.calls) == 1
     assert "# Plan" in brain.calls[0].user_utterance
     assert "Report drift" in brain.calls[0].user_utterance
+
+
+# ---------------------------------------------------------------------------
+# /specialists/pr-reviewer
+# ---------------------------------------------------------------------------
+
+
+def _ok(stdout: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _pr_registry(
+    repo: Path,
+    *,
+    github_repo: str | None = "Obsidian-Owl/reachy-ducky",
+    brain: BrainInterface | None = None,
+) -> BrainRegistry:
+    """One-project registry with a configurable ``github_repo`` for pr-reviewer tests."""
+    b = brain if brain is not None else MockBrain()
+    return BrainRegistry(
+        projects=[
+            Project(
+                slug="repo",
+                path=repo,
+                github_repo=github_repo,
+                primary=True,
+            )
+        ],
+        build_brain=lambda _: b,
+    )
+
+
+def _mock_gh_min(*, pr_json: str) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """Minimum subprocess mocks for a pr-reviewer route happy-path request.
+
+    Any ``gh pr view`` returns ``pr_json``; everything else returns empty
+    list / envelope. Good enough to exercise routing and response shape
+    without over-specifying the fetch graph (covered in detail by the
+    specialist's own tests).
+    """
+
+    def _side_effect(
+        argv: list[str],
+        *args: Any,
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        if argv[:3] == ["gh", "pr", "view"]:
+            return _ok(pr_json)
+        if argv[:3] == ["gh", "pr", "diff"]:
+            return _ok("")
+        if argv[:2] == ["gh", "api"] and "check-runs" in argv[2]:
+            return _ok('{"total_count": 0, "check_runs": []}')
+        if argv[:2] == ["gh", "api"]:  # comments
+            return _ok("[]")
+        if argv[:3] == ["gh", "pr", "list"]:
+            return _ok('[{"number": 42}]')
+        if argv[:2] == ["git", "rev-parse"]:
+            return _ok("feat-retry\n")
+        raise AssertionError(f"unexpected argv: {argv}")
+
+    return _side_effect
+
+
+_HAPPY_PR_JSON = (
+    '{"number": 42, "title": "feat: retry", "body": "Closes #15",'
+    ' "state": "OPEN", "mergeable": "MERGEABLE",'
+    ' "headRefName": "feat-retry", "baseRefName": "main",'
+    ' "url": "https://github.com/Obsidian-Owl/reachy-ducky/pull/42",'
+    ' "headRefOid": "abc123"}'
+)
+
+
+def test_pr_reviewer_endpoint_explicit_pr_number(tmp_path: Path) -> None:
+    """Explicit pr_number → 200 with pr-reviewer response."""
+    repo = _init_repo(tmp_path / "repo")
+    app = create_app(registry=_pr_registry(repo), memory_root=tmp_path / "mem")
+    client = TestClient(app)
+
+    with patch("subprocess.run", side_effect=_mock_gh_min(pr_json=_HAPPY_PR_JSON)):
+        r = client.post(
+            "/specialists/pr-reviewer",
+            json={"name": "pr-reviewer", "project_slug": "repo", "pr_number": 42},
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["name"] == "pr-reviewer"
+    assert "mock" in body["summary"].lower()
+
+
+def test_pr_reviewer_endpoint_auto_detects_when_no_pr_number(tmp_path: Path) -> None:
+    """No pr_number → route still resolves via git rev-parse + gh pr list."""
+    repo = _init_repo(tmp_path / "repo")
+    app = create_app(registry=_pr_registry(repo), memory_root=tmp_path / "mem")
+    client = TestClient(app)
+
+    with patch("subprocess.run", side_effect=_mock_gh_min(pr_json=_HAPPY_PR_JSON)):
+        r = client.post(
+            "/specialists/pr-reviewer",
+            json={"name": "pr-reviewer", "project_slug": "repo"},
+        )
+
+    assert r.status_code == 200
+    assert r.json()["name"] == "pr-reviewer"
+
+
+def test_pr_reviewer_endpoint_unknown_slug_returns_404(tmp_path: Path) -> None:
+    """Unknown slug → 404 with a useful detail (mirrors plan-reviewer behaviour)."""
+    repo = _init_repo(tmp_path / "repo")
+    app = create_app(registry=_pr_registry(repo), memory_root=tmp_path / "mem")
+    client = TestClient(app)
+
+    r = client.post(
+        "/specialists/pr-reviewer",
+        json={"name": "pr-reviewer", "project_slug": "nonexistent"},
+    )
+
+    assert r.status_code == 404
+    assert "nonexistent" in r.json()["detail"]
+
+
+def test_pr_reviewer_endpoint_missing_github_repo_returns_400(tmp_path: Path) -> None:
+    """Project without github_repo → 400 — pr-reviewer can't target GitHub without it."""
+    repo = _init_repo(tmp_path / "repo")
+    app = create_app(
+        registry=_pr_registry(repo, github_repo=None),
+        memory_root=tmp_path / "mem",
+    )
+    client = TestClient(app)
+
+    r = client.post(
+        "/specialists/pr-reviewer",
+        json={"name": "pr-reviewer", "project_slug": "repo", "pr_number": 42},
+    )
+
+    assert r.status_code == 400
+    assert "github_repo" in r.json()["detail"]
+
+
+def test_pr_reviewer_endpoint_response_shape(tmp_path: Path) -> None:
+    """Response matches ``SpecialistResponse`` schema exactly — {name, summary, flags}."""
+    repo = _init_repo(tmp_path / "repo")
+    app = create_app(registry=_pr_registry(repo), memory_root=tmp_path / "mem")
+    client = TestClient(app)
+
+    with patch("subprocess.run", side_effect=_mock_gh_min(pr_json=_HAPPY_PR_JSON)):
+        r = client.post(
+            "/specialists/pr-reviewer",
+            json={"name": "pr-reviewer", "project_slug": "repo", "pr_number": 42},
+        )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert set(data.keys()) == {"name", "summary", "flags"}
+    assert isinstance(data["flags"], list)
+
+
+def test_pr_reviewer_endpoint_invokes_brain_once(tmp_path: Path) -> None:
+    """Each POST triggers exactly one brain.query() call (Pattern A contract)."""
+    repo = _init_repo(tmp_path / "repo")
+    brain = MockBrain()
+    app = create_app(registry=_pr_registry(repo, brain=brain), memory_root=tmp_path / "mem")
+    client = TestClient(app)
+
+    with patch("subprocess.run", side_effect=_mock_gh_min(pr_json=_HAPPY_PR_JSON)):
+        client.post(
+            "/specialists/pr-reviewer",
+            json={"name": "pr-reviewer", "project_slug": "repo", "pr_number": 42},
+        )
+
+    assert len(brain.calls) == 1
+    assert "feat: retry" in brain.calls[0].user_utterance

--- a/daemon/tests/test_server_specialists.py
+++ b/daemon/tests/test_server_specialists.py
@@ -281,6 +281,37 @@ def test_pr_reviewer_endpoint_missing_github_repo_returns_400(tmp_path: Path) ->
     assert "github_repo" in r.json()["detail"]
 
 
+def test_pr_reviewer_endpoint_400_does_not_build_brain(tmp_path: Path) -> None:
+    """The 400 "missing github_repo" path must not trigger a brain build.
+
+    The route should validate the Project *before* calling ``brain_for``
+    so misconfiguration errors stay cheap and side-effect-free. Uses a
+    counting factory to assert zero invocations on the rejection path.
+    """
+    repo = _init_repo(tmp_path / "repo")
+    build_count = 0
+
+    def _counting_factory(_: Project) -> BrainInterface:
+        nonlocal build_count
+        build_count += 1
+        return MockBrain()
+
+    registry = BrainRegistry(
+        projects=[Project(slug="repo", path=repo, github_repo=None, primary=True)],
+        build_brain=_counting_factory,
+    )
+    app = create_app(registry=registry, memory_root=tmp_path / "mem")
+    client = TestClient(app)
+
+    r = client.post(
+        "/specialists/pr-reviewer",
+        json={"name": "pr-reviewer", "project_slug": "repo", "pr_number": 42},
+    )
+
+    assert r.status_code == 400
+    assert build_count == 0, "400 path triggered a brain build — validation order is wrong"
+
+
 def test_pr_reviewer_endpoint_response_shape(tmp_path: Path) -> None:
     """Response matches ``SpecialistResponse`` schema exactly — {name, summary, flags}."""
     repo = _init_repo(tmp_path / "repo")

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -12,7 +12,11 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from reachy_ducky_daemon.specialists.pr_reviewer import _GH_TIMEOUT_SECONDS, _run_gh
+from reachy_ducky_daemon.specialists.pr_reviewer import (
+    _GH_TIMEOUT_SECONDS,
+    _fetch_pr_metadata,
+    _run_gh,
+)
 
 
 def test_run_gh_invokes_list_form_with_timeout() -> None:
@@ -44,3 +48,61 @@ def test_gh_timeout_matches_git_timeout_precedent() -> None:
     raise is a deliberate edit in one place.
     """
     assert _GH_TIMEOUT_SECONDS == 30.0
+
+
+# ---------------------------------------------------------------------------
+# PR metadata fetch
+# ---------------------------------------------------------------------------
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_fetch_pr_metadata_parses_gh_pr_view_json(tmp_path: Path) -> None:
+    """_fetch_pr_metadata invokes ``gh pr view <num> --json ...`` and parses output."""
+    fixture = _FIXTURES / "gh_pr_view_happy.json"
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fixture.read_text(), stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        meta, err = _fetch_pr_metadata(pr_number=42, cwd=tmp_path)
+
+    assert err is None
+    assert meta["number"] == 42
+    assert meta["title"] == "feat: add retry logic"
+    assert meta["state"] == "OPEN"
+    assert meta["headRefName"] == "feat-retry"
+    assert meta["headRefOid"] == "abc123def456"
+    # List form + --json field contract.
+    argv = m.call_args.args[0]
+    assert argv[:3] == ["gh", "pr", "view"]
+    assert "42" in argv
+    assert "--json" in argv
+
+
+def test_fetch_pr_metadata_surfaces_gh_failure_as_diagnostic(tmp_path: Path) -> None:
+    """Non-zero ``gh`` exit returns ``({}, error_string)`` — no exception."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[],
+        returncode=1,
+        stdout="",
+        stderr="GraphQL: Could not resolve to a PullRequest",
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        meta, err = _fetch_pr_metadata(pr_number=999999, cwd=tmp_path)
+
+    assert meta == {}
+    assert err is not None
+    assert "999999" in err or "Could not resolve" in err
+
+
+def test_fetch_pr_metadata_surfaces_unparseable_json_as_diagnostic(tmp_path: Path) -> None:
+    """Malformed stdout returns ``({}, error_string)`` rather than raising JSONDecodeError."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="not json at all", stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        meta, err = _fetch_pr_metadata(pr_number=42, cwd=tmp_path)
+
+    assert meta == {}
+    assert err is not None
+    assert "unparseable" in err.lower() or "json" in err.lower()

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -14,10 +14,12 @@ from unittest.mock import patch
 
 from reachy_ducky_daemon.specialists.pr_reviewer import (
     _GH_TIMEOUT_SECONDS,
+    _current_branch,
     _fetch_check_runs,
     _fetch_diff,
     _fetch_pr_metadata,
     _fetch_review_comments,
+    _find_pr_for_branch,
     _run_gh,
 )
 
@@ -244,3 +246,78 @@ def test_fetch_check_runs_surfaces_unexpected_shape_as_diagnostic(
     assert runs == []
     assert err is not None
     assert "unexpected" in err.lower() or "shape" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Auto-detect: current branch + find-PR-for-branch
+# ---------------------------------------------------------------------------
+
+
+def test_current_branch_reads_git_rev_parse(tmp_path: Path) -> None:
+    """_current_branch shells ``git rev-parse --abbrev-ref HEAD``."""
+    fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="feat-retry\n", stderr="")
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        branch, err = _current_branch(tmp_path)
+
+    assert branch == "feat-retry"
+    assert err is None
+    assert m.call_args.args[0] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+
+
+def test_current_branch_surfaces_git_failure_as_diagnostic(tmp_path: Path) -> None:
+    """git rev-parse failure returns ``("unknown", error)`` — no exception."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=128, stdout="", stderr="fatal: not a git repository"
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        branch, err = _current_branch(tmp_path)
+
+    assert branch == "unknown"
+    assert err is not None
+    assert "not a git repository" in err
+
+
+def test_find_pr_for_branch_picks_first_open(tmp_path: Path) -> None:
+    """_find_pr_for_branch returns the first open PR number for ``head=<branch>``."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout='[{"number": 42, "state": "OPEN"}]', stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        pr_number, err = _find_pr_for_branch(branch="feat-retry", cwd=tmp_path)
+
+    assert pr_number == 42
+    assert err is None
+    argv = m.call_args.args[0]
+    assert argv[:3] == ["gh", "pr", "list"]
+    assert "--head" in argv
+    assert "feat-retry" in argv
+    assert "--state" in argv
+    assert "open" in argv
+
+
+def test_find_pr_for_branch_none_when_no_pr(tmp_path: Path) -> None:
+    """Empty ``gh`` list → ``(None, None)`` — absence of a PR is not an error."""
+    fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+    with patch("subprocess.run", return_value=fake_proc):
+        pr_number, err = _find_pr_for_branch(branch="feat-retry", cwd=tmp_path)
+
+    assert pr_number is None
+    assert err is None
+
+
+def test_find_pr_for_branch_surfaces_gh_failure_as_diagnostic(tmp_path: Path) -> None:
+    """Non-zero ``gh`` exit returns ``(None, error)``.
+
+    Distinguishes "no PR for this branch" (None, None) from
+    "couldn't ask GitHub" (None, error_string) — the orchestrator
+    routes these to different prompts.
+    """
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="authentication required"
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        pr_number, err = _find_pr_for_branch(branch="feat-retry", cwd=tmp_path)
+
+    assert pr_number is None
+    assert err is not None
+    assert "authentication" in err.lower() or "failed" in err.lower()

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 from reachy_ducky_daemon.specialists.pr_reviewer import (
     _GH_TIMEOUT_SECONDS,
+    _fetch_diff,
     _fetch_pr_metadata,
     _run_gh,
 )
@@ -106,3 +107,34 @@ def test_fetch_pr_metadata_surfaces_unparseable_json_as_diagnostic(tmp_path: Pat
     assert meta == {}
     assert err is not None
     assert "unparseable" in err.lower() or "json" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Diff fetch
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_diff_invokes_gh_pr_diff(tmp_path: Path) -> None:
+    """_fetch_diff runs ``gh pr diff <num>`` and returns ``(stdout, None)`` on success."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="diff --git a/src/x.py b/src/x.py\n+x = 2\n",
+        stderr="",
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        diff, err = _fetch_diff(pr_number=42, cwd=tmp_path)
+
+    assert err is None
+    assert "+x = 2" in diff
+    assert m.call_args.args[0] == ["gh", "pr", "diff", "42"]
+
+
+def test_fetch_diff_surfaces_failure_as_diagnostic(tmp_path: Path) -> None:
+    """Non-zero ``gh`` exit returns ``("", error_string)`` — no exception."""
+    fake_proc = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="no such PR")
+    with patch("subprocess.run", return_value=fake_proc):
+        diff, err = _fetch_diff(pr_number=42, cwd=tmp_path)
+
+    assert diff == ""
+    assert err is not None and "no such PR" in err

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -9,11 +9,16 @@ outputs live under ``daemon/tests/fixtures/gh_*.json``.
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
+import pytest
+from reachy_ducky_daemon.brain.mock import MockBrain
 from reachy_ducky_daemon.specialists.pr_reviewer import (
     _GH_TIMEOUT_SECONDS,
+    PRReviewer,
     _assemble_diagnostic_prompt,
     _assemble_prompt,
     _current_branch,
@@ -25,6 +30,7 @@ from reachy_ducky_daemon.specialists.pr_reviewer import (
     _find_pr_for_branch,
     _run_gh,
 )
+from reachy_ducky_protocol.messages import SpecialistResponse
 
 
 def test_run_gh_invokes_list_form_with_timeout() -> None:
@@ -506,4 +512,182 @@ def test_assemble_diagnostic_prompt_surfaces_sub_diagnostics() -> None:
         find_error="gh pr list --head unknown failed: authentication required",
     )
     assert "not a git repository" in prompt
+    assert "authentication required" in prompt
+
+
+# ---------------------------------------------------------------------------
+# PRReviewer orchestrator — end-to-end (subprocess mocked, brain mocked)
+# ---------------------------------------------------------------------------
+
+
+def _ok(stdout: str) -> subprocess.CompletedProcess[str]:
+    """Shorthand for a successful ``CompletedProcess`` with canned stdout."""
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _mock_by_argv(
+    returns: dict[tuple[str, ...], subprocess.CompletedProcess[str]],
+) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """Build a ``subprocess.run`` side_effect that dispatches by argv prefix.
+
+    Longer patterns take precedence over shorter ones — important for
+    distinguishing ``gh api /repos/.../pulls/.../comments`` from
+    ``gh api /repos/.../commits/.../check-runs``.
+    """
+    # Sort keys by length descending so the most specific match wins.
+    ordered = sorted(returns.items(), key=lambda kv: -len(kv[0]))
+
+    def _side_effect(
+        argv: list[str], *args: Any, **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        key = tuple(argv)
+        for pat, proc in ordered:
+            if key[: len(pat)] == pat:
+                return proc
+        raise AssertionError(f"unexpected argv: {argv}")
+
+    return _side_effect
+
+
+@pytest.mark.asyncio
+async def test_review_explicit_pr_number_happy_path(tmp_path: Path) -> None:
+    """Explicit pr_number → fetch all surfaces, assemble prompt, query brain once."""
+    pr_view = _FIXTURES / "gh_pr_view_happy.json"
+    comments = _FIXTURES / "gh_api_comments.json"
+    check_runs = _FIXTURES / "gh_api_check_runs.json"
+
+    side_effect = _mock_by_argv(
+        {
+            ("gh", "pr", "view"): _ok(pr_view.read_text()),
+            ("gh", "pr", "diff"): _ok("diff --git a/src/x.py\n+x = 2\n"),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/pulls/42/comments",
+            ): _ok(comments.read_text()),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/commits/abc123def456/check-runs",
+            ): _ok(check_runs.read_text()),
+        }
+    )
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with patch("subprocess.run", side_effect=side_effect):
+        response = await reviewer.review(pr_number=42)
+
+    assert isinstance(response, SpecialistResponse)
+    assert response.name == "pr-reviewer"
+    # Exactly one brain call — Pattern A contract.
+    assert len(brain.calls) == 1
+    prompt = brain.calls[0].user_utterance
+    assert "feat: add retry logic" in prompt
+    assert "+x = 2" in prompt
+    assert "augment-code[bot]" in prompt
+    # Fixture has mypy failing → ci-red wins over pytest pending.
+    assert "ci-red" in response.flags
+    assert "has-unresolved-comments" in response.flags
+
+
+@pytest.mark.asyncio
+async def test_review_auto_detect_from_current_branch(tmp_path: Path) -> None:
+    """No pr_number → git rev-parse + gh pr list → resolve → same happy fetch."""
+    pr_view = _FIXTURES / "gh_pr_view_happy.json"
+
+    side_effect = _mock_by_argv(
+        {
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): _ok("feat-retry\n"),
+            ("gh", "pr", "list"): _ok('[{"number": 42}]'),
+            ("gh", "pr", "view"): _ok(pr_view.read_text()),
+            ("gh", "pr", "diff"): _ok(""),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/pulls/42/comments",
+            ): _ok("[]"),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/commits/abc123def456/check-runs",
+            ): _ok('{"total_count": 0, "check_runs": []}'),
+        }
+    )
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with patch("subprocess.run", side_effect=side_effect):
+        response = await reviewer.review(pr_number=None)
+
+    assert response.name == "pr-reviewer"
+    assert len(brain.calls) == 1
+    assert "feat: add retry logic" in brain.calls[0].user_utterance
+    # Empty comments + empty check-runs — no ci-* flag, no unresolved-comments.
+    assert not any(f.startswith("ci-") for f in response.flags)
+    assert "has-unresolved-comments" not in response.flags
+
+
+@pytest.mark.asyncio
+async def test_review_graceful_fail_when_no_pr_for_branch(tmp_path: Path) -> None:
+    """Auto-detect branch has no open PR → diagnostic prompt + no-pr-found flag."""
+    side_effect = _mock_by_argv(
+        {
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): _ok("feat-orphan\n"),
+            ("gh", "pr", "list"): _ok("[]"),
+        }
+    )
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with patch("subprocess.run", side_effect=side_effect):
+        response = await reviewer.review(pr_number=None)
+
+    assert response.name == "pr-reviewer"
+    assert "no-pr-found" in response.flags
+    assert len(brain.calls) == 1
+    prompt = brain.calls[0].user_utterance
+    assert "feat-orphan" in prompt
+    assert "no open pr" in prompt.lower() or "no pr" in prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_review_graceful_fail_surfaces_gh_lookup_error(tmp_path: Path) -> None:
+    """gh pr list failing is distinct from "no PR" — error is in the diagnostic prompt."""
+    side_effect = _mock_by_argv(
+        {
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): _ok("feat-x\n"),
+            ("gh", "pr", "list"): subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="authentication required"
+            ),
+        }
+    )
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with patch("subprocess.run", side_effect=side_effect):
+        response = await reviewer.review(pr_number=None)
+
+    assert "no-pr-found" in response.flags
+    prompt = brain.calls[0].user_utterance
     assert "authentication required" in prompt

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from reachy_ducky_daemon.specialists.pr_reviewer import (
     _GH_TIMEOUT_SECONDS,
     _current_branch,
+    _derive_flags,
     _fetch_check_runs,
     _fetch_diff,
     _fetch_pr_metadata,
@@ -321,3 +322,82 @@ def test_find_pr_for_branch_surfaces_gh_failure_as_diagnostic(tmp_path: Path) ->
     assert pr_number is None
     assert err is not None
     assert "authentication" in err.lower() or "failed" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Flag derivation
+# ---------------------------------------------------------------------------
+
+
+def test_derive_flags_no_pr_found_short_circuits() -> None:
+    """Empty PR dict → ``no-pr-found`` and nothing else (other fields are meaningless)."""
+    flags = _derive_flags(pr={}, comments=[], check_runs=[])
+    assert flags == ["no-pr-found"]
+
+
+def test_derive_flags_ci_green_when_all_success() -> None:
+    """All check-runs conclude success → ``ci-green``."""
+    runs: list[dict[str, object]] = [
+        {"conclusion": "success"},
+        {"conclusion": "success"},
+    ]
+    flags = _derive_flags(pr={"number": 1}, comments=[], check_runs=runs)
+    assert "ci-green" in flags
+    assert "ci-red" not in flags
+    assert "ci-pending" not in flags
+
+
+def test_derive_flags_ci_red_when_any_failure() -> None:
+    """Any failure/cancelled/timed_out → ``ci-red`` (failure wins over pending)."""
+    runs: list[dict[str, object]] = [
+        {"conclusion": "success"},
+        {"conclusion": "failure"},
+        {"status": "in_progress", "conclusion": None},
+    ]
+    flags = _derive_flags(pr={"number": 1}, comments=[], check_runs=runs)
+    assert "ci-red" in flags
+    assert "ci-green" not in flags
+    assert "ci-pending" not in flags
+
+
+def test_derive_flags_ci_pending_when_in_progress_without_failure() -> None:
+    """Only pending + success (no failure) → ``ci-pending``."""
+    runs: list[dict[str, object]] = [
+        {"conclusion": "success"},
+        {"status": "in_progress", "conclusion": None},
+    ]
+    flags = _derive_flags(pr={"number": 1}, comments=[], check_runs=runs)
+    assert "ci-pending" in flags
+    assert "ci-red" not in flags
+    assert "ci-green" not in flags
+
+
+def test_derive_flags_no_ci_flag_when_no_check_runs() -> None:
+    """Empty check-runs list → no ci-* flag (nothing to report about CI)."""
+    flags = _derive_flags(pr={"number": 1}, comments=[], check_runs=[])
+    assert not any(f.startswith("ci-") for f in flags)
+
+
+def test_derive_flags_has_unresolved_comments_when_nonzero() -> None:
+    """Any comment present → ``has-unresolved-comments``."""
+    flags = _derive_flags(pr={"number": 1}, comments=[{"id": 1}], check_runs=[])
+    assert "has-unresolved-comments" in flags
+
+
+def test_derive_flags_no_unresolved_comments_flag_when_empty() -> None:
+    """Empty comments list → no unresolved-comments flag."""
+    flags = _derive_flags(pr={"number": 1}, comments=[], check_runs=[])
+    assert "has-unresolved-comments" not in flags
+
+
+def test_derive_flags_emits_merge_conflict_from_mergeable_state() -> None:
+    """mergeable == CONFLICTING → ``merge-conflict``; other states don't emit it."""
+    flags_conflict = _derive_flags(
+        pr={"number": 1, "mergeable": "CONFLICTING"}, comments=[], check_runs=[]
+    )
+    assert "merge-conflict" in flags_conflict
+
+    flags_clean = _derive_flags(
+        pr={"number": 1, "mergeable": "MERGEABLE"}, comments=[], check_runs=[]
+    )
+    assert "merge-conflict" not in flags_clean

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 from reachy_ducky_daemon.specialists.pr_reviewer import (
     _GH_TIMEOUT_SECONDS,
+    _fetch_check_runs,
     _fetch_diff,
     _fetch_pr_metadata,
     _fetch_review_comments,
@@ -193,3 +194,53 @@ def test_fetch_review_comments_surfaces_non_list_json_as_diagnostic(
     assert comments == []
     assert err is not None
     assert "non-list" in err.lower() or "unexpected" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# CI check-runs fetch
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_check_runs_calls_gh_api_at_head_sha(tmp_path: Path) -> None:
+    """_fetch_check_runs hits /repos/{owner}/{repo}/commits/{sha}/check-runs."""
+    fixture = _FIXTURES / "gh_api_check_runs.json"
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fixture.read_text(), stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        runs, err = _fetch_check_runs(
+            owner="Obsidian-Owl", repo="reachy-ducky", head_sha="abc123", cwd=tmp_path
+        )
+
+    assert err is None
+    assert len(runs) == 3
+    assert runs[0]["name"] == "ruff"
+    argv = m.call_args.args[0]
+    assert argv[:2] == ["gh", "api"]
+    assert "/repos/Obsidian-Owl/reachy-ducky/commits/abc123/check-runs" in argv
+
+
+def test_fetch_check_runs_unwraps_github_envelope(tmp_path: Path) -> None:
+    """GitHub wraps check-runs in ``{total_count, check_runs: [...]}`` — unwrap."""
+    envelope = '{"total_count": 1, "check_runs": [{"name": "mypy", "conclusion": "success"}]}'
+    fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout=envelope, stderr="")
+    with patch("subprocess.run", return_value=fake_proc):
+        runs, err = _fetch_check_runs(owner="o", repo="r", head_sha="sha", cwd=tmp_path)
+
+    assert err is None
+    assert runs == [{"name": "mypy", "conclusion": "success"}]
+
+
+def test_fetch_check_runs_surfaces_unexpected_shape_as_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """Missing ``check_runs`` key (unexpected shape) becomes a diagnostic."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout='{"total_count": 0}', stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        runs, err = _fetch_check_runs(owner="o", repo="r", head_sha="sha", cwd=tmp_path)
+
+    assert runs == []
+    assert err is not None
+    assert "unexpected" in err.lower() or "shape" in err.lower()

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -491,6 +491,84 @@ def test_assemble_prompt_handles_empty_optional_sections() -> None:
     assert "no check" in prompt.lower()
 
 
+def test_assemble_prompt_surfaces_diff_fetch_error() -> None:
+    """Fetch failure on the diff surfaces as a diagnostic, not silent (empty diff).
+
+    An empty diff and a failed diff fetch look identical to the brain if
+    we pass ``diff=""`` with no explanatory context — dangerous for the
+    "risk call" (brain might say "no changes so safe" on a PR whose diff
+    we couldn't read). The diagnostic kwarg lets the brain distinguish.
+    """
+    pr: dict[str, object] = {
+        "number": 1,
+        "title": "t",
+        "body": "",
+        "headRefName": "f",
+        "baseRefName": "main",
+    }
+    prompt = _assemble_prompt(
+        pr=pr,
+        diff="",
+        comments=[],
+        check_runs=[],
+        diff_error="gh pr diff 1 failed: authentication required",
+    )
+    # Diagnostic lands inside the DIFF section so the brain anchors it.
+    diff_section = prompt.split("=== DIFF ===", 1)[1].split("=== REVIEW COMMENTS ===", 1)[0]
+    assert "diagnostic" in diff_section.lower()
+    assert "authentication required" in diff_section
+
+
+def test_assemble_prompt_surfaces_comments_fetch_error() -> None:
+    """Fetch failure on review comments surfaces inside the comments section."""
+    pr: dict[str, object] = {
+        "number": 1,
+        "title": "t",
+        "body": "",
+        "headRefName": "f",
+        "baseRefName": "main",
+    }
+    prompt = _assemble_prompt(
+        pr=pr,
+        diff="",
+        comments=[],
+        check_runs=[],
+        comments_error="gh api /repos/o/r/pulls/1/comments failed: 404 Not Found",
+    )
+    comments_section = prompt.split("=== REVIEW COMMENTS ===", 1)[1].split(
+        "=== CI / CHECK RUNS ===", 1
+    )[0]
+    assert "diagnostic" in comments_section.lower()
+    assert "404 Not Found" in comments_section
+
+
+def test_assemble_prompt_surfaces_check_runs_fetch_error() -> None:
+    """Fetch failure on check-runs surfaces inside the CI section — not silent.
+
+    Silent handling is the correctness hazard Augment flagged: an
+    authentication failure on ``/commits/<sha>/check-runs`` would leave
+    ``check_runs=[]`` and ``_derive_flags`` emits no ``ci-*`` flag at
+    all — menubar shows neutral on a PR whose CI state we didn't see.
+    """
+    pr: dict[str, object] = {
+        "number": 1,
+        "title": "t",
+        "body": "",
+        "headRefName": "f",
+        "baseRefName": "main",
+    }
+    prompt = _assemble_prompt(
+        pr=pr,
+        diff="",
+        comments=[],
+        check_runs=[],
+        check_runs_error="gh api /repos/o/r/commits/abc/check-runs failed: 403",
+    )
+    ci_section = prompt.split("=== CI / CHECK RUNS ===", 1)[1].split("=== TASK ===", 1)[0]
+    assert "diagnostic" in ci_section.lower()
+    assert "403" in ci_section
+
+
 def test_assemble_diagnostic_prompt_explains_no_pr() -> None:
     """Diagnostic prompt names the branch, says no PR, asks brain to investigate."""
     prompt = _assemble_diagnostic_prompt(
@@ -692,6 +770,54 @@ async def test_review_graceful_fail_surfaces_gh_lookup_error(tmp_path: Path) -> 
     assert "no-pr-found" in response.flags
     prompt = brain.calls[0].user_utterance
     assert "authentication required" in prompt
+
+
+@pytest.mark.asyncio
+async def test_review_surfaces_diff_fetch_error_in_prompt(tmp_path: Path) -> None:
+    """Even when PR metadata fetch succeeds, a failed gh pr diff must surface.
+
+    Pins the behaviour Augment called out: fetch errors on diff/comments/
+    CI must not be silently degraded into "empty" values — the brain must
+    see the diagnostic so it can distinguish "nothing there" from
+    "couldn't see what was there."
+    """
+    pr_view = _FIXTURES / "gh_pr_view_happy.json"
+
+    side_effect = _mock_by_argv(
+        {
+            ("gh", "pr", "view"): _ok(pr_view.read_text()),
+            # Diff fetch fails — auth-shaped error from gh.
+            ("gh", "pr", "diff"): subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="authentication required"
+            ),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/pulls/42/comments",
+            ): _ok("[]"),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/commits/abc123def456/check-runs",
+            ): _ok('{"total_count": 0, "check_runs": []}'),
+        }
+    )
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with patch("subprocess.run", side_effect=side_effect):
+        await reviewer.review(pr_number=42)
+
+    prompt = brain.calls[0].user_utterance
+    assert "authentication required" in prompt, (
+        "fetch error on diff was silently swallowed — brain cannot distinguish "
+        "'no changes' from 'could not read changes'"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -1,0 +1,46 @@
+"""Tests for :class:`PRReviewer`.
+
+Follows the same shape as ``test_specialist_plan_reviewer.py`` — subprocess
+calls are mocked at the ``subprocess.run`` boundary (rather than running
+real ``gh``, which would need network + auth + a live PR). Canned ``gh``
+outputs live under ``daemon/tests/fixtures/gh_*.json``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from reachy_ducky_daemon.specialists.pr_reviewer import _GH_TIMEOUT_SECONDS, _run_gh
+
+
+def test_run_gh_invokes_list_form_with_timeout() -> None:
+    """_run_gh builds a list-form argv and passes the module-wide timeout.
+
+    Never ``shell=True``; list form prevents injection via args. The
+    timeout mirrors ``_GIT_TIMEOUT_SECONDS`` in plan_reviewer.py:68 so a
+    hanging subprocess cannot wedge the review forever.
+    """
+    fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        result = _run_gh(["pr", "view", "42"], cwd=Path("/tmp"))
+
+    assert result.stdout == "ok"
+    m.assert_called_once()
+    assert m.call_args.args[0] == ["gh", "pr", "view", "42"]
+    call_kwargs = m.call_args.kwargs
+    assert call_kwargs["cwd"] == Path("/tmp")
+    assert call_kwargs["check"] is False
+    assert call_kwargs["capture_output"] is True
+    assert call_kwargs["text"] is True
+    assert call_kwargs["timeout"] == _GH_TIMEOUT_SECONDS
+
+
+def test_gh_timeout_matches_git_timeout_precedent() -> None:
+    """_GH_TIMEOUT_SECONDS mirrors plan_reviewer's 30s git timeout.
+
+    Diverging would be surprising; anchor the value here so any future
+    raise is a deliberate edit in one place.
+    """
+    assert _GH_TIMEOUT_SECONDS == 30.0

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -8,6 +8,7 @@ outputs live under ``daemon/tests/fixtures/gh_*.json``.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
@@ -691,3 +692,55 @@ async def test_review_graceful_fail_surfaces_gh_lookup_error(tmp_path: Path) -> 
     assert "no-pr-found" in response.flags
     prompt = brain.calls[0].user_utterance
     assert "authentication required" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Integration (gated) — live Claude + real GitHub against a stable closed PR
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_pr_reviewer_live_claude(tmp_path: Path) -> None:
+    """End-to-end smoke against real Claude + real GitHub, stable closed PR #46.
+
+    Gated on ``REACHY_DUCKY_RUN_INTEGRATION=1`` — mirrors Task 2.3's
+    integration test shape (``test_plan_reviewer_live_claude``).
+    Targets ``Obsidian-Owl/reachy-ducky#46`` (closed pytest-asyncio bump;
+    won't drift). If you move this test to a different PR, pick one that
+    is closed/merged so the diff + comments surface stays deterministic.
+
+    Prereqs on the runner:
+
+    * ``gh`` CLI installed and authenticated (``GH_TOKEN`` or ``gh auth
+      login``).
+    * Claude Code CLI logged in so the Agent SDK inherits OAuth, or
+      ``ANTHROPIC_API_KEY`` set (see design doc §5).
+    """
+    if not os.environ.get("REACHY_DUCKY_RUN_INTEGRATION"):
+        pytest.skip("set REACHY_DUCKY_RUN_INTEGRATION=1 to run")
+
+    from reachy_ducky_daemon.brain.claude_sdk import ClaudeSDKBrain
+
+    # The integration target repo IS this checkout. ``gh`` infers the
+    # upstream from the remote, and ``ClaudeSDKBrain.with_tools`` scopes
+    # Read/Grep/Glob to ``cwd``.
+    repo = Path.cwd()
+    memory_root = tmp_path / "memory"
+    memory_root.mkdir()
+
+    brain = ClaudeSDKBrain.with_tools(
+        cwd=repo,
+        memory_root=memory_root,
+        github_repo="Obsidian-Owl/reachy-ducky",
+    )
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=repo,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    response = await reviewer.review(pr_number=46)
+
+    assert response.name == "pr-reviewer"
+    assert response.summary  # brain returned *something* non-empty

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -16,6 +16,7 @@ from reachy_ducky_daemon.specialists.pr_reviewer import (
     _GH_TIMEOUT_SECONDS,
     _fetch_diff,
     _fetch_pr_metadata,
+    _fetch_review_comments,
     _run_gh,
 )
 
@@ -138,3 +139,57 @@ def test_fetch_diff_surfaces_failure_as_diagnostic(tmp_path: Path) -> None:
 
     assert diff == ""
     assert err is not None and "no such PR" in err
+
+
+# ---------------------------------------------------------------------------
+# Review comments fetch
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_review_comments_calls_gh_api(tmp_path: Path) -> None:
+    """_fetch_review_comments hits /repos/{owner}/{repo}/pulls/{num}/comments."""
+    fixture = _FIXTURES / "gh_api_comments.json"
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fixture.read_text(), stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        comments, err = _fetch_review_comments(
+            owner="Obsidian-Owl", repo="reachy-ducky", pr_number=42, cwd=tmp_path
+        )
+
+    assert err is None
+    assert len(comments) == 2
+    first_user = comments[0]["user"]
+    assert isinstance(first_user, dict)
+    assert first_user["login"] == "augment-code[bot]"
+    argv = m.call_args.args[0]
+    assert argv[:2] == ["gh", "api"]
+    assert "/repos/Obsidian-Owl/reachy-ducky/pulls/42/comments" in argv
+    assert "--paginate" in argv
+
+
+def test_fetch_review_comments_empty_on_failure(tmp_path: Path) -> None:
+    """404/auth/network failures return ``([], error)`` — no exception."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="404 Not Found"
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        comments, err = _fetch_review_comments(owner="o", repo="r", pr_number=1, cwd=tmp_path)
+
+    assert comments == []
+    assert err is not None
+
+
+def test_fetch_review_comments_surfaces_non_list_json_as_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """GitHub returning a non-list (e.g. error envelope) becomes a diagnostic."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout='{"message": "API rate limit"}', stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        comments, err = _fetch_review_comments(owner="o", repo="r", pr_number=1, cwd=tmp_path)
+
+    assert comments == []
+    assert err is not None
+    assert "non-list" in err.lower() or "unexpected" in err.lower()

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -14,6 +14,8 @@ from unittest.mock import patch
 
 from reachy_ducky_daemon.specialists.pr_reviewer import (
     _GH_TIMEOUT_SECONDS,
+    _assemble_diagnostic_prompt,
+    _assemble_prompt,
     _current_branch,
     _derive_flags,
     _fetch_check_runs,
@@ -401,3 +403,107 @@ def test_derive_flags_emits_merge_conflict_from_mergeable_state() -> None:
         pr={"number": 1, "mergeable": "MERGEABLE"}, comments=[], check_runs=[]
     )
     assert "merge-conflict" not in flags_clean
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_prompt_includes_title_body_diff_comments_ci() -> None:
+    """Happy-path prompt contains PR title, body, diff, comments, CI, and directive."""
+    pr: dict[str, object] = {
+        "number": 42,
+        "title": "feat: add retry logic",
+        "body": "Closes #15. Adds exponential backoff to the upload path.",
+        "headRefName": "feat-retry",
+        "baseRefName": "main",
+        "url": "https://github.com/Obsidian-Owl/reachy-ducky/pull/42",
+    }
+    comments: list[dict[str, object]] = [
+        {
+            "user": {"login": "augment-code[bot]"},
+            "path": "src/upload.py",
+            "line": 42,
+            "body": "no jitter term on the retry",
+        }
+    ]
+    check_runs: list[dict[str, object]] = [
+        {"name": "mypy", "status": "completed", "conclusion": "success"}
+    ]
+
+    prompt = _assemble_prompt(
+        pr=pr,
+        diff="diff --git a/src/upload.py\n+x = 2\n",
+        comments=comments,
+        check_runs=check_runs,
+    )
+
+    # PR metadata anchors.
+    assert "#42" in prompt
+    assert "feat: add retry logic" in prompt
+    assert "Closes #15" in prompt
+    assert "feat-retry" in prompt
+    assert "main" in prompt
+    # Diff anchor.
+    assert "+x = 2" in prompt
+    # Comments: author login + file:line + body all present for referential precision.
+    assert "augment-code[bot]" in prompt
+    assert "src/upload.py" in prompt
+    assert "42" in prompt  # the line number (also the PR number; substring is fine)
+    assert "no jitter term" in prompt
+    # CI section: check name + conclusion.
+    assert "mypy" in prompt
+    assert "success" in prompt
+    # Stable section headers so the brain can anchor attention.
+    assert "=== PR BODY ===" in prompt
+    assert "=== DIFF ===" in prompt
+    assert "=== REVIEW COMMENTS ===" in prompt
+    assert "=== CI / CHECK RUNS ===" in prompt
+    assert "=== TASK ===" in prompt
+    # Directive anchor.
+    assert "synthes" in prompt.lower() or "digest" in prompt.lower()
+
+
+def test_assemble_prompt_handles_empty_optional_sections() -> None:
+    """Empty diff / no comments / no check-runs still produce a valid prompt."""
+    pr: dict[str, object] = {
+        "number": 1,
+        "title": "trivial",
+        "body": "",
+        "headRefName": "f",
+        "baseRefName": "main",
+    }
+    prompt = _assemble_prompt(pr=pr, diff="", comments=[], check_runs=[])
+    # Every section header is still present, with a marker explaining the emptiness.
+    assert "=== DIFF ===" in prompt
+    assert "(empty" in prompt.lower()
+    assert "=== REVIEW COMMENTS ===" in prompt
+    assert "(no line-level" in prompt.lower() or "no comments" in prompt.lower()
+    assert "=== CI / CHECK RUNS ===" in prompt
+    assert "no check" in prompt.lower()
+
+
+def test_assemble_diagnostic_prompt_explains_no_pr() -> None:
+    """Diagnostic prompt names the branch, says no PR, asks brain to investigate."""
+    prompt = _assemble_diagnostic_prompt(
+        branch="feat-orphan",
+        branch_error=None,
+        find_error=None,
+    )
+    assert "feat-orphan" in prompt
+    assert "no open pr" in prompt.lower() or "no pr" in prompt.lower()
+    # Directive asks brain to investigate with tools.
+    assert "investigate" in prompt.lower() or "check" in prompt.lower()
+    assert "=== TASK ===" in prompt
+
+
+def test_assemble_diagnostic_prompt_surfaces_sub_diagnostics() -> None:
+    """Sub-diagnostics (branch_error, find_error) show up so the brain has full context."""
+    prompt = _assemble_diagnostic_prompt(
+        branch="unknown",
+        branch_error="git rev-parse failed: fatal: not a git repository",
+        find_error="gh pr list --head unknown failed: authentication required",
+    )
+    assert "not a git repository" in prompt
+    assert "authentication required" in prompt

--- a/docs/plans/2026-04-21-reachy-ducky-design.md
+++ b/docs/plans/2026-04-21-reachy-ducky-design.md
@@ -232,7 +232,9 @@ Ship-first scope, aimed at roughly one to two weeks of focused work.
 5. **Reachy Mini app skeleton.** `VoiceInterface` with OpenAI Realtime + `fastrtc`. Wake word from community Space. Hard-mute with menu-bar indicator. On-demand conversational mode only.
 6. **Embodiment minimum:** `play_move` on state transitions (listening/thinking/muted), `look_at_image` gaze to user. No idle breathing yet; no urgent/soft-nudge tiers yet (that's phase C).
 
-**Deferred to phase B:** `fswatch`/git-ref event watcher, specialists 2–4 (`test-gap-assessor`, `scope-creep-detector`, `pr-reviewer`).
+**Deferred to phase B:** `fswatch`/git-ref event watcher, specialists `test-gap-assessor` and `scope-creep-detector`.
+
+**Landed in phase B (2026-04-23):** `pr-reviewer` — see `docs/plans/2026-04-23-pr-reviewer-specialist.md`.
 
 **Deferred to phase C:** Claude Code / Codex hooks, `agent-trace-critic`, interruption policy with severity tiers, per-project overrides.
 

--- a/docs/plans/2026-04-23-pr-reviewer-specialist.md
+++ b/docs/plans/2026-04-23-pr-reviewer-specialist.md
@@ -1,0 +1,1466 @@
+# pr-reviewer Specialist — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Ship the Phase B `pr-reviewer` specialist — a read-only, plan-aware, conversational PR digest. One layer above Augment/Codex/Claude-review: synthesizes intent ↔ diff, rolls up bot reviews, reports CI, calls risk. Not a gate; an advisor.
+
+**Architecture:** Same Pattern A shape as `PlanReviewer`. Python deterministically pre-loads context via `gh` CLI subprocess → assembles a single prompt → one `brain.query()` call → wraps text as `SpecialistResponse`. Follow-up questions route through `/brain/query`, which already has the full `mcp__github__*` + Read/Grep/Glob + gated Bash surface for live deep-dives.
+
+**Invocation model:** `SpecialistRequest.pr_number: int | None`. Resolution order:
+1. Explicit `pr_number` → fetch that PR.
+2. No `pr_number` → `git rev-parse --abbrev-ref HEAD` in project repo → `gh pr list --head <branch> --state open` → take first.
+3. No PR found → diagnostic prompt (brain uses tools to explain why no PR exists) — still returns a `SpecialistResponse`, just a different shape.
+
+**Response shape:** Reuse existing `SpecialistResponse(name, summary, flags)` — no protocol extension. `summary` carries the digest prose. `flags` carries Python-derived objective tags (`ci-green` / `ci-red` / `ci-pending`, `has-unresolved-comments`, `no-pr-found`, `merge-conflict`). Brain inferences stay in `summary` prose.
+
+**Tech Stack:**
+- Python 3.12, `uv` workspace
+- Pydantic v2 for `SpecialistRequest` extension
+- `subprocess` (list-form, `shell=False`) for `gh` CLI
+- `gh` CLI as daemon prereq (auth via `GH_TOKEN` = same PAT as `github-mcp-server`)
+- `pytest`, `pytest-asyncio`, `unittest.mock.patch` for subprocess mocking
+- FastAPI `TestClient` for route tests
+
+**Conventions used throughout:**
+- Every task follows TDD: write failing test → run it (fails with expected message) → implement minimal code → run it (passes) → commit.
+- Subprocess calls use list-form args (never `shell=True`), `check=False`, `timeout=30.0`, stderr surfaced as diagnostic.
+- All test subprocess calls are mocked at `subprocess.run` boundary; no network, no live `gh`.
+- Integration tests (`@pytest.mark.integration`) gated on `REACHY_DUCKY_RUN_INTEGRATION=1`.
+- Per-task quality gate: `uv run ruff check . && uv run ruff format --check . && uv run mypy --strict <touched-packages> && uv run pytest -q` before commit.
+- Full-branch quality gate (before pushing): `uv run ruff check . && uv run ruff format --check . && uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests && uv run pyright && uv run bandit -ll -r daemon/src app/src menubar/src protocol/src && uv run pytest -q --cov`. Coverage must stay ≥ 90%.
+
+**Reference skills:** @superpowers:test-driven-development, @superpowers:verification-before-completion
+
+**Template to mirror:** `daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py` + `daemon/tests/test_specialist_plan_reviewer.py`. Code patterns, docstring conventions, `_run_*` subprocess helper shape, `_assemble_prompt` structure, and `review()` orchestrator layout all carry over directly.
+
+**Session scope (per handoff 2026-04-22):** Don't try to finish in one session. A good pass: this plan, plus Tasks 1.1 and 1.2 (protocol extension + `_run_gh` scaffolding). Tasks 2.x–6.x carry over to future sessions via the branch + plan doc.
+
+**Deferred:** Secret redaction across specialists → tracked in #50. Not a pr-reviewer blocker; cross-specialist follow-up.
+
+---
+
+## Milestone 1 — Protocol + subprocess scaffolding
+
+### Task 1.1: Extend `SpecialistRequest` with optional `pr_number`
+
+**Files:**
+- Modify: `protocol/src/reachy_ducky_protocol/messages.py:44-47`
+- Modify: `protocol/tests/test_messages.py`
+
+**Step 1: Write the failing test**
+
+Append to `protocol/tests/test_messages.py`:
+
+```python
+def test_specialist_request_pr_number_defaults_to_none() -> None:
+    """pr_number is optional on SpecialistRequest — omission leaves it None."""
+    req = SpecialistRequest(name="pr-reviewer", project_slug="reachy-ducky")
+    assert req.pr_number is None
+
+
+def test_specialist_request_accepts_pr_number() -> None:
+    """pr_number is a plain int when supplied."""
+    req = SpecialistRequest(name="pr-reviewer", project_slug="reachy-ducky", pr_number=42)
+    assert req.pr_number == 42
+
+
+def test_specialist_request_rejects_non_int_pr_number() -> None:
+    """pr_number must be an int — strings and floats fail validation."""
+    with pytest.raises(ValidationError):
+        SpecialistRequest.model_validate(
+            {"name": "pr-reviewer", "project_slug": "reachy-ducky", "pr_number": "42"}
+        )
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest protocol/tests/test_messages.py::test_specialist_request_pr_number_defaults_to_none -v`
+Expected: FAIL with `AttributeError: 'SpecialistRequest' object has no attribute 'pr_number'` or a field-not-found Pydantic error.
+
+**Step 3: Write minimal implementation**
+
+Edit `protocol/src/reachy_ducky_protocol/messages.py` at the `SpecialistRequest` class (currently lines 44–47):
+
+```python
+class SpecialistRequest(_WireMessage):
+    name: str
+    project_slug: str
+    branch: str | None = None
+    pr_number: int | None = None
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest protocol/tests/test_messages.py -v`
+Expected: all tests PASS (the three new ones plus the existing ones).
+
+Also run the type-check:
+`uv run mypy --strict protocol/src protocol/tests`
+Expected: no new errors.
+
+**Step 5: Commit**
+
+```bash
+git add protocol/src/reachy_ducky_protocol/messages.py protocol/tests/test_messages.py
+git commit -m "feat(protocol): add optional pr_number to SpecialistRequest
+
+Non-breaking additive field — plan-reviewer ignores it; pr-reviewer
+(coming next) uses it for explicit PR targeting with branch-attached
+auto-detect as the fallback path."
+```
+
+---
+
+### Task 1.2: Create `pr_reviewer.py` skeleton with `_run_gh` helper
+
+**Files:**
+- Create: `daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py`
+- Create: `daemon/tests/test_specialist_pr_reviewer.py`
+
+**Step 1: Write the failing test**
+
+Create `daemon/tests/test_specialist_pr_reviewer.py`:
+
+```python
+"""Tests for :class:`PRReviewer`.
+
+Follows the same shape as test_specialist_plan_reviewer.py — subprocess
+calls are mocked at the ``subprocess.run`` boundary (rather than running
+real ``gh``, which would need network + auth + a live PR). All canned
+``gh`` outputs live under ``daemon/tests/fixtures/gh_*.json``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from reachy_ducky_daemon.specialists.pr_reviewer import _GH_TIMEOUT_SECONDS, _run_gh
+
+
+def test_run_gh_invokes_list_form_with_timeout() -> None:
+    """_run_gh builds a list-form argv and passes the module-wide timeout.
+
+    Never ``shell=True``; list form prevents injection via args. The
+    timeout mirrors ``_GIT_TIMEOUT_SECONDS`` in plan_reviewer.py:68.
+    """
+    fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        result = _run_gh(["pr", "view", "42"], cwd=Path("/tmp"))
+
+    assert result.stdout == "ok"
+    m.assert_called_once()
+    call_kwargs = m.call_args.kwargs
+    assert m.call_args.args[0] == ["gh", "pr", "view", "42"]
+    assert call_kwargs["cwd"] == Path("/tmp")
+    assert call_kwargs["check"] is False
+    assert call_kwargs["capture_output"] is True
+    assert call_kwargs["text"] is True
+    assert call_kwargs["timeout"] == _GH_TIMEOUT_SECONDS
+
+
+def test_gh_timeout_matches_git_timeout_precedent() -> None:
+    """_GH_TIMEOUT_SECONDS mirrors plan_reviewer's 30s git timeout.
+
+    Diverging would be surprising; anchor the value here so any future
+    raise is a deliberate edit in one place.
+    """
+    assert _GH_TIMEOUT_SECONDS == 30.0
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest daemon/tests/test_specialist_pr_reviewer.py -v`
+Expected: FAIL with `ImportError: cannot import name '_run_gh'` (module doesn't exist yet).
+
+**Step 3: Write minimal implementation**
+
+Create `daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py`:
+
+```python
+"""``PRReviewer`` — the Phase B PR-digest specialist.
+
+Pattern A (per plan_reviewer.py): Python deterministically pre-loads PR
+context via ``gh`` CLI subprocess, assembles a single prompt, dispatches
+to the brain once, wraps the reply. The brain's full tool surface
+(``mcp__github__*``, Read/Grep/Glob, gated Bash) remains available for
+follow-up questions via ``/brain/query`` but does not run inside this
+specialist.
+
+Read-only by construction: only ``gh`` subcommands that produce no side
+effects are invoked (``pr view``, ``pr diff``, ``pr list``, ``api GET``).
+The PAT the CLI uses is scoped ``repo:read + pull_requests:read +
+issues:read`` — even if an unexpected verb reached ``gh``, GitHub would
+403 it. No new PreToolUse gate at the specialist layer; see
+``docs/plans/2026-04-23-pr-reviewer-specialist.md`` for the threat model.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 — list-form read-only gh only; no shell
+from pathlib import Path
+
+__all__ = ["_GH_TIMEOUT_SECONDS", "_run_gh"]
+
+_GH_TIMEOUT_SECONDS = 30.0
+
+
+def _run_gh(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a read-only ``gh`` subcommand and return the completed process.
+
+    ``check=False`` so the caller can inspect ``returncode`` and surface
+    ``stderr`` as diagnostic context in the assembled prompt — an
+    individual ``gh`` hiccup should not abort the whole review. List-form
+    args per ``.claude/rules/python-standards.md``.
+    """
+    return subprocess.run(  # noqa: S603  # nosec B603 B607 — list form, read-only gh only; gh resolved via PATH is the intended portable behaviour
+        ["gh", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=_GH_TIMEOUT_SECONDS,
+    )
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest daemon/tests/test_specialist_pr_reviewer.py -v`
+Expected: both tests PASS.
+
+Run the type-check:
+`uv run mypy --strict daemon/src daemon/tests`
+Expected: no new errors.
+
+Run bandit to confirm the `nosec` comments are formatted correctly:
+`uv run bandit -ll -r daemon/src`
+Expected: no medium/high findings.
+
+**Step 5: Commit**
+
+```bash
+git add daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py daemon/tests/test_specialist_pr_reviewer.py
+git commit -m "feat(specialists): add pr_reviewer module with _run_gh helper
+
+Mirrors plan_reviewer's _run_git shape: list-form args, check=False,
+stderr-as-diagnostic, 30s timeout. Threat model: read-only PAT scoping
++ hardcoded verbs + no LLM in the loop = no new PreToolUse gate needed
+at the specialist layer."
+```
+
+---
+
+## Milestone 2 — GitHub data fetch helpers
+
+### Task 2.1: PR metadata fetch (`_fetch_pr_metadata`)
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py`
+- Modify: `daemon/tests/test_specialist_pr_reviewer.py`
+- Create: `daemon/tests/fixtures/gh_pr_view_happy.json`
+
+**Step 1: Write the failing test**
+
+Add to `daemon/tests/test_specialist_pr_reviewer.py`:
+
+```python
+def test_fetch_pr_metadata_parses_gh_pr_view_json(tmp_path: Path) -> None:
+    """_fetch_pr_metadata invokes `gh pr view --json ...` and returns parsed dict."""
+    fixture = Path(__file__).parent / "fixtures" / "gh_pr_view_happy.json"
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fixture.read_text(), stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        meta, err = _fetch_pr_metadata(pr_number=42, cwd=tmp_path)
+
+    assert err is None
+    assert meta["number"] == 42
+    assert meta["title"] == "feat: add retry logic"
+    assert meta["state"] == "OPEN"
+    assert meta["headRefName"] == "feat-retry"
+    # List form + --json fields.
+    argv = m.call_args.args[0]
+    assert argv[:3] == ["gh", "pr", "view"]
+    assert "42" in argv
+    assert "--json" in argv
+
+
+def test_fetch_pr_metadata_surfaces_gh_failure_as_diagnostic(tmp_path: Path) -> None:
+    """Non-zero gh exit returns (empty_dict, error_string) — no exception."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="GraphQL: Could not resolve to a PullRequest"
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        meta, err = _fetch_pr_metadata(pr_number=999999, cwd=tmp_path)
+
+    assert meta == {}
+    assert err is not None
+    assert "999999" in err or "Could not resolve" in err
+```
+
+Create `daemon/tests/fixtures/gh_pr_view_happy.json`:
+
+```json
+{
+  "number": 42,
+  "title": "feat: add retry logic",
+  "body": "Closes #15. Adds exponential backoff to the upload path.",
+  "state": "OPEN",
+  "mergeable": "MERGEABLE",
+  "author": {"login": "macattak"},
+  "headRefName": "feat-retry",
+  "baseRefName": "main",
+  "url": "https://github.com/Obsidian-Owl/reachy-ducky/pull/42",
+  "labels": [],
+  "files": [{"path": "src/upload.py", "additions": 20, "deletions": 3}],
+  "reviewDecision": "CHANGES_REQUESTED",
+  "headRefOid": "abc123def456",
+  "closingIssuesReferences": [{"number": 15, "title": "Upload flake on slow connections"}]
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest daemon/tests/test_specialist_pr_reviewer.py::test_fetch_pr_metadata_parses_gh_pr_view_json -v`
+Expected: FAIL with `ImportError: cannot import name '_fetch_pr_metadata'`.
+
+**Step 3: Write minimal implementation**
+
+Append to `daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py`:
+
+```python
+import json
+
+_PR_VIEW_FIELDS = ",".join([
+    "number",
+    "title",
+    "body",
+    "state",
+    "mergeable",
+    "author",
+    "headRefName",
+    "baseRefName",
+    "url",
+    "labels",
+    "files",
+    "reviewDecision",
+    "headRefOid",
+    "closingIssuesReferences",
+])
+
+
+def _fetch_pr_metadata(
+    pr_number: int,
+    cwd: Path,
+) -> tuple[dict[str, object], str | None]:
+    """Return ``(metadata_dict, error_string_or_None)`` for one PR.
+
+    Invokes ``gh pr view <num> --json <fields>`` and parses the JSON
+    output. On non-zero exit or malformed JSON, returns ``({}, error)``
+    so the caller can surface the diagnostic in the prompt.
+    """
+    try:
+        proc = _run_gh(
+            ["pr", "view", str(pr_number), "--json", _PR_VIEW_FIELDS],
+            cwd=cwd,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {}, f"gh pr view {pr_number} failed: {exc}"
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        return {}, f"gh pr view {pr_number} failed: {stderr}"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return {}, f"gh pr view {pr_number} emitted unparseable JSON: {exc}"
+    if not isinstance(parsed, dict):
+        return {}, f"gh pr view {pr_number} returned non-object JSON"
+    return parsed, None
+```
+
+Add `_fetch_pr_metadata` and `_PR_VIEW_FIELDS` to `__all__`.
+
+**Step 4: Run tests**
+
+`uv run pytest daemon/tests/test_specialist_pr_reviewer.py -v`
+Expected: all PASS.
+
+`uv run mypy --strict daemon/src daemon/tests`
+Expected: clean.
+
+**Step 5: Commit**
+
+```bash
+git add daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py daemon/tests/test_specialist_pr_reviewer.py daemon/tests/fixtures/gh_pr_view_happy.json
+git commit -m "feat(specialists/pr-reviewer): fetch PR metadata via gh pr view --json
+
+One call covers title, body, state, mergeable, head/base branches, files,
+linked issues, CI decision, and head SHA. Non-zero exit surfaces as a
+diagnostic string (mirrors plan_reviewer's error-as-data pattern)."
+```
+
+---
+
+### Task 2.2: Diff fetch (`_fetch_diff`)
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py`
+- Modify: `daemon/tests/test_specialist_pr_reviewer.py`
+
+**Step 1: Failing test**
+
+```python
+def test_fetch_diff_invokes_gh_pr_diff(tmp_path: Path) -> None:
+    """_fetch_diff runs `gh pr diff <num>` and returns (stdout, None) on success."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="diff --git a/src/x.py b/src/x.py\n+x = 2\n", stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        diff, err = _fetch_diff(pr_number=42, cwd=tmp_path)
+
+    assert err is None
+    assert "+x = 2" in diff
+    assert m.call_args.args[0] == ["gh", "pr", "diff", "42"]
+
+
+def test_fetch_diff_surfaces_failure_as_diagnostic(tmp_path: Path) -> None:
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="no such PR"
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        diff, err = _fetch_diff(pr_number=42, cwd=tmp_path)
+
+    assert diff == ""
+    assert err is not None and "no such PR" in err
+```
+
+**Step 2:** Run test — expect `ImportError`.
+
+**Step 3:** Implement:
+
+```python
+def _fetch_diff(pr_number: int, cwd: Path) -> tuple[str, str | None]:
+    """Return ``(diff_text, error_or_None)`` from ``gh pr diff``."""
+    try:
+        proc = _run_gh(["pr", "diff", str(pr_number)], cwd=cwd)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "", f"gh pr diff {pr_number} failed: {exc}"
+    if proc.returncode != 0:
+        return "", f"gh pr diff {pr_number} failed: {proc.stderr.strip() or 'non-zero exit'}"
+    return proc.stdout, None
+```
+
+**Step 4:** Run tests — expect PASS. Run mypy — expect clean.
+
+**Step 5:** Commit:
+
+```bash
+git commit -m "feat(specialists/pr-reviewer): fetch raw diff via gh pr diff"
+```
+
+---
+
+### Task 2.3: Review comments fetch (`_fetch_review_comments`)
+
+**Files:** same two modules + `daemon/tests/fixtures/gh_api_comments.json`.
+
+**Step 1: Failing test**
+
+```python
+def test_fetch_review_comments_calls_gh_api(tmp_path: Path) -> None:
+    """_fetch_review_comments hits /repos/{owner}/{repo}/pulls/{num}/comments via gh api."""
+    fixture = Path(__file__).parent / "fixtures" / "gh_api_comments.json"
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fixture.read_text(), stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        comments, err = _fetch_review_comments(
+            owner="Obsidian-Owl", repo="reachy-ducky", pr_number=42, cwd=tmp_path
+        )
+
+    assert err is None
+    assert len(comments) == 2
+    assert comments[0]["user"]["login"] == "augment-code[bot]"
+    argv = m.call_args.args[0]
+    assert argv[:3] == ["gh", "api"]
+    assert "/repos/Obsidian-Owl/reachy-ducky/pulls/42/comments" in argv
+
+
+def test_fetch_review_comments_empty_on_failure(tmp_path: Path) -> None:
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="404 Not Found"
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        comments, err = _fetch_review_comments(
+            owner="o", repo="r", pr_number=1, cwd=tmp_path
+        )
+
+    assert comments == []
+    assert err is not None
+```
+
+Create `daemon/tests/fixtures/gh_api_comments.json`:
+
+```json
+[
+  {
+    "id": 1,
+    "user": {"login": "augment-code[bot]"},
+    "path": "src/upload.py",
+    "line": 42,
+    "body": "This retry loop lacks a jitter term — will synchronize on multi-client failures."
+  },
+  {
+    "id": 2,
+    "user": {"login": "codex[bot]"},
+    "path": "src/auth.py",
+    "line": 7,
+    "body": "Potential timing-attack surface on the comparison."
+  }
+]
+```
+
+**Step 2:** Run test — expect `ImportError`.
+
+**Step 3:** Implement:
+
+```python
+def _fetch_review_comments(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    cwd: Path,
+) -> tuple[list[dict[str, object]], str | None]:
+    """Return ``(comments_list, error_or_None)`` from gh api.
+
+    Comments are line-level review comments — the surface Augment and
+    Codex bots post into. Issue-style PR comments live at a different
+    endpoint and are intentionally not fetched here (digest focuses on
+    line-level critique, not general PR chatter).
+    """
+    endpoint = f"/repos/{owner}/{repo}/pulls/{pr_number}/comments"
+    try:
+        proc = _run_gh(["api", endpoint, "--paginate"], cwd=cwd)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return [], f"gh api {endpoint} failed: {exc}"
+    if proc.returncode != 0:
+        return [], f"gh api {endpoint} failed: {proc.stderr.strip() or 'non-zero exit'}"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return [], f"gh api {endpoint} emitted unparseable JSON: {exc}"
+    if not isinstance(parsed, list):
+        return [], f"gh api {endpoint} returned non-list JSON"
+    return parsed, None
+```
+
+**Step 4:** Run tests — expect PASS.
+
+**Step 5:** Commit:
+
+```bash
+git commit -m "feat(specialists/pr-reviewer): fetch line-level review comments via gh api"
+```
+
+---
+
+### Task 2.4: CI check-runs fetch (`_fetch_check_runs`)
+
+**Files:** same two modules + `daemon/tests/fixtures/gh_api_check_runs.json`.
+
+**Step 1: Failing test**
+
+```python
+def test_fetch_check_runs_calls_gh_api_at_head_sha(tmp_path: Path) -> None:
+    fixture = Path(__file__).parent / "fixtures" / "gh_api_check_runs.json"
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fixture.read_text(), stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        runs, err = _fetch_check_runs(
+            owner="Obsidian-Owl", repo="reachy-ducky", head_sha="abc123", cwd=tmp_path
+        )
+
+    assert err is None
+    assert len(runs) == 3
+    argv = m.call_args.args[0]
+    assert argv[:3] == ["gh", "api"]
+    assert "/repos/Obsidian-Owl/reachy-ducky/commits/abc123/check-runs" in argv
+
+
+def test_fetch_check_runs_unwraps_github_envelope(tmp_path: Path) -> None:
+    """GitHub returns {total_count, check_runs: [...]} — function returns the list."""
+    envelope = '{"total_count": 1, "check_runs": [{"name": "mypy", "conclusion": "success"}]}'
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=envelope, stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        runs, err = _fetch_check_runs(
+            owner="o", repo="r", head_sha="sha", cwd=tmp_path
+        )
+
+    assert err is None
+    assert runs == [{"name": "mypy", "conclusion": "success"}]
+```
+
+Create `daemon/tests/fixtures/gh_api_check_runs.json`:
+
+```json
+{
+  "total_count": 3,
+  "check_runs": [
+    {"name": "ruff", "status": "completed", "conclusion": "success"},
+    {"name": "mypy", "status": "completed", "conclusion": "failure"},
+    {"name": "pytest", "status": "in_progress", "conclusion": null}
+  ]
+}
+```
+
+**Step 2:** Run test — expect `ImportError`.
+
+**Step 3:** Implement:
+
+```python
+def _fetch_check_runs(
+    owner: str,
+    repo: str,
+    head_sha: str,
+    cwd: Path,
+) -> tuple[list[dict[str, object]], str | None]:
+    """Return ``(check_runs_list, error_or_None)`` for the PR's head commit.
+
+    GitHub wraps check-runs in ``{total_count, check_runs: [...]}``; we
+    unwrap to the list for caller convenience.
+    """
+    endpoint = f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs"
+    try:
+        proc = _run_gh(["api", endpoint], cwd=cwd)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return [], f"gh api {endpoint} failed: {exc}"
+    if proc.returncode != 0:
+        return [], f"gh api {endpoint} failed: {proc.stderr.strip() or 'non-zero exit'}"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return [], f"gh api {endpoint} emitted unparseable JSON: {exc}"
+    if not isinstance(parsed, dict) or "check_runs" not in parsed:
+        return [], f"gh api {endpoint} returned unexpected shape"
+    runs = parsed["check_runs"]
+    if not isinstance(runs, list):
+        return [], f"gh api {endpoint} returned check_runs of wrong type"
+    return runs, None
+```
+
+**Step 4–5:** Run tests, commit:
+
+```bash
+git commit -m "feat(specialists/pr-reviewer): fetch CI check-runs for PR head SHA"
+```
+
+---
+
+### Task 2.5: Auto-detect — current branch + find-PR-for-branch
+
+**Files:** same two modules.
+
+**Step 1: Failing tests**
+
+```python
+def test_current_branch_reads_rev_parse(tmp_path: Path) -> None:
+    """_current_branch shells `git rev-parse --abbrev-ref HEAD`."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="feat-retry\n", stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        branch, err = _current_branch(tmp_path)
+
+    assert branch == "feat-retry"
+    assert err is None
+    assert m.call_args.args[0] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+
+
+def test_find_pr_for_branch_picks_first_open(tmp_path: Path) -> None:
+    """_find_pr_for_branch returns the first open PR number for the given branch."""
+    stdout = '[{"number": 42, "state": "OPEN"}]'
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=stdout, stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc) as m:
+        pr_number, err = _find_pr_for_branch(branch="feat-retry", cwd=tmp_path)
+
+    assert pr_number == 42
+    assert err is None
+    argv = m.call_args.args[0]
+    assert argv[:3] == ["gh", "pr", "list"]
+    assert "--head" in argv
+    assert "feat-retry" in argv
+
+
+def test_find_pr_for_branch_none_when_no_pr(tmp_path: Path) -> None:
+    """Empty gh output → (None, None) — not an error, just no PR attached."""
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="[]", stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_proc):
+        pr_number, err = _find_pr_for_branch(branch="feat-retry", cwd=tmp_path)
+
+    assert pr_number is None
+    assert err is None
+```
+
+**Step 2:** Run tests — expect `ImportError` for the two new symbols.
+
+**Step 3: Implementation**
+
+```python
+def _current_branch(cwd: Path) -> tuple[str, str | None]:
+    """Return ``(branch_name, error_or_None)`` for the checkout at ``cwd``.
+
+    Mirrors plan_reviewer._current_branch (plan_reviewer.py:89). Kept
+    duplicated rather than factored out because the two specialists
+    should not import private helpers from each other — if a third
+    specialist needs it, promote to ``specialists/_subprocess.py``.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603  # nosec B603 B607
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "unknown", f"git rev-parse failed: {exc}"
+    if proc.returncode != 0:
+        return "unknown", f"git rev-parse failed: {proc.stderr.strip() or 'non-zero exit'}"
+    return proc.stdout.strip() or "unknown", None
+
+
+def _find_pr_for_branch(
+    branch: str,
+    cwd: Path,
+) -> tuple[int | None, str | None]:
+    """Return ``(pr_number_or_None, error_or_None)`` for the branch's open PR.
+
+    Uses ``gh pr list --head <branch> --state open --json number`` — so
+    the repo context is inferred from ``cwd``'s upstream remote (the
+    same way ``gh pr view`` infers it). Picks the first result if
+    multiple open PRs share the head ref.
+    """
+    try:
+        proc = _run_gh(
+            ["pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+            cwd=cwd,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"gh pr list --head {branch} failed: {exc}"
+    if proc.returncode != 0:
+        return None, f"gh pr list --head {branch} failed: {proc.stderr.strip() or 'non-zero exit'}"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return None, f"gh pr list emitted unparseable JSON: {exc}"
+    if not isinstance(parsed, list) or not parsed:
+        return None, None
+    first = parsed[0]
+    if not isinstance(first, dict) or "number" not in first:
+        return None, "gh pr list returned unexpected shape"
+    number = first["number"]
+    if not isinstance(number, int):
+        return None, "gh pr list returned non-int PR number"
+    return number, None
+```
+
+**Step 4–5:** Run tests, commit:
+
+```bash
+git commit -m "feat(specialists/pr-reviewer): auto-detect PR from current branch
+
+Adds _current_branch + _find_pr_for_branch. Resolution order in the
+orchestrator: explicit pr_number > auto-detect from HEAD > graceful
+diagnostic prompt (next task)."
+```
+
+---
+
+## Milestone 3 — Flag derivation + prompt assembly
+
+### Task 3.1: Flag derivation (`_derive_flags`)
+
+**Files:** same two modules.
+
+**Step 1: Failing tests**
+
+```python
+def test_derive_flags_emits_ci_status_from_check_runs() -> None:
+    """ci-green when all check-runs succeed; ci-red if any fails; ci-pending if any in_progress."""
+    all_green = [{"conclusion": "success"}, {"conclusion": "success"}]
+    assert "ci-green" in _derive_flags(pr={}, comments=[], check_runs=all_green)
+
+    has_red = [{"conclusion": "success"}, {"conclusion": "failure"}]
+    assert "ci-red" in _derive_flags(pr={}, comments=[], check_runs=has_red)
+
+    has_pending = [{"conclusion": "success"}, {"status": "in_progress", "conclusion": None}]
+    assert "ci-pending" in _derive_flags(pr={}, comments=[], check_runs=has_pending)
+
+
+def test_derive_flags_emits_has_unresolved_comments_when_nonzero() -> None:
+    assert "has-unresolved-comments" in _derive_flags(
+        pr={}, comments=[{"id": 1}], check_runs=[]
+    )
+    assert "has-unresolved-comments" not in _derive_flags(
+        pr={}, comments=[], check_runs=[]
+    )
+
+
+def test_derive_flags_emits_merge_conflict_from_mergeable_state() -> None:
+    assert "merge-conflict" in _derive_flags(
+        pr={"mergeable": "CONFLICTING"}, comments=[], check_runs=[]
+    )
+    assert "merge-conflict" not in _derive_flags(
+        pr={"mergeable": "MERGEABLE"}, comments=[], check_runs=[]
+    )
+
+
+def test_derive_flags_emits_no_pr_found_when_pr_dict_empty() -> None:
+    assert "no-pr-found" in _derive_flags(pr={}, comments=[], check_runs=[])
+    assert "no-pr-found" not in _derive_flags(
+        pr={"number": 42}, comments=[], check_runs=[]
+    )
+```
+
+**Step 2:** Run tests — `ImportError`.
+
+**Step 3: Implementation**
+
+```python
+def _derive_flags(
+    pr: dict[str, object],
+    comments: list[dict[str, object]],
+    check_runs: list[dict[str, object]],
+) -> list[str]:
+    """Compute objective machine-tags from pre-fetched data.
+
+    Deliberately *does not* emit risk-inference flags (``risk:scope-creep``,
+    ``recommend:push-fix``) — those live in the brain's summary prose.
+    Flags here are derivable without an LLM, stay stable across brain
+    output evolution, and are safe for the menu-bar app to branch on.
+    """
+    flags: list[str] = []
+
+    if not pr:
+        flags.append("no-pr-found")
+        return flags
+
+    if any(
+        (isinstance(r, dict) and r.get("status") == "in_progress")
+        or (isinstance(r, dict) and r.get("conclusion") is None and r.get("status") != "completed")
+        for r in check_runs
+    ):
+        flags.append("ci-pending")
+    elif any(
+        isinstance(r, dict) and r.get("conclusion") in {"failure", "cancelled", "timed_out"}
+        for r in check_runs
+    ):
+        flags.append("ci-red")
+    elif check_runs:
+        flags.append("ci-green")
+
+    if comments:
+        flags.append("has-unresolved-comments")
+
+    if pr.get("mergeable") == "CONFLICTING":
+        flags.append("merge-conflict")
+
+    return flags
+```
+
+**Step 4–5:** Run tests, commit:
+
+```bash
+git commit -m "feat(specialists/pr-reviewer): derive objective flags from prefetched data
+
+Flags: ci-green/red/pending, has-unresolved-comments, merge-conflict,
+no-pr-found. Risk inferences (scope-creep, recommend-*) stay in summary
+prose — flags are for deterministic downstream consumers (menu bar,
+phase-C interruption tiers)."
+```
+
+---
+
+### Task 3.2: Prompt assembly (happy + diagnostic paths)
+
+**Files:** same two modules.
+
+**Step 1: Failing tests**
+
+```python
+def test_assemble_prompt_includes_title_body_diff_comments_ci() -> None:
+    prompt = _assemble_prompt(
+        pr={
+            "number": 42,
+            "title": "feat: add retry logic",
+            "body": "Closes #15.",
+            "headRefName": "feat-retry",
+            "baseRefName": "main",
+            "url": "https://github.com/Obsidian-Owl/reachy-ducky/pull/42",
+        },
+        diff="diff --git a/src/x.py\n+x = 2\n",
+        comments=[
+            {
+                "user": {"login": "augment-code[bot]"},
+                "path": "src/x.py",
+                "line": 2,
+                "body": "no jitter",
+            }
+        ],
+        check_runs=[{"name": "mypy", "conclusion": "success"}],
+        plan_context="=== PLAN ===\nPlan says Y\n",
+    )
+    assert "feat: add retry logic" in prompt
+    assert "Closes #15" in prompt
+    assert "+x = 2" in prompt
+    assert "augment-code[bot]" in prompt
+    assert "no jitter" in prompt
+    assert "mypy" in prompt
+    assert "Plan says Y" in prompt
+    # Directive is the contract — substring anchor only.
+    assert "Synthesize" in prompt or "digest" in prompt.lower()
+
+
+def test_assemble_diagnostic_prompt_explains_no_pr() -> None:
+    prompt = _assemble_diagnostic_prompt(
+        branch="feat-retry",
+        branch_error=None,
+        find_error=None,
+    )
+    assert "feat-retry" in prompt
+    assert "no open PR" in prompt.lower() or "no PR" in prompt.lower()
+    # Directive asks the brain to investigate with tools.
+    assert "investigate" in prompt.lower() or "check" in prompt.lower()
+```
+
+**Step 2:** Run — `ImportError`.
+
+**Step 3: Implementation**
+
+```python
+_DIRECTIVE = (
+    "Synthesize a short PR digest for the developer. Be terse and referentially "
+    "precise (file paths + line numbers, bot names, CI job names). Cover: "
+    "(1) does the diff match the PR body / linked issues, (2) which bot "
+    "comments are legit vs noisy, (3) CI & merge-readiness, (4) your risk call "
+    "(safe to merge / push a fix / split). Do not re-review the diff line by "
+    "line — Augment and Codex already did. You are the synthesis layer."
+)
+
+_DIAGNOSTIC_DIRECTIVE = (
+    "No open PR was found for this branch. Use mcp__github__list_pull_requests "
+    "(including state=all), git log / git show, and git status to investigate. "
+    "Was there a merged or closed PR? Is the branch even pushed to the remote? "
+    "Are we actually checked out on the branch the user thinks? Return a short, "
+    "actionable explanation — not an apology."
+)
+
+
+def _assemble_prompt(
+    pr: dict[str, object],
+    diff: str,
+    comments: list[dict[str, object]],
+    check_runs: list[dict[str, object]],
+    plan_context: str = "",
+) -> str:
+    """Build the review prompt. Mirrors plan_reviewer._assemble_prompt shape."""
+    parts: list[str] = []
+    parts.append(f"PR #{pr.get('number')}: {pr.get('title', '(no title)')}")
+    parts.append(f"Branch: {pr.get('headRefName')} → {pr.get('baseRefName')}")
+    url = pr.get("url")
+    if url:
+        parts.append(f"URL: {url}")
+    parts.append("")
+
+    parts.append("=== PR BODY ===")
+    parts.append(str(pr.get("body") or "(empty)"))
+    parts.append("")
+
+    if plan_context:
+        parts.append(plan_context)
+        parts.append("")
+
+    parts.append("=== DIFF ===")
+    parts.append(diff if diff.strip() else "(empty diff)")
+    parts.append("")
+
+    parts.append("=== REVIEW COMMENTS ===")
+    if not comments:
+        parts.append("(no line-level review comments)")
+    else:
+        for c in comments:
+            user = c.get("user", {})
+            login = user.get("login", "unknown") if isinstance(user, dict) else "unknown"
+            path = c.get("path", "?")
+            line = c.get("line", "?")
+            body = c.get("body", "")
+            parts.append(f"--- {login} on {path}:{line} ---")
+            parts.append(str(body))
+    parts.append("")
+
+    parts.append("=== CI / CHECK RUNS ===")
+    if not check_runs:
+        parts.append("(no check runs)")
+    else:
+        for r in check_runs:
+            name = r.get("name", "?")
+            status = r.get("status", "?")
+            conclusion = r.get("conclusion", "?")
+            parts.append(f"- {name}: {status} / {conclusion}")
+    parts.append("")
+
+    parts.append("=== TASK ===")
+    parts.append(_DIRECTIVE)
+    return "\n".join(parts)
+
+
+def _assemble_diagnostic_prompt(
+    branch: str,
+    branch_error: str | None,
+    find_error: str | None,
+) -> str:
+    """Build a diagnostic-shaped prompt when no PR was resolvable.
+
+    Brain is expected to dig with its tool surface and explain *why*
+    there's no PR rather than produce a review of nothing.
+    """
+    parts = [f"Branch: {branch}"]
+    if branch_error is not None:
+        parts.append(f"(branch diagnostic: {branch_error})")
+    if find_error is not None:
+        parts.append(f"(lookup diagnostic: {find_error})")
+    parts.append("")
+    parts.append(f"No open PR was found for branch '{branch}'.")
+    parts.append("")
+    parts.append("=== TASK ===")
+    parts.append(_DIAGNOSTIC_DIRECTIVE)
+    return "\n".join(parts)
+```
+
+**Step 4–5:** Run tests, commit:
+
+```bash
+git commit -m "feat(specialists/pr-reviewer): assemble happy-path + diagnostic prompts
+
+Happy path: PR metadata + PR body + diff + review comments + CI + optional
+plan context + synthesis directive.
+Diagnostic path (no-PR-found): branch + diagnostics + tool-investigation
+directive. Mirrors plan_reviewer._assemble_prompt shape with stable section
+headers for attention anchors."
+```
+
+---
+
+## Milestone 4 — Orchestrator
+
+### Task 4.1: `PRReviewer` class with `review(pr_number=None)`
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py`
+- Modify: `daemon/tests/test_specialist_pr_reviewer.py`
+
+**Step 1: Failing tests**
+
+End-to-end tests with the full subprocess.run surface mocked and a `MockBrain`. Exercise all three paths:
+
+```python
+import pytest
+from reachy_ducky_daemon.brain.mock import MockBrain
+from reachy_ducky_daemon.specialists.pr_reviewer import PRReviewer
+from reachy_ducky_protocol.messages import SpecialistResponse
+
+
+def _mock_gh_and_git(returns: dict[tuple[str, ...], subprocess.CompletedProcess[str]]):
+    """Build a side_effect that dispatches to canned CompletedProcess values by argv."""
+    def _side_effect(argv, *args, **kwargs):
+        key = tuple(argv)
+        for pat, proc in returns.items():
+            if key[: len(pat)] == pat:
+                return proc
+        raise AssertionError(f"unexpected argv: {argv}")
+    return _side_effect
+
+
+@pytest.mark.asyncio
+async def test_review_explicit_pr_number_happy_path(tmp_path: Path) -> None:
+    pr_view = Path(__file__).parent / "fixtures" / "gh_pr_view_happy.json"
+    comments = Path(__file__).parent / "fixtures" / "gh_api_comments.json"
+    check_runs = Path(__file__).parent / "fixtures" / "gh_api_check_runs.json"
+    ok = lambda stdout: subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    side_effect = _mock_gh_and_git({
+        ("gh", "pr", "view"): ok(pr_view.read_text()),
+        ("gh", "pr", "diff"): ok("diff --git a/x.py\n+x = 2\n"),
+        ("gh", "api", "/repos/Obsidian-Owl/reachy-ducky/pulls/42/comments"): ok(comments.read_text()),
+        ("gh", "api", "/repos/Obsidian-Owl/reachy-ducky/commits/abc123def456/check-runs"): ok(check_runs.read_text()),
+    })
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with patch("subprocess.run", side_effect=side_effect):
+        response = await reviewer.review(pr_number=42)
+
+    assert isinstance(response, SpecialistResponse)
+    assert response.name == "pr-reviewer"
+    assert len(brain.calls) == 1
+    prompt = brain.calls[0].user_utterance
+    assert "feat: add retry logic" in prompt
+    assert "+x = 2" in prompt
+    assert "augment-code[bot]" in prompt
+    # Objective flags flow through deterministically.
+    assert "ci-red" in response.flags  # mypy failure in fixture
+    assert "has-unresolved-comments" in response.flags
+
+
+@pytest.mark.asyncio
+async def test_review_auto_detect_from_current_branch(tmp_path: Path) -> None:
+    ok = lambda stdout: subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+    pr_view = Path(__file__).parent / "fixtures" / "gh_pr_view_happy.json"
+
+    side_effect = _mock_gh_and_git({
+        ("git", "rev-parse"): ok("feat-retry\n"),
+        ("gh", "pr", "list"): ok('[{"number": 42}]'),
+        ("gh", "pr", "view"): ok(pr_view.read_text()),
+        ("gh", "pr", "diff"): ok(""),
+        ("gh", "api"): ok("[]"),  # both comments + check_runs
+    })
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain, repo=tmp_path, owner="Obsidian-Owl", repo_name="reachy-ducky"
+    )
+    with patch("subprocess.run", side_effect=side_effect):
+        response = await reviewer.review(pr_number=None)
+
+    assert response.name == "pr-reviewer"
+    assert len(brain.calls) == 1
+    assert "feat: add retry logic" in brain.calls[0].user_utterance
+
+
+@pytest.mark.asyncio
+async def test_review_graceful_fail_when_no_pr_for_branch(tmp_path: Path) -> None:
+    ok = lambda stdout: subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    side_effect = _mock_gh_and_git({
+        ("git", "rev-parse"): ok("feat-orphan\n"),
+        ("gh", "pr", "list"): ok("[]"),
+    })
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain, repo=tmp_path, owner="Obsidian-Owl", repo_name="reachy-ducky"
+    )
+    with patch("subprocess.run", side_effect=side_effect):
+        response = await reviewer.review(pr_number=None)
+
+    assert response.name == "pr-reviewer"
+    assert "no-pr-found" in response.flags
+    assert len(brain.calls) == 1
+    prompt = brain.calls[0].user_utterance
+    assert "feat-orphan" in prompt
+    assert "no open pr" in prompt.lower() or "no pr" in prompt.lower()
+```
+
+**Step 2:** Run — `ImportError: cannot import name 'PRReviewer'`.
+
+**Step 3: Implementation**
+
+```python
+from reachy_ducky_protocol.messages import BrainRequest, SpecialistResponse
+
+from reachy_ducky_daemon.brain.interface import BrainInterface
+
+_SPECIALIST_NAME = "pr-reviewer"
+
+
+class PRReviewer:
+    """Hybrid specialist: pre-load PR surfaces + brain digest.
+
+    Matches the ``PlanReviewer`` shape — deterministic pre-fetch in
+    Python, one ``brain.query()`` call, wrap the reply. Owner/repo are
+    passed explicitly (the caller already holds per-project
+    ``github_repo`` config); parsing ``<owner>/<repo>`` from the wire
+    would duplicate that concern.
+    """
+
+    def __init__(
+        self,
+        *,
+        brain: BrainInterface,
+        repo: Path,
+        owner: str,
+        repo_name: str,
+    ) -> None:
+        self._brain = brain
+        self._repo = repo
+        self._owner = owner
+        self._repo_name = repo_name
+
+    async def review(self, *, pr_number: int | None = None) -> SpecialistResponse:
+        resolved_pr, branch, branch_err, find_err = self._resolve_pr(pr_number)
+
+        if resolved_pr is None:
+            prompt = _assemble_diagnostic_prompt(
+                branch=branch, branch_error=branch_err, find_error=find_err
+            )
+            flags = _derive_flags(pr={}, comments=[], check_runs=[])
+            response = await self._brain.query(BrainRequest(user_utterance=prompt))
+            return SpecialistResponse(
+                name=_SPECIALIST_NAME, summary=response.text, flags=flags
+            )
+
+        pr_meta, _meta_err = _fetch_pr_metadata(resolved_pr, cwd=self._repo)
+        diff, _diff_err = _fetch_diff(resolved_pr, cwd=self._repo)
+        comments, _c_err = _fetch_review_comments(
+            owner=self._owner, repo=self._repo_name,
+            pr_number=resolved_pr, cwd=self._repo,
+        )
+        head_sha = pr_meta.get("headRefOid")
+        if isinstance(head_sha, str):
+            check_runs, _ci_err = _fetch_check_runs(
+                owner=self._owner, repo=self._repo_name,
+                head_sha=head_sha, cwd=self._repo,
+            )
+        else:
+            check_runs = []
+
+        prompt = _assemble_prompt(
+            pr=pr_meta, diff=diff, comments=comments, check_runs=check_runs
+        )
+        flags = _derive_flags(pr=pr_meta, comments=comments, check_runs=check_runs)
+        response = await self._brain.query(BrainRequest(user_utterance=prompt))
+        return SpecialistResponse(
+            name=_SPECIALIST_NAME, summary=response.text, flags=flags
+        )
+
+    def _resolve_pr(
+        self,
+        pr_number: int | None,
+    ) -> tuple[int | None, str, str | None, str | None]:
+        """Return ``(pr, branch, branch_err, find_err)``.
+
+        Explicit ``pr_number`` short-circuits the lookup. Otherwise:
+        read HEAD branch, then ``gh pr list --head``. Missing PR is a
+        graceful ``None`` — not an error.
+        """
+        if pr_number is not None:
+            return pr_number, "(explicit)", None, None
+
+        branch, branch_err = _current_branch(self._repo)
+        if branch_err is not None:
+            return None, branch, branch_err, None
+
+        pr, find_err = _find_pr_for_branch(branch=branch, cwd=self._repo)
+        return pr, branch, None, find_err
+```
+
+Export `PRReviewer` in `__all__`.
+
+**Step 4–5:** Run tests, commit:
+
+```bash
+git commit -m "feat(specialists): PRReviewer orchestrator with three-path resolution
+
+Paths: explicit pr_number > auto-detect from current branch > diagnostic
+prompt when no open PR found. One brain.query() per call regardless of
+path. Matches PlanReviewer's shape and invocation contract."
+```
+
+---
+
+## Milestone 5 — Server + client wiring
+
+### Task 5.1: `POST /specialists/pr-reviewer` route
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/server.py` (add route + import, after line 130)
+- Modify: `daemon/tests/test_server_specialists.py`
+- Modify: `daemon/src/reachy_ducky_daemon/project.py` (add `github_repo` accessor if not already owner/name-split)
+
+**Pre-check:** read `daemon/src/reachy_ducky_daemon/project.py` and confirm `Project.github_repo` is `"<owner>/<repo>"` or similar. If parsing is needed, this task includes a small `_split_github_repo(repo: str) -> tuple[str, str]` helper + its own tests.
+
+**Step 1: Failing tests**
+
+```python
+def test_pr_reviewer_endpoint_explicit_pr_number(tmp_path: Path) -> None:
+    # ... mirror test_plan_reviewer_endpoint shape, POST
+    #     /specialists/pr-reviewer with {"name": "pr-reviewer",
+    #     "project_slug": "repo", "pr_number": 42}, mock subprocess for
+    #     all gh/git calls, assert 200 + body["name"] == "pr-reviewer".
+
+
+def test_pr_reviewer_endpoint_auto_detect(tmp_path: Path) -> None:
+    # Same but no pr_number — mock git rev-parse + gh pr list.
+
+
+def test_pr_reviewer_endpoint_unknown_slug_returns_404(tmp_path: Path) -> None:
+    ...
+
+
+def test_pr_reviewer_endpoint_response_shape(tmp_path: Path) -> None:
+    # Shape: {name, summary, flags}. Same as plan_reviewer's response-shape test.
+
+
+def test_pr_reviewer_endpoint_invokes_brain_once(tmp_path: Path) -> None:
+    ...
+
+
+def test_pr_reviewer_endpoint_project_without_github_repo_returns_400(tmp_path: Path) -> None:
+    """A project with github_repo=None can't do PR review — 400 with a useful detail."""
+    ...
+```
+
+**Step 2:** Run — route doesn't exist → 404.
+
+**Step 3: Implementation** in `server.py` after the plan_reviewer route:
+
+```python
+from .specialists.pr_reviewer import PRReviewer
+
+@app.post("/specialists/pr-reviewer", response_model=SpecialistResponse)
+async def pr_reviewer_route(req: SpecialistRequest) -> SpecialistResponse:
+    try:
+        brain = registry.brain_for(req.project_slug)
+        repo = registry.path_for(req.project_slug)
+        project = registry.project_for(req.project_slug)  # add accessor if missing
+    except KeyError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown project: {req.project_slug}",
+        ) from None
+    if not project.github_repo:
+        raise HTTPException(
+            status_code=400,
+            detail=f"project '{req.project_slug}' has no github_repo configured",
+        )
+    owner, repo_name = project.github_repo.split("/", 1)
+    return await PRReviewer(
+        brain=brain, repo=repo, owner=owner, repo_name=repo_name,
+    ).review(pr_number=req.pr_number)
+```
+
+**Step 4–5:** Run tests, commit:
+
+```bash
+git commit -m "feat(server): POST /specialists/pr-reviewer route
+
+Resolves project → repo path + owner/repo from config → PRReviewer.
+400 when the project has no github_repo configured; 404 for unknown
+slugs; 200 for happy + graceful-fail paths."
+```
+
+---
+
+### Task 5.2: `DaemonClient.pr_reviewer(...)` method
+
+**Files:**
+- Modify: `app/src/reachy_ducky_app/daemon_client.py` (after line 125)
+- Modify: `app/tests/test_daemon_client.py`
+
+**Step 1–5** parallel to plan_reviewer's client pattern (lines 110–125). Method signature:
+
+```python
+async def pr_reviewer(
+    self,
+    *,
+    project_slug: str,
+    pr_number: int | None = None,
+) -> SpecialistResponse:
+    """POST ``/specialists/pr-reviewer`` and get a PR review envelope."""
+    req = SpecialistRequest(
+        name="pr-reviewer", project_slug=project_slug, pr_number=pr_number,
+    )
+    r = await self._http.post(
+        f"{self._base}/specialists/pr-reviewer",
+        json=req.model_dump(),
+        headers=self._headers(),
+        timeout=120.0,
+    )
+    r.raise_for_status()
+    return SpecialistResponse.model_validate(r.json())
+```
+
+Test via `pytest-httpx` following the existing `test_daemon_client.py:136` pattern.
+
+Commit:
+
+```bash
+git commit -m "feat(app): DaemonClient.pr_reviewer() for app → daemon wire"
+```
+
+---
+
+## Milestone 6 — Integration, docs, CI
+
+### Task 6.1: Gated live-PR integration smoke
+
+**Files:**
+- Modify: `daemon/tests/test_specialist_pr_reviewer.py` (append)
+
+**Step 1:** Write `@pytest.mark.integration` test targeting stable closed PR #46 (pytest-asyncio bump). Gated on `REACHY_DUCKY_RUN_INTEGRATION=1` per plan_reviewer's pattern (test_specialist_plan_reviewer.py:295–322). Uses real `gh` + `ClaudeSDKBrain.with_tools(...)`.
+
+**Steps 2–5:** Run with env var set, confirm it works end-to-end, commit:
+
+```bash
+git commit -m "test(specialists/pr-reviewer): gated live-PR integration smoke"
+```
+
+---
+
+### Task 6.2: Docs updates
+
+**Files:**
+- Modify: `CLAUDE.md` (add `gh` CLI to Prereqs section + `GH_TOKEN` note)
+- Modify: `README.md` (if it lists daemon prereqs)
+- Modify: `docs/plans/2026-04-21-reachy-ducky-design.md` §12 (mark pr-reviewer as Phase B landed)
+
+Content:
+
+```markdown
+### Prereqs for the daemon's Pattern B brain
+
+[existing content]
+
+- **`gh` CLI (2.x)** — required for the `pr-reviewer` specialist's pre-fetch
+  path. Authenticates via `GH_TOKEN` (reuse the same
+  `GITHUB_PERSONAL_ACCESS_TOKEN`) or an interactive `gh auth login`.
+```
+
+Commit:
+
+```bash
+git commit -m "docs: note gh CLI prereq for pr-reviewer; mark pr-reviewer landed"
+```
+
+---
+
+## Done / exit criteria
+
+When every task above is committed on `pr-reviewer-specialist` and the full-branch quality gate passes:
+
+```bash
+uv run ruff check . \
+  && uv run ruff format --check . \
+  && uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests \
+  && uv run pyright \
+  && uv run bandit -ll -r daemon/src app/src menubar/src protocol/src \
+  && uv run pytest -q --cov
+```
+
+Coverage ≥ 90%. Then: push, open PR, wait for Augment + Codex reviews, `@codex review` after each push, merge when both are addressed. Close #50 manually with a comment if the redaction follow-up is not resolved in this PR (it won't be — it's a separate issue).

--- a/protocol/src/reachy_ducky_protocol/messages.py
+++ b/protocol/src/reachy_ducky_protocol/messages.py
@@ -45,6 +45,7 @@ class SpecialistRequest(_WireMessage):
     name: str
     project_slug: str
     branch: str | None = None
+    pr_number: int | None = None
 
 
 class SpecialistResponse(_WireResponse):

--- a/protocol/tests/test_messages.py
+++ b/protocol/tests/test_messages.py
@@ -41,6 +41,35 @@ def test_specialist_request_plan_reviewer() -> None:
     assert req.name == "plan-reviewer"
 
 
+def test_specialist_request_pr_number_defaults_to_none() -> None:
+    """pr_number is optional on SpecialistRequest — omission leaves it None."""
+    req = SpecialistRequest(name="pr-reviewer", project_slug="reachy-ducky")
+    assert req.pr_number is None
+
+
+def test_specialist_request_accepts_pr_number() -> None:
+    """pr_number is a plain int when supplied."""
+    req = SpecialistRequest(name="pr-reviewer", project_slug="reachy-ducky", pr_number=42)
+    assert req.pr_number == 42
+
+
+def test_specialist_request_rejects_non_int_pr_number() -> None:
+    """pr_number must be int-coercible — non-numeric strings fail validation.
+
+    Pydantic v2 lax-mode coerces ``"42"`` to ``42``, which is consistent with
+    the rest of the protocol. This test pins the int-valued-ness of the field
+    against an input Pydantic cannot coerce.
+    """
+    with pytest.raises(ValidationError):
+        SpecialistRequest.model_validate(
+            {
+                "name": "pr-reviewer",
+                "project_slug": "reachy-ducky",
+                "pr_number": "not-a-number",
+            }
+        )
+
+
 def test_state_enum_values() -> None:
     """State enum serializes to the lowercase strings the voice app receives."""
     assert State.IDLE.value == "idle"


### PR DESCRIPTION
## Summary

- Adds the Phase B `pr-reviewer` specialist per design doc §9 — a read-only, plan-aware PR synthesis layer one level above Augment/Codex/Claude-review. Given a PR number (or auto-detected from the current branch), Python pre-fetches PR surfaces via `gh` CLI, assembles a single prompt, dispatches to the brain once, wraps the reply as `SpecialistResponse`. Follow-up "dig deeper" questions route through the existing `/brain/query` with the full `mcp__github__*` + Read/Grep/Bash surface.
- Mirrors `PlanReviewer`'s Pattern A shape. Auto-detect fallback (`git rev-parse` → `gh pr list --head`) with graceful diagnostic prompt when no PR is found — instead of a curt error, the brain investigates with tools and returns an actionable explanation.
- Non-breaking protocol addition: `SpecialistRequest.pr_number: int | None = None`. New route `POST /specialists/pr-reviewer`. New daemon-client method `DaemonClient.pr_reviewer(project_slug, pr_number=None)`. New daemon prereq: `gh` CLI (authenticates via `GH_TOKEN` = same PAT as `github-mcp-server`).

15 commits in TDD-shaped cycles following [`docs/plans/2026-04-23-pr-reviewer-specialist.md`](docs/plans/2026-04-23-pr-reviewer-specialist.md). Design doc §12 updated to mark pr-reviewer as landed.

## Scope notes

- **Advisor, not a gate.** Ducky remains read-only; the response is a digest + machine-tag flags (`ci-green`/`ci-red`/`ci-pending`, `has-unresolved-comments`, `merge-conflict`, `no-pr-found`). Risk inferences stay in prose.
- **Reuses `SpecialistResponse`** — no discriminated union. If phase-C interruption policy needs typed fields later, we can introduce them then.
- **Security posture:** no new `PreToolUse` gate at the specialist layer. Threat model analysis is in the plan doc; short version is that subprocess is hardcoded verbs on a read-only PAT — no LLM in the loop.

## Deferred

Secret redaction across specialists (pre-brain `gitleaks`/`trufflehog`) remains unimplemented — tracked in #50. `pr-reviewer` extends the leak surface (PR body + review comment bodies + linked-issue bodies) but the fix spans both `plan_reviewer` and `pr_reviewer`, so it's handled as a separate change.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy --strict` across daemon/app/menubar/protocol (src + tests) — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run bandit -ll -r` — 0 issues
- [x] `uv run pytest -q --cov` — **546 passed**, 4 skipped, 4 deselected; **coverage 90.11%** (floor 90%)
- [ ] Optional: `REACHY_DUCKY_RUN_INTEGRATION=1 uv run pytest -m integration` — live smoke against PR #46; requires `gh auth` + Claude OAuth
- [ ] Augment review addressed before merge
- [ ] Codex review addressed before merge (remember: `@codex review` must be explicitly commented to re-trigger on each push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)