### PR TITLE
feat(specialists): secret redaction across specialists (closes #50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,13 @@ jobs:
         # exercise the real redact path; without the binary they'd fail
         # closed with a ``redaction-failed`` flag. Version pinned for
         # reproducibility; bump intentionally via a separate commit.
+        #
+        # Bumped from 8.21.2 → 8.30.1 after the first CI run of PR #52 showed
+        # the older Linux binary returning empty stdout with ``--report-path -``
+        # for the ``stdin`` subcommand — behavior fixed in a later release.
         if: runner.os == 'Linux'
         run: |
-          VERSION=8.21.2
+          VERSION=8.30.1
           curl -sSL \
             "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
             | sudo tar xz -C /usr/local/bin gitleaks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,27 @@ jobs:
         # lazy-import contract that a fake-rumps unit test can't see).
         run: uv sync --all-packages --group dev --extra macos
 
+      - name: Install gitleaks (Linux)
+        # The daemon's specialists pipe every prompt through ``gitleaks stdin``
+        # before ``brain.query()`` (pre-brain secret redaction, design doc §10 /
+        # closed issue #50). Specialist tests that go through ``review()``
+        # exercise the real redact path; without the binary they'd fail
+        # closed with a ``redaction-failed`` flag. Version pinned for
+        # reproducibility; bump intentionally via a separate commit.
+        if: runner.os == 'Linux'
+        run: |
+          VERSION=8.21.2
+          curl -sSL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Install gitleaks (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install gitleaks
+          gitleaks version
+
       - name: Ruff lint
         run: uv run ruff check .
 

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -256,7 +256,7 @@ class PlanReviewer:
         )
 
         try:
-            redacted, rule_ids = redact(prompt)
+            redacted, rule_ids = redact(prompt, cwd=self._repo)
         except RedactionError as exc:
             return SpecialistResponse(
                 name=_SPECIALIST_NAME,

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -53,6 +53,7 @@ from reachy_ducky_daemon.brain.interface import BrainInterface
 # Phase A specialist lands, so this cross-subpackage private import doesn't
 # become precedent.
 from reachy_ducky_daemon.brain.plans_mcp import _list_plans
+from reachy_ducky_daemon.specialists.redaction import RedactionError, redact
 
 __all__ = ["PlanReviewer"]
 
@@ -235,9 +236,12 @@ class PlanReviewer:
         self._repo = repo
 
     async def review(self) -> SpecialistResponse:
-        """Assemble the review prompt, dispatch to the brain, wrap the response.
+        """Assemble the review prompt, redact secrets, dispatch to the brain.
 
-        Exactly one ``brain.query`` call per invocation.
+        Exactly one ``brain.query`` call per invocation — but only when
+        redaction succeeds. A :class:`RedactionError` short-circuits to
+        a fail-closed diagnostic response; no brain call fires, no
+        secret leaks.
         """
         branch, branch_error = _current_branch(self._repo)
         plans = _collect_plans(self._repo)
@@ -251,5 +255,21 @@ class PlanReviewer:
             diff_error=diff_error,
         )
 
-        response = await self._brain.query(BrainRequest(user_utterance=prompt))
-        return SpecialistResponse(name=_SPECIALIST_NAME, summary=response.text)
+        try:
+            redacted, rule_ids = redact(prompt)
+        except RedactionError as exc:
+            return SpecialistResponse(
+                name=_SPECIALIST_NAME,
+                summary=(
+                    f"Redaction unavailable: {exc}. Aborting review to "
+                    "prevent secret leaks — re-run once the redactor is back."
+                ),
+                flags=["redaction-failed"],
+            )
+
+        response = await self._brain.query(BrainRequest(user_utterance=redacted))
+        return SpecialistResponse(
+            name=_SPECIALIST_NAME,
+            summary=response.text,
+            flags=[f"redacted:{rid}" for rid in rule_ids],
+        )

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from reachy_ducky_protocol.messages import BrainRequest, SpecialistResponse
 
 from reachy_ducky_daemon.brain.interface import BrainInterface
+from reachy_ducky_daemon.specialists.redaction import RedactionError, redact
 
 __all__ = [
     "_GH_TIMEOUT_SECONDS",
@@ -544,9 +545,8 @@ class PRReviewer:
             comments_error=comments_err,
             check_runs_error=check_runs_err,
         )
-        flags = _derive_flags(pr=pr_meta, comments=comments, check_runs=check_runs)
-        brain_resp = await self._brain.query(BrainRequest(user_utterance=prompt))
-        return SpecialistResponse(name=_SPECIALIST_NAME, summary=brain_resp.text, flags=flags)
+        base_flags = _derive_flags(pr=pr_meta, comments=comments, check_runs=check_runs)
+        return await self._query_with_redaction(prompt=prompt, base_flags=base_flags)
 
     async def _diagnostic_response(
         self,
@@ -555,15 +555,53 @@ class PRReviewer:
         branch_error: str | None,
         find_error: str | None,
     ) -> SpecialistResponse:
-        """Dispatch the diagnostic prompt and wrap the brain's reply."""
+        """Dispatch the diagnostic prompt (redacted) and wrap the brain's reply."""
         prompt = _assemble_diagnostic_prompt(
             branch=branch or "unknown",
             branch_error=branch_error,
             find_error=find_error,
         )
-        flags = _derive_flags(pr={}, comments=[], check_runs=[])
-        brain_resp = await self._brain.query(BrainRequest(user_utterance=prompt))
-        return SpecialistResponse(name=_SPECIALIST_NAME, summary=brain_resp.text, flags=flags)
+        base_flags = _derive_flags(pr={}, comments=[], check_runs=[])
+        return await self._query_with_redaction(prompt=prompt, base_flags=base_flags)
+
+    async def _query_with_redaction(
+        self,
+        *,
+        prompt: str,
+        base_flags: list[str],
+    ) -> SpecialistResponse:
+        """Redact, then query brain. Fail-closed on :class:`RedactionError`.
+
+        Shared by both the happy review path and the diagnostic path so
+        every prompt that reaches ``brain.query()`` is run through
+        :func:`redact` first (design doc §10). ``RedactionError`` short-
+        circuits to a 200 ``SpecialistResponse`` with a
+        ``redaction-failed`` flag and no brain call — secrets cannot
+        leak through a broken gitleaks install.
+
+        ``base_flags`` are preserved on both success (merged with
+        ``redacted:<rid>`` entries) and failure (merged with
+        ``redaction-failed``) so the caller still sees the objective
+        state we determined without the brain.
+        """
+        try:
+            redacted, rule_ids = redact(prompt)
+        except RedactionError as exc:
+            return SpecialistResponse(
+                name=_SPECIALIST_NAME,
+                summary=(
+                    f"Redaction unavailable: {exc}. Aborting review to "
+                    "prevent secret leaks — re-run once the redactor is back."
+                ),
+                flags=[*base_flags, "redaction-failed"],
+            )
+
+        brain_resp = await self._brain.query(BrainRequest(user_utterance=redacted))
+        return SpecialistResponse(
+            name=_SPECIALIST_NAME,
+            summary=brain_resp.text,
+            flags=[*base_flags, *(f"redacted:{rid}" for rid in rule_ids)],
+        )
 
     def _resolve_pr(self, pr_number: int | None) -> tuple[int | None, str, str | None, str | None]:
         """Return ``(pr, branch, branch_error, find_error)`` per the resolution order.

--- a/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py
@@ -479,7 +479,11 @@ class PRReviewer:
       actionable explanation rather than a review-of-nothing.
 
     Exactly one ``brain.query()`` call fires per :meth:`review` invocation
-    regardless of which path is taken.
+    *when redaction succeeds*. A :class:`RedactionError` from the pre-brain
+    redaction step (design doc §10) short-circuits to a fail-closed
+    ``SpecialistResponse`` with a ``redaction-failed`` flag and no brain
+    call — see :meth:`_query_with_redaction`. Every other code path goes
+    through the brain exactly once.
     """
 
     def __init__(
@@ -585,7 +589,7 @@ class PRReviewer:
         state we determined without the brain.
         """
         try:
-            redacted, rule_ids = redact(prompt)
+            redacted, rule_ids = redact(prompt, cwd=self._repo)
         except RedactionError as exc:
             return SpecialistResponse(
                 name=_SPECIALIST_NAME,

--- a/daemon/src/reachy_ducky_daemon/specialists/redaction.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/redaction.py
@@ -1,0 +1,113 @@
+"""Pre-brain secret redaction using the ``gitleaks`` CLI.
+
+Specialists assemble prompts from user-controlled surfaces (plan text,
+diffs, PR bodies, review comments) and pass them to ``brain.query()``.
+Any secret pasted into one of those surfaces would otherwise flow
+straight to Claude. :func:`redact` pipes the assembled prompt through
+``gitleaks stdin``, splices ``[REDACTED:<RuleID>]`` over each match,
+and returns the sanitized text plus a deduplicated list of rule IDs
+the caller can emit as ``redacted:<rule_id>`` flags.
+
+Coherence with the rest of the stack: gitleaks honours any
+``.gitleaks.toml`` in the current directory via the same precedence
+chain as lefthook's ``gitleaks protect --staged``, so "what counts as
+a secret" stays unified across commit-time and brain-time.
+
+Fail policy: on any subprocess failure, malformed output, or missing
+binary, :func:`redact` raises :class:`RedactionError`. Callers route
+to a fail-closed diagnostic ``SpecialistResponse`` — no brain call
+fires when redaction can't run.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404 — list-form read-only gitleaks only; no shell
+from typing import TypedDict
+
+__all__ = [
+    "_GITLEAKS_TIMEOUT_SECONDS",
+    "RedactionError",
+    "redact",
+]
+
+_GITLEAKS_TIMEOUT_SECONDS = 30.0
+
+
+class RedactionError(RuntimeError):
+    """Raised when redaction cannot run to completion.
+
+    Intentionally a :class:`RuntimeError` so specialists can catch
+    broadly. The ``str(exc)`` carries enough context for the
+    diagnostic response body.
+    """
+
+
+class _Finding(TypedDict):
+    """Narrow view of a gitleaks finding — only the fields we consume."""
+
+    RuleID: str
+    StartLine: int
+    EndLine: int
+    StartColumn: int
+    EndColumn: int
+
+
+def redact(text: str) -> tuple[str, list[str]]:
+    """Return ``(redacted_text, deduplicated_rule_ids)``.
+
+    Invokes ``gitleaks stdin`` with ``--redact`` (so raw secrets never
+    appear in the JSON output we parse) and splices
+    ``[REDACTED:<RuleID>]`` into ``text`` at each reported position.
+    Rule IDs in the returned list are deduplicated, order-preserved
+    (first occurrence wins).
+
+    Raises :class:`RedactionError` on missing binary, subprocess
+    timeout, non-zero exit, malformed JSON, or unexpected JSON shape.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603  # nosec B603 B607 — list form, read-only gitleaks only
+            [
+                "gitleaks",
+                "stdin",
+                "--no-banner",
+                "--exit-code",
+                "0",
+                "--report-format",
+                "json",
+                "--report-path",
+                "-",
+                "--redact",
+            ],
+            input=text,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GITLEAKS_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError as exc:
+        raise RedactionError(f"gitleaks binary not found on PATH: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RedactionError(f"gitleaks stdin timeout after {_GITLEAKS_TIMEOUT_SECONDS}s") from exc
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RedactionError(f"gitleaks subprocess failed: {exc}") from exc
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        raise RedactionError(f"gitleaks stdin failed: {stderr}")
+
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RedactionError(f"gitleaks stdin emitted unparseable JSON: {exc}") from exc
+
+    if not isinstance(parsed, list):
+        raise RedactionError(
+            f"gitleaks stdin returned non-list JSON (unexpected shape): {type(parsed).__name__}"
+        )
+
+    # Splicing lands in Task 1.2. For now: empty findings → pass through;
+    # non-empty findings → placeholder pass-through (will be replaced).
+    if not parsed:
+        return text, []
+    return text, []

--- a/daemon/src/reachy_ducky_daemon/specialists/redaction.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/redaction.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import subprocess  # nosec B404 — list-form read-only gitleaks only; no shell
+from pathlib import Path
 from typing import TypedDict
 
 __all__ = [
@@ -53,7 +54,7 @@ class _Finding(TypedDict):
     EndColumn: int
 
 
-def redact(text: str) -> tuple[str, list[str]]:
+def redact(text: str, *, cwd: Path) -> tuple[str, list[str]]:
     """Return ``(redacted_text, deduplicated_rule_ids)``.
 
     Invokes ``gitleaks stdin`` with ``--redact`` (so raw secrets never
@@ -62,8 +63,18 @@ def redact(text: str) -> tuple[str, list[str]]:
     Rule IDs in the returned list are deduplicated, order-preserved
     (first occurrence wins).
 
+    ``cwd`` is the project directory gitleaks runs inside — required so
+    the config-precedence chain picks up any repo-local
+    ``.gitleaks.toml`` (the "what's a secret" rules stay unified with
+    ``lefthook pre-commit``'s ``gitleaks protect --staged``). Without
+    this, gitleaks would inherit the daemon's CWD and silently skip
+    repo-local allowlists. Required kwarg specifically so callers can
+    never accidentally forget — the daemon might be started from any
+    directory, but the specialists always know their project root.
+
     Raises :class:`RedactionError` on missing binary, subprocess
-    timeout, non-zero exit, malformed JSON, or unexpected JSON shape.
+    timeout, non-zero exit, malformed JSON, unexpected JSON shape,
+    malformed findings, or coordinates out of range.
     """
     try:
         proc = subprocess.run(  # noqa: S603  # nosec B603 B607 — list form, read-only gitleaks only
@@ -80,6 +91,7 @@ def redact(text: str) -> tuple[str, list[str]]:
                 "--redact",
             ],
             input=text,
+            cwd=cwd,
             check=False,
             capture_output=True,
             text=True,
@@ -143,24 +155,55 @@ def redact(text: str) -> tuple[str, list[str]]:
         # end is exclusive 0-indexed, so EndColumn maps straight through.
         end_col_idx = f["EndColumn"]
 
-        # Defensive: clamp to the line list we have. Out-of-range indices
-        # mean gitleaks and our line-split disagree about content — fail
-        # closed rather than silently skip.
+        # Defensive line-range check. Out-of-range indices mean gitleaks
+        # and our text.split('\n') disagree about content — fail closed
+        # rather than silently skip.
         if not (0 <= start_line_idx < len(lines)) or not (0 <= end_line_idx < len(lines)):
             raise RedactionError(
                 f"gitleaks finding line {f['StartLine']}-{f['EndLine']} "
                 f"out of range (text has {len(lines)} lines)"
             )
 
+        # Defensive column-range check. Python slicing silently clamps
+        # negatives and oversized indices, which could leave part of a
+        # secret unredacted if gitleaks ever emits malformed coordinates
+        # (line-ending / unicode-width mismatches, etc.). Validate
+        # against the *actual* bounds of the lines we're about to edit.
+        if f["StartColumn"] < 1 or f["EndColumn"] < f["StartColumn"]:
+            raise RedactionError(
+                f"gitleaks finding has invalid column range "
+                f"{f['StartColumn']}-{f['EndColumn']} "
+                f"(StartColumn must be ≥ 1 and ≤ EndColumn)"
+            )
         if start_line_idx == end_line_idx:
             line = lines[start_line_idx]
+            if f["EndColumn"] > len(line) + 1:
+                # +1 because EndColumn is 1-indexed end-inclusive; a
+                # finding that covers the full line reports
+                # EndColumn == len(line).
+                raise RedactionError(
+                    f"gitleaks finding EndColumn {f['EndColumn']} "
+                    f"exceeds line {f['StartLine']} length ({len(line)})"
+                )
             lines[start_line_idx] = line[:start_col_idx] + marker + line[end_col_idx:]
         else:
+            start_line = lines[start_line_idx]
+            end_line = lines[end_line_idx]
+            if f["StartColumn"] > len(start_line) + 1:
+                raise RedactionError(
+                    f"gitleaks finding StartColumn {f['StartColumn']} "
+                    f"exceeds line {f['StartLine']} length ({len(start_line)})"
+                )
+            if f["EndColumn"] > len(end_line) + 1:
+                raise RedactionError(
+                    f"gitleaks finding EndColumn {f['EndColumn']} "
+                    f"exceeds line {f['EndLine']} length ({len(end_line)})"
+                )
             # Multi-line: collapse the whole range to a single marker,
             # preserving any prefix on the start line and any suffix on
             # the end line. Inner + end lines drop.
-            prefix = lines[start_line_idx][:start_col_idx]
-            suffix = lines[end_line_idx][end_col_idx:]
+            prefix = start_line[:start_col_idx]
+            suffix = end_line[end_col_idx:]
             lines[start_line_idx] = prefix + marker + suffix
             del lines[start_line_idx + 1 : end_line_idx + 1]
 

--- a/daemon/src/reachy_ducky_daemon/specialists/redaction.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/redaction.py
@@ -54,6 +54,23 @@ class _Finding(TypedDict):
     EndColumn: int
 
 
+class _Span(TypedDict):
+    """A splice target — either one finding or a composite of overlapping findings.
+
+    ``rule_ids`` is the ordered, deduplicated list of rule IDs that matched
+    somewhere inside the span. For a single finding it's ``[RuleID]``; for a
+    composite built from overlapping findings it carries each contributing
+    rule in first-occurrence order. The marker rendered at splice time is
+    ``[REDACTED:{','.join(rule_ids)}]``.
+    """
+
+    rule_ids: list[str]
+    StartLine: int
+    EndLine: int
+    StartColumn: int
+    EndColumn: int
+
+
 def redact(text: str, *, cwd: Path) -> tuple[str, list[str]]:
     """Return ``(redacted_text, deduplicated_rule_ids)``.
 
@@ -144,74 +161,164 @@ def redact(text: str, *, cwd: Path) -> tuple[str, list[str]]:
 
     lines = text.split("\n")
 
+    # Per-finding validation before any splicing. Keeps every malformed-
+    # finding failure mode in one place and stops later overlap-merging
+    # from dealing with coordinate garbage.
+    for f in findings:
+        _validate_finding(f, lines)
+
+    # Merge overlapping findings into composite spans so the descending-
+    # splice order is stable. Disjoint-sort alone only preserves stability
+    # when intervals don't overlap; if gitleaks emits two findings that
+    # share any position (same token matching two rules, nested matches),
+    # splicing one mutates the coordinate space the next was measured in
+    # and can leave a secret fragment behind.
+    spans = _merge_overlapping_findings(findings)
+
     # Splice from the end so earlier splices don't shift later indices.
-    # Sort by (StartLine, StartColumn) descending.
-    for f in sorted(findings, key=lambda f: (f["StartLine"], f["StartColumn"]), reverse=True):
-        marker = f"[REDACTED:{f['RuleID']}]"
-        start_line_idx = f["StartLine"] - 1
-        end_line_idx = f["EndLine"] - 1
-        start_col_idx = f["StartColumn"] - 1
+    for span in sorted(spans, key=lambda s: (s["StartLine"], s["StartColumn"]), reverse=True):
+        marker = f"[REDACTED:{','.join(span['rule_ids'])}]"
+        start_line_idx = span["StartLine"] - 1
+        end_line_idx = span["EndLine"] - 1
+        start_col_idx = span["StartColumn"] - 1
         # gitleaks EndColumn is end-inclusive 1-indexed; Python slice
         # end is exclusive 0-indexed, so EndColumn maps straight through.
-        end_col_idx = f["EndColumn"]
+        end_col_idx = span["EndColumn"]
 
-        # Defensive line-range check. Out-of-range indices mean gitleaks
-        # and our text.split('\n') disagree about content — fail closed
-        # rather than silently skip.
-        if not (0 <= start_line_idx < len(lines)) or not (0 <= end_line_idx < len(lines)):
-            raise RedactionError(
-                f"gitleaks finding line {f['StartLine']}-{f['EndLine']} "
-                f"out of range (text has {len(lines)} lines)"
-            )
-
-        # Defensive column-range check. Python slicing silently clamps
-        # negatives and oversized indices, which could leave part of a
-        # secret unredacted if gitleaks ever emits malformed coordinates
-        # (line-ending / unicode-width mismatches, etc.). Validate
-        # against the *actual* bounds of the lines we're about to edit.
-        if f["StartColumn"] < 1 or f["EndColumn"] < f["StartColumn"]:
-            raise RedactionError(
-                f"gitleaks finding has invalid column range "
-                f"{f['StartColumn']}-{f['EndColumn']} "
-                f"(StartColumn must be ≥ 1 and ≤ EndColumn)"
-            )
         if start_line_idx == end_line_idx:
             line = lines[start_line_idx]
-            if f["EndColumn"] > len(line) + 1:
-                # +1 because EndColumn is 1-indexed end-inclusive; a
-                # finding that covers the full line reports
-                # EndColumn == len(line).
-                raise RedactionError(
-                    f"gitleaks finding EndColumn {f['EndColumn']} "
-                    f"exceeds line {f['StartLine']} length ({len(line)})"
-                )
             lines[start_line_idx] = line[:start_col_idx] + marker + line[end_col_idx:]
         else:
-            start_line = lines[start_line_idx]
-            end_line = lines[end_line_idx]
-            if f["StartColumn"] > len(start_line) + 1:
-                raise RedactionError(
-                    f"gitleaks finding StartColumn {f['StartColumn']} "
-                    f"exceeds line {f['StartLine']} length ({len(start_line)})"
-                )
-            if f["EndColumn"] > len(end_line) + 1:
-                raise RedactionError(
-                    f"gitleaks finding EndColumn {f['EndColumn']} "
-                    f"exceeds line {f['EndLine']} length ({len(end_line)})"
-                )
             # Multi-line: collapse the whole range to a single marker,
             # preserving any prefix on the start line and any suffix on
             # the end line. Inner + end lines drop.
-            prefix = start_line[:start_col_idx]
-            suffix = end_line[end_col_idx:]
+            prefix = lines[start_line_idx][:start_col_idx]
+            suffix = lines[end_line_idx][end_col_idx:]
             lines[start_line_idx] = prefix + marker + suffix
             del lines[start_line_idx + 1 : end_line_idx + 1]
 
-    # Dedup rule IDs in original emission order (first occurrence wins).
-    # Iterate the un-sorted findings list so the output flag list reflects
-    # gitleaks' natural top-to-bottom emission.
+    # Dedup rule IDs in emission order (first occurrence wins). Spans
+    # are built in ascending (StartLine, StartColumn) order so iterating
+    # them preserves gitleaks' natural top-to-bottom emission.
     seen: dict[str, None] = {}
-    for f in findings:
-        seen.setdefault(f["RuleID"], None)
+    for span in spans:
+        for rid in span["rule_ids"]:
+            seen.setdefault(rid, None)
 
     return "\n".join(lines), list(seen.keys())
+
+
+def _validate_finding(f: _Finding, lines: list[str]) -> None:
+    """Raise :class:`RedactionError` if ``f`` has coordinates we can't trust.
+
+    Centralises the "fail-closed on malformed coordinates" policy — if
+    gitleaks and our text disagree (line-ending / unicode-width mismatch,
+    inverted range, out-of-range column) we refuse to splice rather than
+    risk leaving a secret fragment behind. Python slicing would silently
+    clamp negatives or oversized indices otherwise.
+    """
+    # Line-range: must be in-bounds AND StartLine <= EndLine.
+    start_line_idx = f["StartLine"] - 1
+    end_line_idx = f["EndLine"] - 1
+    if not (0 <= start_line_idx < len(lines)) or not (0 <= end_line_idx < len(lines)):
+        raise RedactionError(
+            f"gitleaks finding line {f['StartLine']}-{f['EndLine']} "
+            f"out of range (text has {len(lines)} lines)"
+        )
+    if f["StartLine"] > f["EndLine"]:
+        raise RedactionError(
+            f"gitleaks finding has inverted line range "
+            f"{f['StartLine']}>{f['EndLine']} (StartLine must be ≤ EndLine)"
+        )
+
+    # Column ordering semantics differ between single-line and multi-line
+    # findings: for same-line findings, EndColumn ≥ StartColumn is required;
+    # for multi-line findings each column applies to its own line so no
+    # ordering relationship holds between them. Only the ≥ 1 lower bound
+    # is always required.
+    if f["StartColumn"] < 1 or f["EndColumn"] < 1:
+        raise RedactionError(
+            f"gitleaks finding has invalid column range "
+            f"{f['StartColumn']}-{f['EndColumn']} (columns must be ≥ 1)"
+        )
+    if f["StartLine"] == f["EndLine"] and f["EndColumn"] < f["StartColumn"]:
+        raise RedactionError(
+            f"gitleaks finding has invalid column range "
+            f"{f['StartColumn']}-{f['EndColumn']} "
+            f"(EndColumn must be ≥ StartColumn on the same line)"
+        )
+
+    # Column bounds against actual line lengths. +1 on the upper bound
+    # because EndColumn is 1-indexed end-inclusive; a finding that covers
+    # the full line reports EndColumn == len(line).
+    start_line = lines[start_line_idx]
+    end_line = lines[end_line_idx]
+    if f["StartLine"] == f["EndLine"]:
+        if f["EndColumn"] > len(start_line) + 1:
+            raise RedactionError(
+                f"gitleaks finding EndColumn {f['EndColumn']} "
+                f"exceeds line {f['StartLine']} length ({len(start_line)})"
+            )
+    else:
+        if f["StartColumn"] > len(start_line) + 1:
+            raise RedactionError(
+                f"gitleaks finding StartColumn {f['StartColumn']} "
+                f"exceeds line {f['StartLine']} length ({len(start_line)})"
+            )
+        if f["EndColumn"] > len(end_line) + 1:
+            raise RedactionError(
+                f"gitleaks finding EndColumn {f['EndColumn']} "
+                f"exceeds line {f['EndLine']} length ({len(end_line)})"
+            )
+
+
+def _merge_overlapping_findings(findings: list[_Finding]) -> list[_Span]:
+    """Return composite spans where any overlapping findings are merged.
+
+    Walks findings in ascending ``(StartLine, StartColumn)`` order; each
+    span either starts a new composite or extends the previous one if
+    its start position falls inside (or touches) the previous span's
+    end position. The returned list is ordered by start position, which
+    matches the order gitleaks emits its findings — useful for the flag
+    list's first-occurrence dedup.
+
+    Merging is the Codex-review fix (PR #52) for the correctness hazard
+    where splicing one finding mutates the coordinate space of an
+    overlapping sibling. After merging, all splice intervals are
+    disjoint and descending-sort gives stable indices.
+    """
+    ordered = sorted(findings, key=lambda f: (f["StartLine"], f["StartColumn"]))
+    merged: list[_Span] = []
+    for f in ordered:
+        if merged and _spans_overlap(merged[-1], f):
+            prev = merged[-1]
+            # Extend the end bound if this finding reaches further.
+            if (f["EndLine"], f["EndColumn"]) > (prev["EndLine"], prev["EndColumn"]):
+                prev["EndLine"] = f["EndLine"]
+                prev["EndColumn"] = f["EndColumn"]
+            if f["RuleID"] not in prev["rule_ids"]:
+                prev["rule_ids"].append(f["RuleID"])
+        else:
+            merged.append(
+                {
+                    "rule_ids": [f["RuleID"]],
+                    "StartLine": f["StartLine"],
+                    "EndLine": f["EndLine"],
+                    "StartColumn": f["StartColumn"],
+                    "EndColumn": f["EndColumn"],
+                }
+            )
+    return merged
+
+
+def _spans_overlap(a: _Span, b: _Finding) -> bool:
+    """True if ``a`` ends at or after ``b`` starts (inclusive positions).
+
+    Caller guarantees ``a`` starts at or before ``b`` (list is pre-sorted
+    ascending). Both coordinate pairs are 1-indexed end-inclusive, so
+    ``(EndLine, EndColumn)`` is the last covered position and
+    ``(StartLine, StartColumn)`` is the first — adjacency counts as
+    overlap so we merge ``[1..5]`` + ``[5..10]`` into ``[1..10]``
+    (they share column 5).
+    """
+    return (a["EndLine"], a["EndColumn"]) >= (b["StartLine"], b["StartColumn"])

--- a/daemon/src/reachy_ducky_daemon/specialists/redaction.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/redaction.py
@@ -106,8 +106,69 @@ def redact(text: str) -> tuple[str, list[str]]:
             f"gitleaks stdin returned non-list JSON (unexpected shape): {type(parsed).__name__}"
         )
 
-    # Splicing lands in Task 1.2. For now: empty findings → pass through;
-    # non-empty findings → placeholder pass-through (will be replaced).
     if not parsed:
         return text, []
-    return text, []
+
+    # Narrow: only entries with the five required int/str fields are
+    # processed. Anything malformed becomes a RedactionError — we can't
+    # safely splice without trustworthy coordinates, and silently
+    # dropping findings would risk leaving secrets in.
+    findings: list[_Finding] = []
+    for entry in parsed:
+        if not isinstance(entry, dict):
+            raise RedactionError("gitleaks finding is not an object")
+        try:
+            findings.append(
+                {
+                    "RuleID": str(entry["RuleID"]),
+                    "StartLine": int(entry["StartLine"]),
+                    "EndLine": int(entry["EndLine"]),
+                    "StartColumn": int(entry["StartColumn"]),
+                    "EndColumn": int(entry["EndColumn"]),
+                }
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RedactionError(f"gitleaks finding missing required field: {exc}") from exc
+
+    lines = text.split("\n")
+
+    # Splice from the end so earlier splices don't shift later indices.
+    # Sort by (StartLine, StartColumn) descending.
+    for f in sorted(findings, key=lambda f: (f["StartLine"], f["StartColumn"]), reverse=True):
+        marker = f"[REDACTED:{f['RuleID']}]"
+        start_line_idx = f["StartLine"] - 1
+        end_line_idx = f["EndLine"] - 1
+        start_col_idx = f["StartColumn"] - 1
+        # gitleaks EndColumn is end-inclusive 1-indexed; Python slice
+        # end is exclusive 0-indexed, so EndColumn maps straight through.
+        end_col_idx = f["EndColumn"]
+
+        # Defensive: clamp to the line list we have. Out-of-range indices
+        # mean gitleaks and our line-split disagree about content — fail
+        # closed rather than silently skip.
+        if not (0 <= start_line_idx < len(lines)) or not (0 <= end_line_idx < len(lines)):
+            raise RedactionError(
+                f"gitleaks finding line {f['StartLine']}-{f['EndLine']} "
+                f"out of range (text has {len(lines)} lines)"
+            )
+
+        if start_line_idx == end_line_idx:
+            line = lines[start_line_idx]
+            lines[start_line_idx] = line[:start_col_idx] + marker + line[end_col_idx:]
+        else:
+            # Multi-line: collapse the whole range to a single marker,
+            # preserving any prefix on the start line and any suffix on
+            # the end line. Inner + end lines drop.
+            prefix = lines[start_line_idx][:start_col_idx]
+            suffix = lines[end_line_idx][end_col_idx:]
+            lines[start_line_idx] = prefix + marker + suffix
+            del lines[start_line_idx + 1 : end_line_idx + 1]
+
+    # Dedup rule IDs in original emission order (first occurrence wins).
+    # Iterate the un-sorted findings list so the output flag list reflects
+    # gitleaks' natural top-to-bottom emission.
+    seen: dict[str, None] = {}
+    for f in findings:
+        seen.setdefault(f["RuleID"], None)
+
+    return "\n".join(lines), list(seen.keys())

--- a/daemon/tests/test_server_specialists.py
+++ b/daemon/tests/test_server_specialists.py
@@ -200,6 +200,11 @@ def _mock_gh_min(*, pr_json: str) -> Callable[..., subprocess.CompletedProcess[s
             return _ok('[{"number": 42}]')
         if argv[:2] == ["git", "rev-parse"]:
             return _ok("feat-retry\n")
+        # Redaction path (wired into PRReviewer after #50 landed) — pass
+        # through with zero findings so the route's happy path reaches
+        # brain.query unmodified from this test's perspective.
+        if argv[:2] == ["gitleaks", "stdin"]:
+            return _ok("[]")
         raise AssertionError(f"unexpected argv: {argv}")
 
     return _side_effect

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from reachy_ducky_daemon.brain.mock import MockBrain
 from reachy_ducky_daemon.specialists.plan_reviewer import PlanReviewer
+from reachy_ducky_daemon.specialists.redaction import RedactionError
 from reachy_ducky_protocol.messages import SpecialistResponse
 
 # ---------------------------------------------------------------------------
@@ -320,3 +322,58 @@ async def test_plan_reviewer_live_claude(repo_with_plan_and_drift: Path) -> None
 
     assert response.name == "plan-reviewer"
     assert response.summary  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# Redaction integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plan_reviewer_redacts_prompt_before_brain_query(
+    repo_with_plan_and_drift: Path,
+) -> None:
+    """Prompt reaching the brain is the redacted version; rule ids flow to flags."""
+    # Inject a sensitive-looking token into the plan so we can observe it
+    # being scrubbed. Fresh tmp_path per test — safe to mutate.
+    plan_path = repo_with_plan_and_drift / "docs" / "plans" / "foo.md"
+    plan_path.write_text(plan_path.read_text() + "\nsensitive token here\n")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=repo_with_plan_and_drift)
+
+    def _fake_redact(text: str) -> tuple[str, list[str]]:
+        return text.replace("sensitive token here", "[REDACTED:fake-rule]"), ["fake-rule"]
+
+    with patch(
+        "reachy_ducky_daemon.specialists.plan_reviewer.redact",
+        side_effect=_fake_redact,
+    ):
+        response = await reviewer.review()
+
+    assert len(brain.calls) == 1
+    prompt = brain.calls[0].user_utterance
+    assert "sensitive token here" not in prompt
+    assert "[REDACTED:fake-rule]" in prompt
+    assert "redacted:fake-rule" in response.flags
+
+
+@pytest.mark.asyncio
+async def test_plan_reviewer_aborts_on_redaction_failure(
+    repo_with_plan_and_drift: Path,
+) -> None:
+    """RedactionError → 200 SpecialistResponse with redaction-failed flag, no brain call."""
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=repo_with_plan_and_drift)
+
+    with patch(
+        "reachy_ducky_daemon.specialists.plan_reviewer.redact",
+        side_effect=RedactionError("gitleaks binary not found"),
+    ):
+        response = await reviewer.review()
+
+    assert response.name == "plan-reviewer"
+    assert "redaction-failed" in response.flags
+    assert "gitleaks binary not found" in response.summary
+    assert "abort" in response.summary.lower() or "unavailable" in response.summary.lower()
+    assert len(brain.calls) == 0, "brain.query must not fire when redaction fails"

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -342,7 +342,9 @@ async def test_plan_reviewer_redacts_prompt_before_brain_query(
     brain = MockBrain()
     reviewer = PlanReviewer(brain=brain, repo=repo_with_plan_and_drift)
 
-    def _fake_redact(text: str) -> tuple[str, list[str]]:
+    def _fake_redact(text: str, *, cwd: Path) -> tuple[str, list[str]]:
+        assert cwd == repo_with_plan_and_drift
+
         return text.replace("sensitive token here", "[REDACTED:fake-rule]"), ["fake-rule"]
 
     with patch(

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -612,9 +612,20 @@ def _mock_by_argv(
     Longer patterns take precedence over shorter ones — important for
     distinguishing ``gh api /repos/.../pulls/.../comments`` from
     ``gh api /repos/.../commits/.../check-runs``.
+
+    A default no-findings ``gitleaks stdin`` response is merged in so
+    existing tests (written before redaction wiring landed) dispatch
+    cleanly without touching each case. Tests that want to observe
+    redaction-specific behavior can override by supplying their own
+    ``("gitleaks", "stdin")`` entry, or by patching
+    ``pr_reviewer.redact`` directly.
     """
+    defaults: dict[tuple[str, ...], subprocess.CompletedProcess[str]] = {
+        ("gitleaks", "stdin"): _ok("[]"),
+    }
+    merged = {**defaults, **returns}
     # Sort keys by length descending so the most specific match wins.
-    ordered = sorted(returns.items(), key=lambda kv: -len(kv[0]))
+    ordered = sorted(merged.items(), key=lambda kv: -len(kv[0]))
 
     def _side_effect(
         argv: list[str], *args: Any, **kwargs: Any
@@ -870,3 +881,141 @@ async def test_pr_reviewer_live_claude(tmp_path: Path) -> None:
 
     assert response.name == "pr-reviewer"
     assert response.summary  # brain returned *something* non-empty
+
+
+# ---------------------------------------------------------------------------
+# Redaction integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pr_reviewer_redacts_happy_path(tmp_path: Path) -> None:
+    """Happy path: prompt the brain sees is the redacted version; rule ids flagged."""
+    pr_view = _FIXTURES / "gh_pr_view_happy.json"
+    comments = _FIXTURES / "gh_api_comments.json"
+    check_runs = _FIXTURES / "gh_api_check_runs.json"
+
+    side_effect = _mock_by_argv(
+        {
+            ("gh", "pr", "view"): _ok(pr_view.read_text()),
+            ("gh", "pr", "diff"): _ok("diff context\nsensitive_token_here\nmore diff\n"),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/pulls/42/comments",
+            ): _ok(comments.read_text()),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/commits/abc123def456/check-runs",
+            ): _ok(check_runs.read_text()),
+        }
+    )
+
+    def _fake_redact(text: str) -> tuple[str, list[str]]:
+        return text.replace("sensitive_token_here", "[REDACTED:fake-rule]"), ["fake-rule"]
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with (
+        patch("subprocess.run", side_effect=side_effect),
+        patch(
+            "reachy_ducky_daemon.specialists.pr_reviewer.redact",
+            side_effect=_fake_redact,
+        ),
+    ):
+        response = await reviewer.review(pr_number=42)
+
+    assert "sensitive_token_here" not in brain.calls[0].user_utterance
+    assert "[REDACTED:fake-rule]" in brain.calls[0].user_utterance
+    assert "redacted:fake-rule" in response.flags
+    # Existing derived flags preserved — flag list is a union, not a replacement.
+    assert "ci-red" in response.flags
+    assert "has-unresolved-comments" in response.flags
+
+
+@pytest.mark.asyncio
+async def test_pr_reviewer_redacts_diagnostic_path(tmp_path: Path) -> None:
+    """Diagnostic (no-PR-found) path also redacts.
+
+    branch_error / find_error / stderr strings can legitimately embed
+    credentials (auth URLs with tokens, etc.), so the fail-closed
+    posture must cover the diagnostic path too.
+    """
+    side_effect = _mock_by_argv(
+        {
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): _ok("feat-x\n"),
+            # gh pr list fails with a stderr that embeds a credential-ish URL.
+            ("gh", "pr", "list"): subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="remote: url https://x:sensitive_token_here@github.com/...",
+            ),
+        }
+    )
+
+    def _fake_redact(text: str) -> tuple[str, list[str]]:
+        return text.replace("sensitive_token_here", "[REDACTED:fake-rule]"), ["fake-rule"]
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with (
+        patch("subprocess.run", side_effect=side_effect),
+        patch(
+            "reachy_ducky_daemon.specialists.pr_reviewer.redact",
+            side_effect=_fake_redact,
+        ),
+    ):
+        response = await reviewer.review(pr_number=None)
+
+    assert "sensitive_token_here" not in brain.calls[0].user_utterance
+    assert "[REDACTED:fake-rule]" in brain.calls[0].user_utterance
+    assert "redacted:fake-rule" in response.flags
+    assert "no-pr-found" in response.flags
+
+
+@pytest.mark.asyncio
+async def test_pr_reviewer_aborts_on_redaction_failure(tmp_path: Path) -> None:
+    """RedactionError on the happy path → 200 response, redaction-failed flag, no brain call."""
+    from reachy_ducky_daemon.specialists.redaction import RedactionError
+
+    pr_view = _FIXTURES / "gh_pr_view_happy.json"
+    side_effect = _mock_by_argv(
+        {
+            ("gh", "pr", "view"): _ok(pr_view.read_text()),
+            ("gh", "pr", "diff"): _ok(""),
+            ("gh", "api"): _ok("[]"),
+        }
+    )
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with (
+        patch("subprocess.run", side_effect=side_effect),
+        patch(
+            "reachy_ducky_daemon.specialists.pr_reviewer.redact",
+            side_effect=RedactionError("gitleaks timeout after 30.0s"),
+        ),
+    ):
+        response = await reviewer.review(pr_number=42)
+
+    assert response.name == "pr-reviewer"
+    assert "redaction-failed" in response.flags
+    assert "timeout" in response.summary.lower()
+    assert len(brain.calls) == 0, "brain.query must not fire when redaction fails"

--- a/daemon/tests/test_specialist_pr_reviewer.py
+++ b/daemon/tests/test_specialist_pr_reviewer.py
@@ -912,7 +912,9 @@ async def test_pr_reviewer_redacts_happy_path(tmp_path: Path) -> None:
         }
     )
 
-    def _fake_redact(text: str) -> tuple[str, list[str]]:
+    def _fake_redact(text: str, *, cwd: Path) -> tuple[str, list[str]]:
+        assert cwd == tmp_path
+
         return text.replace("sensitive_token_here", "[REDACTED:fake-rule]"), ["fake-rule"]
 
     brain = MockBrain()
@@ -960,7 +962,9 @@ async def test_pr_reviewer_redacts_diagnostic_path(tmp_path: Path) -> None:
         }
     )
 
-    def _fake_redact(text: str) -> tuple[str, list[str]]:
+    def _fake_redact(text: str, *, cwd: Path) -> tuple[str, list[str]]:
+        assert cwd == tmp_path
+
         return text.replace("sensitive_token_here", "[REDACTED:fake-rule]"), ["fake-rule"]
 
     brain = MockBrain()

--- a/daemon/tests/test_specialist_redaction.py
+++ b/daemon/tests/test_specialist_redaction.py
@@ -191,6 +191,19 @@ def test_redact_raises_on_multiline_start_column_past_line_length(tmp_path: Path
             redact("short\nlines here\n", cwd=tmp_path)
 
 
+def test_redact_raises_on_inverted_line_range(tmp_path: Path) -> None:
+    """StartLine > EndLine → RedactionError (Codex P2, PR #52 second review).
+
+    Python's ``del lines[start+1:end+1]`` silently no-ops on a reversed
+    slice, which would leave the original secret text in place while the
+    marker landed on the wrong line. Fail closed instead.
+    """
+    bad = '[{"RuleID": "x", "StartLine": 3, "EndLine": 1, "StartColumn": 1, "EndColumn": 3}]'
+    with patch("subprocess.run", return_value=_ok(bad)):
+        with pytest.raises(RedactionError, match="inverted line range"):
+            redact("aaa\nbbb\nccc\nddd\n", cwd=tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # Splicing logic — single-line, multi-line, dedup
 # ---------------------------------------------------------------------------
@@ -333,6 +346,137 @@ def test_redact_splices_without_shifting_earlier_findings(tmp_path: Path) -> Non
     # Bookend words still present and in order.
     assert out.index("alpha") < out.index("[REDACTED:rule-a]") < out.index("beta")
     assert out.index("beta") < out.index("[REDACTED:rule-b]") < out.index("end")
+
+
+def test_redact_multiline_allows_end_column_less_than_start_column(tmp_path: Path) -> None:
+    """Multi-line finding where EndColumn < StartColumn is legitimate.
+
+    StartColumn and EndColumn apply to different lines when StartLine <
+    EndLine, so there's no cross-line ordering relationship between
+    them — ``col 7 on line 1`` to ``col 4 on line 2`` is a valid span.
+    Regression guard: an earlier check rejected this case unconditionally
+    and had to be narrowed to same-line findings.
+    """
+    # Span: from col 7 on line 1 through col 4 on line 2 (inclusive).
+    findings = [
+        {
+            "RuleID": "private-key",
+            "StartLine": 1,
+            "EndLine": 2,
+            "StartColumn": 7,
+            "EndColumn": 4,
+        }
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact("prefix-SECRET\nKEY-suffix\n", cwd=tmp_path)
+
+    assert "[REDACTED:private-key]" in out
+    assert flags == ["private-key"]
+
+
+def test_redact_merges_overlapping_same_line_findings(tmp_path: Path) -> None:
+    """Overlapping findings on one line → single composite marker with both rule IDs.
+
+    Codex P1 (PR #52 second review): descending sort only preserves
+    coordinate stability for disjoint intervals. If gitleaks emits two
+    findings that share a position (same token matching two rules),
+    splicing one mutates the coordinate space the other was measured in
+    and can leave a secret fragment behind.
+    """
+    # Same token at cols 1..14 matches two rules. A (broad) covers 1..14,
+    # B (specific) covers 5..14. Overlap → merged span 1..14 with both
+    # rule IDs, first-occurrence order.
+    findings = [
+        {
+            "RuleID": "generic-api-key",
+            "StartLine": 1,
+            "EndLine": 1,
+            "StartColumn": 1,
+            "EndColumn": 14,
+        },
+        {
+            "RuleID": "github-pat",
+            "StartLine": 1,
+            "EndLine": 1,
+            "StartColumn": 5,
+            "EndColumn": 14,
+        },
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact("ghp_ABCDEFGHIJ rest", cwd=tmp_path)
+
+    # Exactly one splice (not two) — the overlap merged into one composite.
+    assert out.count("[REDACTED:") == 1
+    # Marker carries both rule IDs, comma-joined, first-occurrence order.
+    assert "[REDACTED:generic-api-key,github-pat]" in out
+    # Original token gone.
+    assert "ghp_ABCDEFGHIJ" not in out
+    assert "rest" in out
+    # Flags list both rules, deduped, first-occurrence order.
+    assert flags == ["generic-api-key", "github-pat"]
+
+
+def test_redact_merges_overlapping_multi_line_findings(tmp_path: Path) -> None:
+    """Overlap across lines → single composite marker spanning the union."""
+    # A: line 1 col 1 → line 2 col 3.
+    # B: line 2 col 2 → line 3 col 5. They share position (2, 2..3).
+    # Merged: line 1 col 1 → line 3 col 5, rule_ids=[A, B].
+    findings = [
+        {
+            "RuleID": "rule-a",
+            "StartLine": 1,
+            "EndLine": 2,
+            "StartColumn": 1,
+            "EndColumn": 3,
+        },
+        {
+            "RuleID": "rule-b",
+            "StartLine": 2,
+            "EndLine": 3,
+            "StartColumn": 2,
+            "EndColumn": 5,
+        },
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact("aaaaa\nbbbbb\nccccc\n", cwd=tmp_path)
+
+    assert out.count("[REDACTED:") == 1
+    assert "[REDACTED:rule-a,rule-b]" in out
+    assert flags == ["rule-a", "rule-b"]
+
+
+def test_redact_non_overlapping_findings_stay_separate(tmp_path: Path) -> None:
+    """Non-overlapping findings must NOT merge — two markers, disjoint splices.
+
+    Regression guard for the overlap-merge pass: ranges [1..5] and
+    [7..11] share no position (col 6 sits between them), so the merge
+    logic must keep them separate. Otherwise adjacent findings would
+    collapse unnecessarily and lose per-rule attribution.
+    """
+    findings = [
+        {
+            "RuleID": "rule-a",
+            "StartLine": 1,
+            "EndLine": 1,
+            "StartColumn": 1,
+            "EndColumn": 5,
+        },
+        {
+            "RuleID": "rule-b",
+            "StartLine": 1,
+            "EndLine": 1,
+            "StartColumn": 7,
+            "EndColumn": 11,
+        },
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact("AAAAA BBBBB end", cwd=tmp_path)
+
+    assert out.count("[REDACTED:rule-a]") == 1
+    assert out.count("[REDACTED:rule-b]") == 1
+    # No composite marker.
+    assert "[REDACTED:rule-a,rule-b]" not in out
+    assert flags == ["rule-a", "rule-b"]
 
 
 # ---------------------------------------------------------------------------

--- a/daemon/tests/test_specialist_redaction.py
+++ b/daemon/tests/test_specialist_redaction.py
@@ -105,3 +105,147 @@ def test_redact_raises_on_non_list_json() -> None:
     with patch("subprocess.run", return_value=_ok('{"oops": true}')):
         with pytest.raises(RedactionError, match="list"):
             redact("anything")
+
+
+# ---------------------------------------------------------------------------
+# Splicing logic — single-line, multi-line, dedup
+# ---------------------------------------------------------------------------
+
+
+def _finding_json(findings: list[dict[str, object]]) -> str:
+    """Render a list of gitleaks-shaped finding dicts as JSON stdout."""
+    import json as _json
+
+    return _json.dumps(findings)
+
+
+def test_redact_splices_single_finding() -> None:
+    """One github-pat → marker replaces the match, rule id returned.
+
+    Concatenation form keeps the source file out of lefthook's
+    gitleaks-staged rule while the runtime value is a 40-char
+    shape-matching fake. The subprocess mock returns canned findings
+    regardless of what we pass in.
+    """
+    input_text = "github_pat = ghp_" + ("x" * 36) + "\n"  # gitleaks:allow
+    findings = [
+        {
+            "RuleID": "github-pat",
+            "StartLine": 1,
+            "EndLine": 1,
+            "StartColumn": 14,  # 1-indexed start of the ghp_ token
+            "EndColumn": 53,  # end-inclusive, 1-indexed, 40-char span
+        }
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact(input_text)
+
+    # The shape-matching "token" built by concatenation above must be gone.
+    assert ("ghp_" + ("x" * 36)) not in out  # gitleaks:allow
+    assert "[REDACTED:github-pat]" in out
+    assert flags == ["github-pat"]
+
+
+def test_redact_deduplicates_same_rule() -> None:
+    """Three github-pat findings on separate lines → three splices, one flag entry."""
+    input_text = (
+        "a = ghp_" + ("a" * 36) + "\n"  # gitleaks:allow
+        "b = ghp_" + ("b" * 36) + "\n"  # gitleaks:allow
+        "c = ghp_" + ("c" * 36) + "\n"  # gitleaks:allow
+    )
+    findings = [
+        {
+            "RuleID": "github-pat",
+            "StartLine": i,
+            "EndLine": i,
+            "StartColumn": 5,
+            "EndColumn": 44,
+        }
+        for i in (1, 2, 3)
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact(input_text)
+
+    assert out.count("[REDACTED:github-pat]") == 3
+    assert flags == ["github-pat"]
+
+
+def test_redact_preserves_rule_order_across_types() -> None:
+    """Multiple distinct rules → flag list preserves first-occurrence order."""
+    input_text = "line1 with github\nline2 with aws\n"
+    findings = [
+        {
+            "RuleID": "github-pat",
+            "StartLine": 1,
+            "EndLine": 1,
+            "StartColumn": 12,
+            "EndColumn": 17,
+        },
+        {
+            "RuleID": "aws-access-key",
+            "StartLine": 2,
+            "EndLine": 2,
+            "StartColumn": 12,
+            "EndColumn": 14,
+        },
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        _, flags = redact(input_text)
+
+    assert flags == ["github-pat", "aws-access-key"]
+
+
+def test_redact_collapses_multi_line_finding_to_single_marker() -> None:
+    """Multi-line finding → one marker replaces the entire range.
+
+    Uses generic placeholder lines rather than a real-looking private
+    key block — that literal shape would trip gitleaks' ``private-key``
+    rule at commit time on this source file. The mocked subprocess
+    returns canned findings regardless.
+    """
+    input_text = (
+        "context before\n"
+        "PLACEHOLDER_LINE_1\n"
+        "PLACEHOLDER_LINE_2_WITH_KEY_MATERIAL\n"
+        "PLACEHOLDER_LINE_3\n"
+        "context after\n"
+    )
+    findings = [
+        {
+            "RuleID": "private-key",
+            "StartLine": 2,
+            "EndLine": 4,
+            "StartColumn": 1,
+            "EndColumn": 18,  # length of "PLACEHOLDER_LINE_3"
+        }
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact(input_text)
+
+    assert "PLACEHOLDER_LINE_1" not in out
+    assert "PLACEHOLDER_LINE_2_WITH_KEY_MATERIAL" not in out
+    assert "PLACEHOLDER_LINE_3" not in out
+    assert "[REDACTED:private-key]" in out
+    # Bookend context preserved.
+    assert "context before" in out
+    assert "context after" in out
+    assert flags == ["private-key"]
+
+
+def test_redact_splices_without_shifting_earlier_findings() -> None:
+    """Two findings on the same line: marker for the later one doesn't shift the earlier."""
+    input_text = "alpha AAAAAAAA beta BBBBBBBB end\n"
+    findings = [
+        {"RuleID": "rule-a", "StartLine": 1, "EndLine": 1, "StartColumn": 7, "EndColumn": 14},
+        {"RuleID": "rule-b", "StartLine": 1, "EndLine": 1, "StartColumn": 21, "EndColumn": 28},
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, _ = redact(input_text)
+
+    assert "AAAAAAAA" not in out
+    assert "BBBBBBBB" not in out
+    assert out.count("[REDACTED:rule-a]") == 1
+    assert out.count("[REDACTED:rule-b]") == 1
+    # Bookend words still present and in order.
+    assert out.index("alpha") < out.index("[REDACTED:rule-a]") < out.index("beta")
+    assert out.index("beta") < out.index("[REDACTED:rule-b]") < out.index("end")

--- a/daemon/tests/test_specialist_redaction.py
+++ b/daemon/tests/test_specialist_redaction.py
@@ -7,6 +7,7 @@ binary. Mirrors the shape of ``test_specialist_pr_reviewer.py``.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from unittest.mock import patch
 
@@ -249,3 +250,41 @@ def test_redact_splices_without_shifting_earlier_findings() -> None:
     # Bookend words still present and in order.
     assert out.index("alpha") < out.index("[REDACTED:rule-a]") < out.index("beta")
     assert out.index("beta") < out.index("[REDACTED:rule-b]") < out.index("end")
+
+
+# ---------------------------------------------------------------------------
+# Integration (gated) — real gitleaks binary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_redact_real_gitleaks_catches_synthetic_pat() -> None:
+    """End-to-end smoke: pipe a synthetic GitHub PAT through real gitleaks.
+
+    Gated on ``REACHY_DUCKY_RUN_INTEGRATION=1`` — the only test in
+    this module that requires the actual binary on PATH. Mirrors the
+    gating pattern from
+    ``test_specialist_pr_reviewer.test_pr_reviewer_live_claude``.
+
+    Uses a concatenated PAT shape so the source file itself stays out
+    of gitleaks' commit-time scan; the runtime value is 40 chars of
+    ``ghp_`` + 36 mixed-case alphanumeric. The 36-char body must have
+    enough entropy (~5.0) to clear gitleaks' ``github-pat`` rule —
+    homogeneous strings like ``"A" * 36`` won't trigger it.
+    """
+    if not os.environ.get("REACHY_DUCKY_RUN_INTEGRATION"):
+        pytest.skip("set REACHY_DUCKY_RUN_INTEGRATION=1 to run")
+
+    # High-entropy mixed-case body (36 chars). Built via concatenation so
+    # the literal in source doesn't match gitleaks' regex.
+    fake_pat = "ghp_" + "xK9Pm2Qw7nL8tRa5VcFgHjKbNdEfShUzMvXy"  # gitleaks:allow
+    synthetic = f"benign preamble\ngithub_pat = {fake_pat}\npostamble line\n"
+
+    redacted, flags = redact(synthetic)
+
+    assert fake_pat not in redacted
+    assert "[REDACTED:github-pat]" in redacted
+    assert "github-pat" in flags
+    # Non-secret content preserved.
+    assert "benign preamble" in redacted
+    assert "postamble line" in redacted

--- a/daemon/tests/test_specialist_redaction.py
+++ b/daemon/tests/test_specialist_redaction.py
@@ -1,0 +1,107 @@
+"""Tests for :func:`redact`.
+
+Unit tier mocks ``subprocess.run`` at the boundary — no real ``gitleaks``
+invocation. A gated integration test at the bottom exercises the real
+binary. Mirrors the shape of ``test_specialist_pr_reviewer.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from reachy_ducky_daemon.specialists.redaction import (
+    _GITLEAKS_TIMEOUT_SECONDS,
+    RedactionError,
+    redact,
+)
+
+
+def _ok(stdout: str) -> subprocess.CompletedProcess[str]:
+    """Shorthand for a successful ``CompletedProcess`` with canned stdout."""
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_gitleaks_timeout_matches_gh_timeout_precedent() -> None:
+    """_GITLEAKS_TIMEOUT_SECONDS aligns with pr_reviewer's 30s gh timeout.
+
+    Keeps the "subprocess operation time budget" consistent across
+    specialist helpers — any future bump is a deliberate edit in one
+    place.
+    """
+    assert _GITLEAKS_TIMEOUT_SECONDS == 30.0
+
+
+def test_redact_passes_clean_text_through_unchanged() -> None:
+    """Empty JSON findings → input text unchanged, empty flag list."""
+    with patch("subprocess.run", return_value=_ok("[]")):
+        out, flags = redact("just benign text\nno secrets here\n")
+
+    assert out == "just benign text\nno secrets here\n"
+    assert flags == []
+
+
+def test_redact_invokes_gitleaks_stdin_with_expected_flags() -> None:
+    """Argv contract: gitleaks stdin with our flag set."""
+    with patch("subprocess.run", return_value=_ok("[]")) as m:
+        redact("anything")
+
+    argv = m.call_args.args[0]
+    assert argv[:2] == ["gitleaks", "stdin"]
+    assert "--no-banner" in argv
+    assert "--exit-code" in argv
+    assert "0" in argv  # exit-code value
+    assert "--report-format" in argv
+    assert "json" in argv
+    assert "--report-path" in argv
+    assert "-" in argv  # stdout sentinel
+    assert "--redact" in argv
+
+    call_kwargs = m.call_args.kwargs
+    assert call_kwargs["check"] is False
+    assert call_kwargs["text"] is True
+    assert call_kwargs["timeout"] == _GITLEAKS_TIMEOUT_SECONDS
+    # Input is piped via stdin.
+    assert call_kwargs["input"] == "anything"
+
+
+def test_redact_raises_on_missing_binary() -> None:
+    """FileNotFoundError from subprocess (binary missing) → RedactionError."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("gitleaks")):
+        with pytest.raises(RedactionError, match="gitleaks"):
+            redact("anything")
+
+
+def test_redact_raises_on_timeout() -> None:
+    """TimeoutExpired → RedactionError with 'timeout' in the message."""
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="gitleaks", timeout=30.0),
+    ):
+        with pytest.raises(RedactionError, match="timeout"):
+            redact("anything")
+
+
+def test_redact_raises_on_non_zero_exit() -> None:
+    """Non-zero exit (gitleaks crashed) → RedactionError with stderr in message."""
+    bad = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="gitleaks: fatal: bad config"
+    )
+    with patch("subprocess.run", return_value=bad):
+        with pytest.raises(RedactionError, match="fatal: bad config"):
+            redact("anything")
+
+
+def test_redact_raises_on_malformed_json() -> None:
+    """Malformed JSON on stdout → RedactionError."""
+    with patch("subprocess.run", return_value=_ok("not json")):
+        with pytest.raises(RedactionError, match="JSON"):
+            redact("anything")
+
+
+def test_redact_raises_on_non_list_json() -> None:
+    """Unexpected JSON shape (object instead of list) → RedactionError."""
+    with patch("subprocess.run", return_value=_ok('{"oops": true}')):
+        with pytest.raises(RedactionError, match="list"):
+            redact("anything")

--- a/daemon/tests/test_specialist_redaction.py
+++ b/daemon/tests/test_specialist_redaction.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -34,19 +35,19 @@ def test_gitleaks_timeout_matches_gh_timeout_precedent() -> None:
     assert _GITLEAKS_TIMEOUT_SECONDS == 30.0
 
 
-def test_redact_passes_clean_text_through_unchanged() -> None:
+def test_redact_passes_clean_text_through_unchanged(tmp_path: Path) -> None:
     """Empty JSON findings → input text unchanged, empty flag list."""
     with patch("subprocess.run", return_value=_ok("[]")):
-        out, flags = redact("just benign text\nno secrets here\n")
+        out, flags = redact("just benign text\nno secrets here\n", cwd=tmp_path)
 
     assert out == "just benign text\nno secrets here\n"
     assert flags == []
 
 
-def test_redact_invokes_gitleaks_stdin_with_expected_flags() -> None:
-    """Argv contract: gitleaks stdin with our flag set."""
+def test_redact_invokes_gitleaks_stdin_with_expected_flags(tmp_path: Path) -> None:
+    """Argv + kwargs contract: gitleaks stdin with our flag set, cwd threaded through."""
     with patch("subprocess.run", return_value=_ok("[]")) as m:
-        redact("anything")
+        redact("anything", cwd=tmp_path)
 
     argv = m.call_args.args[0]
     assert argv[:2] == ["gitleaks", "stdin"]
@@ -65,57 +66,60 @@ def test_redact_invokes_gitleaks_stdin_with_expected_flags() -> None:
     assert call_kwargs["timeout"] == _GITLEAKS_TIMEOUT_SECONDS
     # Input is piped via stdin.
     assert call_kwargs["input"] == "anything"
+    # cwd is threaded through so gitleaks runs in the project dir and
+    # picks up any repo-local .gitleaks.toml (mirrors lefthook).
+    assert call_kwargs["cwd"] == tmp_path
 
 
-def test_redact_raises_on_missing_binary() -> None:
+def test_redact_raises_on_missing_binary(tmp_path: Path) -> None:
     """FileNotFoundError from subprocess (binary missing) → RedactionError."""
     with patch("subprocess.run", side_effect=FileNotFoundError("gitleaks")):
         with pytest.raises(RedactionError, match="gitleaks"):
-            redact("anything")
+            redact("anything", cwd=tmp_path)
 
 
-def test_redact_raises_on_timeout() -> None:
+def test_redact_raises_on_timeout(tmp_path: Path) -> None:
     """TimeoutExpired → RedactionError with 'timeout' in the message."""
     with patch(
         "subprocess.run",
         side_effect=subprocess.TimeoutExpired(cmd="gitleaks", timeout=30.0),
     ):
         with pytest.raises(RedactionError, match="timeout"):
-            redact("anything")
+            redact("anything", cwd=tmp_path)
 
 
-def test_redact_raises_on_non_zero_exit() -> None:
+def test_redact_raises_on_non_zero_exit(tmp_path: Path) -> None:
     """Non-zero exit (gitleaks crashed) → RedactionError with stderr in message."""
     bad = subprocess.CompletedProcess(
         args=[], returncode=1, stdout="", stderr="gitleaks: fatal: bad config"
     )
     with patch("subprocess.run", return_value=bad):
         with pytest.raises(RedactionError, match="fatal: bad config"):
-            redact("anything")
+            redact("anything", cwd=tmp_path)
 
 
-def test_redact_raises_on_malformed_json() -> None:
+def test_redact_raises_on_malformed_json(tmp_path: Path) -> None:
     """Malformed JSON on stdout → RedactionError."""
     with patch("subprocess.run", return_value=_ok("not json")):
         with pytest.raises(RedactionError, match="JSON"):
-            redact("anything")
+            redact("anything", cwd=tmp_path)
 
 
-def test_redact_raises_on_non_list_json() -> None:
+def test_redact_raises_on_non_list_json(tmp_path: Path) -> None:
     """Unexpected JSON shape (object instead of list) → RedactionError."""
     with patch("subprocess.run", return_value=_ok('{"oops": true}')):
         with pytest.raises(RedactionError, match="list"):
-            redact("anything")
+            redact("anything", cwd=tmp_path)
 
 
-def test_redact_raises_on_generic_subprocess_error() -> None:
+def test_redact_raises_on_generic_subprocess_error(tmp_path: Path) -> None:
     """OSError / generic SubprocessError → RedactionError (not a crash)."""
     with patch("subprocess.run", side_effect=OSError("permission denied")):
         with pytest.raises(RedactionError, match="subprocess failed"):
-            redact("anything")
+            redact("anything", cwd=tmp_path)
 
 
-def test_redact_raises_on_non_dict_finding_entry() -> None:
+def test_redact_raises_on_non_dict_finding_entry(tmp_path: Path) -> None:
     """JSON list entry that isn't an object → RedactionError (fail closed).
 
     Silently dropping malformed findings could leave secrets in the
@@ -123,18 +127,18 @@ def test_redact_raises_on_non_dict_finding_entry() -> None:
     """
     with patch("subprocess.run", return_value=_ok('["not a dict"]')):
         with pytest.raises(RedactionError, match="not an object"):
-            redact("anything")
+            redact("anything", cwd=tmp_path)
 
 
-def test_redact_raises_on_finding_missing_required_field() -> None:
+def test_redact_raises_on_finding_missing_required_field(tmp_path: Path) -> None:
     """Finding object missing RuleID/StartLine/etc. → RedactionError."""
     incomplete = '[{"RuleID": "github-pat", "StartLine": 1}]'
     with patch("subprocess.run", return_value=_ok(incomplete)):
         with pytest.raises(RedactionError, match="missing required field"):
-            redact("anything")
+            redact("anything", cwd=tmp_path)
 
 
-def test_redact_raises_on_finding_out_of_range() -> None:
+def test_redact_raises_on_finding_out_of_range(tmp_path: Path) -> None:
     """Finding coords beyond the parsed line count → RedactionError (fail closed).
 
     gitleaks and our ``text.split('\\n')`` disagreeing about line structure
@@ -147,7 +151,44 @@ def test_redact_raises_on_finding_out_of_range() -> None:
     )
     with patch("subprocess.run", return_value=_ok(findings_out_of_range)):
         with pytest.raises(RedactionError, match="out of range"):
-            redact("short input")
+            redact("short input", cwd=tmp_path)
+
+
+def test_redact_raises_on_non_positive_start_column(tmp_path: Path) -> None:
+    """StartColumn ≤ 0 → RedactionError (Python slicing with negatives silently wraps)."""
+    bad = '[{"RuleID": "x", "StartLine": 1, "EndLine": 1, "StartColumn": 0, "EndColumn": 5}]'
+    with patch("subprocess.run", return_value=_ok(bad)):
+        with pytest.raises(RedactionError, match="invalid column range"):
+            redact("short input", cwd=tmp_path)
+
+
+def test_redact_raises_on_end_before_start(tmp_path: Path) -> None:
+    """EndColumn < StartColumn → RedactionError (would splice the wrong range)."""
+    bad = '[{"RuleID": "x", "StartLine": 1, "EndLine": 1, "StartColumn": 8, "EndColumn": 3}]'
+    with patch("subprocess.run", return_value=_ok(bad)):
+        with pytest.raises(RedactionError, match="invalid column range"):
+            redact("short input", cwd=tmp_path)
+
+
+def test_redact_raises_on_end_column_past_line_length(tmp_path: Path) -> None:
+    """EndColumn past line length → RedactionError.
+
+    Silent Python slice clamping would leave a partial secret behind;
+    fail closed instead.
+    """
+    # "short" is 5 chars; EndColumn 999 would clamp silently if we didn't validate.
+    bad = '[{"RuleID": "x", "StartLine": 1, "EndLine": 1, "StartColumn": 1, "EndColumn": 999}]'
+    with patch("subprocess.run", return_value=_ok(bad)):
+        with pytest.raises(RedactionError, match="exceeds line"):
+            redact("short", cwd=tmp_path)
+
+
+def test_redact_raises_on_multiline_start_column_past_line_length(tmp_path: Path) -> None:
+    """Multi-line finding with StartColumn past start-line length → RedactionError."""
+    bad = '[{"RuleID": "x", "StartLine": 1, "EndLine": 2, "StartColumn": 999, "EndColumn": 1}]'
+    with patch("subprocess.run", return_value=_ok(bad)):
+        with pytest.raises(RedactionError, match="StartColumn"):
+            redact("short\nlines here\n", cwd=tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -162,7 +203,7 @@ def _finding_json(findings: list[dict[str, object]]) -> str:
     return _json.dumps(findings)
 
 
-def test_redact_splices_single_finding() -> None:
+def test_redact_splices_single_finding(tmp_path: Path) -> None:
     """One github-pat → marker replaces the match, rule id returned.
 
     Concatenation form keeps the source file out of lefthook's
@@ -181,7 +222,7 @@ def test_redact_splices_single_finding() -> None:
         }
     ]
     with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
-        out, flags = redact(input_text)
+        out, flags = redact(input_text, cwd=tmp_path)
 
     # The shape-matching "token" built by concatenation above must be gone.
     assert ("ghp_" + ("x" * 36)) not in out  # gitleaks:allow
@@ -189,7 +230,7 @@ def test_redact_splices_single_finding() -> None:
     assert flags == ["github-pat"]
 
 
-def test_redact_deduplicates_same_rule() -> None:
+def test_redact_deduplicates_same_rule(tmp_path: Path) -> None:
     """Three github-pat findings on separate lines → three splices, one flag entry."""
     input_text = (
         "a = ghp_" + ("a" * 36) + "\n"  # gitleaks:allow
@@ -207,13 +248,13 @@ def test_redact_deduplicates_same_rule() -> None:
         for i in (1, 2, 3)
     ]
     with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
-        out, flags = redact(input_text)
+        out, flags = redact(input_text, cwd=tmp_path)
 
     assert out.count("[REDACTED:github-pat]") == 3
     assert flags == ["github-pat"]
 
 
-def test_redact_preserves_rule_order_across_types() -> None:
+def test_redact_preserves_rule_order_across_types(tmp_path: Path) -> None:
     """Multiple distinct rules → flag list preserves first-occurrence order."""
     input_text = "line1 with github\nline2 with aws\n"
     findings = [
@@ -233,12 +274,12 @@ def test_redact_preserves_rule_order_across_types() -> None:
         },
     ]
     with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
-        _, flags = redact(input_text)
+        _, flags = redact(input_text, cwd=tmp_path)
 
     assert flags == ["github-pat", "aws-access-key"]
 
 
-def test_redact_collapses_multi_line_finding_to_single_marker() -> None:
+def test_redact_collapses_multi_line_finding_to_single_marker(tmp_path: Path) -> None:
     """Multi-line finding → one marker replaces the entire range.
 
     Uses generic placeholder lines rather than a real-looking private
@@ -263,7 +304,7 @@ def test_redact_collapses_multi_line_finding_to_single_marker() -> None:
         }
     ]
     with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
-        out, flags = redact(input_text)
+        out, flags = redact(input_text, cwd=tmp_path)
 
     assert "PLACEHOLDER_LINE_1" not in out
     assert "PLACEHOLDER_LINE_2_WITH_KEY_MATERIAL" not in out
@@ -275,7 +316,7 @@ def test_redact_collapses_multi_line_finding_to_single_marker() -> None:
     assert flags == ["private-key"]
 
 
-def test_redact_splices_without_shifting_earlier_findings() -> None:
+def test_redact_splices_without_shifting_earlier_findings(tmp_path: Path) -> None:
     """Two findings on the same line: marker for the later one doesn't shift the earlier."""
     input_text = "alpha AAAAAAAA beta BBBBBBBB end\n"
     findings = [
@@ -283,7 +324,7 @@ def test_redact_splices_without_shifting_earlier_findings() -> None:
         {"RuleID": "rule-b", "StartLine": 1, "EndLine": 1, "StartColumn": 21, "EndColumn": 28},
     ]
     with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
-        out, _ = redact(input_text)
+        out, _ = redact(input_text, cwd=tmp_path)
 
     assert "AAAAAAAA" not in out
     assert "BBBBBBBB" not in out
@@ -300,7 +341,7 @@ def test_redact_splices_without_shifting_earlier_findings() -> None:
 
 
 @pytest.mark.integration
-def test_redact_real_gitleaks_catches_synthetic_pat() -> None:
+def test_redact_real_gitleaks_catches_synthetic_pat(tmp_path: Path) -> None:
     """End-to-end smoke: pipe a synthetic GitHub PAT through real gitleaks.
 
     Gated on ``REACHY_DUCKY_RUN_INTEGRATION=1`` — the only test in
@@ -322,7 +363,7 @@ def test_redact_real_gitleaks_catches_synthetic_pat() -> None:
     fake_pat = "ghp_" + "xK9Pm2Qw7nL8tRa5VcFgHjKbNdEfShUzMvXy"  # gitleaks:allow
     synthetic = f"benign preamble\ngithub_pat = {fake_pat}\npostamble line\n"
 
-    redacted, flags = redact(synthetic)
+    redacted, flags = redact(synthetic, cwd=tmp_path)
 
     assert fake_pat not in redacted
     assert "[REDACTED:github-pat]" in redacted

--- a/daemon/tests/test_specialist_redaction.py
+++ b/daemon/tests/test_specialist_redaction.py
@@ -108,6 +108,48 @@ def test_redact_raises_on_non_list_json() -> None:
             redact("anything")
 
 
+def test_redact_raises_on_generic_subprocess_error() -> None:
+    """OSError / generic SubprocessError → RedactionError (not a crash)."""
+    with patch("subprocess.run", side_effect=OSError("permission denied")):
+        with pytest.raises(RedactionError, match="subprocess failed"):
+            redact("anything")
+
+
+def test_redact_raises_on_non_dict_finding_entry() -> None:
+    """JSON list entry that isn't an object → RedactionError (fail closed).
+
+    Silently dropping malformed findings could leave secrets in the
+    output, so any list element we can't narrow becomes an error.
+    """
+    with patch("subprocess.run", return_value=_ok('["not a dict"]')):
+        with pytest.raises(RedactionError, match="not an object"):
+            redact("anything")
+
+
+def test_redact_raises_on_finding_missing_required_field() -> None:
+    """Finding object missing RuleID/StartLine/etc. → RedactionError."""
+    incomplete = '[{"RuleID": "github-pat", "StartLine": 1}]'
+    with patch("subprocess.run", return_value=_ok(incomplete)):
+        with pytest.raises(RedactionError, match="missing required field"):
+            redact("anything")
+
+
+def test_redact_raises_on_finding_out_of_range() -> None:
+    """Finding coords beyond the parsed line count → RedactionError (fail closed).
+
+    gitleaks and our ``text.split('\\n')`` disagreeing about line structure
+    means we can't trust the splice coordinates — better to abort than
+    risk a mis-placed marker that leaves a secret partially in.
+    """
+    # One-line input, finding claims it's on line 99.
+    findings_out_of_range = (
+        '[{"RuleID": "x", "StartLine": 99, "EndLine": 99, "StartColumn": 1, "EndColumn": 5}]'
+    )
+    with patch("subprocess.run", return_value=_ok(findings_out_of_range)):
+        with pytest.raises(RedactionError, match="out of range"):
+            redact("short input")
+
+
 # ---------------------------------------------------------------------------
 # Splicing logic — single-line, multi-line, dedup
 # ---------------------------------------------------------------------------

--- a/docs/plans/2026-04-21-reachy-ducky-design.md
+++ b/docs/plans/2026-04-21-reachy-ducky-design.md
@@ -185,7 +185,7 @@ Three escalation levels:
 ## 10. Privacy / redaction
 
 - **Repo allowlist.** Ducky reads only repos the user opts in. New repos require explicit "watch this project" onboarding; unknown repos are invisible.
-- **Secret redaction pre-send.** `gitleaks`/`trufflehog` patterns run on any diff/file content before it goes to the thinking brain; matches redacted inline.
+- **Secret redaction pre-send (landed 2026-04-23).** `gitleaks stdin` runs over every specialist-assembled prompt before it reaches `brain.query()`; matches are spliced with `[REDACTED:<RuleID>]` and surface as `redacted:<rule_id>` flags on the `SpecialistResponse`. Fail-closed: a broken `gitleaks` install aborts the review with a `redaction-failed` flag — no brain call fires. Shared helper: `daemon/src/reachy_ducky_daemon/specialists/redaction.py`. Gitleaks config precedence mirrors lefthook's pre-commit hook, so "what's a secret" stays unified across commit-time and brain-time. See `docs/plans/2026-04-23-secret-redaction-specialists.md` and closed issue #50.
 - **Hard blocklist by default:** `.env*`, `*.pem`, `*.key`, `id_rsa*`, `secrets/**`, `credentials*`. Extensible per-project.
 - **Transcript ingestion (phase D)**: opt-in per project, never default.
 

--- a/docs/plans/2026-04-23-secret-redaction-specialists.md
+++ b/docs/plans/2026-04-23-secret-redaction-specialists.md
@@ -1,0 +1,1132 @@
+# Secret Redaction Across Specialists — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Implement design doc §10's pre-brain secret redaction. Pipe every specialist-assembled prompt through `gitleaks stdin` before `brain.query()`, splice `[REDACTED:<RuleID>]` markers in place of matches, surface findings as `redacted:<RuleID>` flags. Fail-closed: if redaction can't run, abort the review with a diagnostic `SpecialistResponse` rather than risk leaking secrets. **Closes #50.**
+
+**Architecture:** Shared helper module `daemon/src/reachy_ducky_daemon/specialists/redaction.py` exports `redact(text: str) -> tuple[str, list[str]]`, which invokes `gitleaks stdin` as a subprocess, parses its JSON findings, and splices markers inline using the reported 1-indexed (StartLine, StartColumn, EndLine, EndColumn) coordinates. Each specialist's `review()` wraps the call in a try/except; on `RedactionError` the specialist returns a 200 `SpecialistResponse` with `flags=["redaction-failed"]` and no brain call fires.
+
+**Tech Stack:**
+- Python 3.12, `uv` workspace
+- `gitleaks` (Go binary, already on PATH locally and trusted by `lefthook pre-commit`)
+- `subprocess` (list-form, `shell=False`, stdin-piped, 30s timeout)
+- `pytest`, `unittest.mock.patch` for subprocess mocking
+- Pydantic v2 `SpecialistResponse` (no protocol changes — flags list already carries machine-tags)
+
+**Conventions:**
+- TDD per task: failing test → run (confirm failure shape) → minimal impl → run (pass) → commit.
+- Subprocess list-form, `check=False`, stderr surfaced in exception messages.
+- Unit tests mock `subprocess.run`; no real `gitleaks` invocation at the unit tier.
+- One `@pytest.mark.integration` smoke test exercises the real binary, gated on `REACHY_DUCKY_RUN_INTEGRATION=1`.
+- Per-task gate before commit: `uv run ruff check . && uv run ruff format --check . && uv run mypy --strict <touched> && uv run pytest -q`.
+- Full-branch gate before push: `uv run ruff check . && uv run ruff format --check . && uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests && uv run pyright && uv run bandit -ll -r daemon/src app/src menubar/src protocol/src && uv run pytest -q --cov`. Helper ≥ 95% coverage; overall ≥ 90%.
+
+**Reference skills:** @superpowers:test-driven-development, @superpowers:verification-before-completion
+
+**Template to mirror:** `daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py` — subprocess helper shape (`_run_gh`), error-as-data pattern, module layout, docstring style. The helper here is a single-function module (not a class) because it's stateless.
+
+---
+
+## Milestone 1 — Redaction helper module
+
+### Task 1.1: Scaffold `redaction.py` + `RedactionError` + subprocess invocation
+
+**Files:**
+- Create: `daemon/src/reachy_ducky_daemon/specialists/redaction.py`
+- Create: `daemon/tests/test_specialist_redaction.py`
+
+**Step 1: Write the failing tests**
+
+Create `daemon/tests/test_specialist_redaction.py`:
+
+```python
+"""Tests for :func:`redact`.
+
+Unit tier mocks ``subprocess.run`` at the boundary — no real ``gitleaks``
+invocation. A gated integration test at the bottom exercises the real
+binary. Mirrors the shape of ``test_specialist_pr_reviewer.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from reachy_ducky_daemon.specialists.redaction import (
+    _GITLEAKS_TIMEOUT_SECONDS,
+    RedactionError,
+    redact,
+)
+
+
+def _ok(stdout: str) -> subprocess.CompletedProcess[str]:
+    """Shorthand for a successful ``CompletedProcess`` with canned stdout."""
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_gitleaks_timeout_matches_gh_timeout_precedent() -> None:
+    """_GITLEAKS_TIMEOUT_SECONDS aligns with pr_reviewer's 30s gh timeout.
+
+    Keeps the "subprocess operation time budget" consistent across
+    specialist helpers — any future bump is a deliberate edit in one place.
+    """
+    assert _GITLEAKS_TIMEOUT_SECONDS == 30.0
+
+
+def test_redact_passes_clean_text_through_unchanged() -> None:
+    """Empty JSON findings → input text unchanged, empty flag list."""
+    with patch("subprocess.run", return_value=_ok("[]")):
+        out, flags = redact("just benign text\nno secrets here\n")
+
+    assert out == "just benign text\nno secrets here\n"
+    assert flags == []
+
+
+def test_redact_invokes_gitleaks_stdin_with_expected_flags() -> None:
+    """Argv contract: gitleaks stdin --no-banner --exit-code 0 --report-format json --report-path - --redact."""
+    with patch("subprocess.run", return_value=_ok("[]")) as m:
+        redact("anything")
+
+    argv = m.call_args.args[0]
+    assert argv[:2] == ["gitleaks", "stdin"]
+    assert "--no-banner" in argv
+    assert "--exit-code" in argv
+    assert "0" in argv  # exit-code value
+    assert "--report-format" in argv
+    assert "json" in argv
+    assert "--report-path" in argv
+    assert "-" in argv  # stdout sentinel
+    assert "--redact" in argv
+
+    call_kwargs = m.call_args.kwargs
+    assert call_kwargs["check"] is False
+    assert call_kwargs["text"] is True
+    assert call_kwargs["timeout"] == _GITLEAKS_TIMEOUT_SECONDS
+    # Input is piped via stdin.
+    assert call_kwargs["input"] == "anything"
+
+
+def test_redact_raises_on_missing_binary() -> None:
+    """FileNotFoundError from subprocess (binary missing) → RedactionError."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("gitleaks")):
+        with pytest.raises(RedactionError, match="gitleaks"):
+            redact("anything")
+
+
+def test_redact_raises_on_timeout() -> None:
+    """TimeoutExpired → RedactionError with 'timeout' in the message."""
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="gitleaks", timeout=30.0),
+    ):
+        with pytest.raises(RedactionError, match="timeout"):
+            redact("anything")
+
+
+def test_redact_raises_on_non_zero_exit() -> None:
+    """Non-zero exit (gitleaks crashed) → RedactionError with stderr in message."""
+    bad = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="gitleaks: fatal: bad config"
+    )
+    with patch("subprocess.run", return_value=bad):
+        with pytest.raises(RedactionError, match="fatal: bad config"):
+            redact("anything")
+
+
+def test_redact_raises_on_malformed_json() -> None:
+    """Malformed JSON on stdout → RedactionError."""
+    with patch("subprocess.run", return_value=_ok("not json")):
+        with pytest.raises(RedactionError, match="JSON"):
+            redact("anything")
+
+
+def test_redact_raises_on_non_list_json() -> None:
+    """Unexpected JSON shape (object instead of list) → RedactionError."""
+    with patch("subprocess.run", return_value=_ok('{"oops": true}')):
+        with pytest.raises(RedactionError, match="list"):
+            redact("anything")
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest daemon/tests/test_specialist_redaction.py -v`
+Expected: `ModuleNotFoundError: No module named 'reachy_ducky_daemon.specialists.redaction'` (module doesn't exist yet).
+
+**Step 3: Write minimal implementation**
+
+Create `daemon/src/reachy_ducky_daemon/specialists/redaction.py`:
+
+```python
+"""Pre-brain secret redaction using the ``gitleaks`` CLI.
+
+Specialists assemble prompts from user-controlled surfaces (plan text,
+diffs, PR bodies, review comments) and pass them to ``brain.query()``.
+Any secret pasted into one of those surfaces would otherwise flow
+straight to Claude. :func:`redact` pipes the assembled prompt through
+``gitleaks stdin``, splices ``[REDACTED:<RuleID>]`` over each match,
+and returns the sanitized text plus a deduplicated list of rule IDs
+the caller can emit as ``redacted:<rule_id>`` flags.
+
+Coherence with the rest of the stack: gitleaks honours any
+``.gitleaks.toml`` in the current directory via the same precedence
+chain as lefthook's ``gitleaks protect --staged``, so "what counts as
+a secret" stays unified across commit-time and brain-time.
+
+Fail policy: on any subprocess failure, malformed output, or missing
+binary, :func:`redact` raises :class:`RedactionError`. Callers route
+to a fail-closed diagnostic ``SpecialistResponse`` — no brain call
+fires when redaction can't run.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404 — list-form read-only gitleaks only; no shell
+from typing import TypedDict
+
+__all__ = [
+    "_GITLEAKS_TIMEOUT_SECONDS",
+    "RedactionError",
+    "redact",
+]
+
+_GITLEAKS_TIMEOUT_SECONDS = 30.0
+
+
+class RedactionError(RuntimeError):
+    """Raised when redaction cannot run to completion.
+
+    Intentionally a ``RuntimeError`` so specialists can catch broadly.
+    The str(exc) carries enough context for the diagnostic response.
+    """
+
+
+class _Finding(TypedDict):
+    """Narrow view of a gitleaks finding — only the fields we consume."""
+
+    RuleID: str
+    StartLine: int
+    EndLine: int
+    StartColumn: int
+    EndColumn: int
+
+
+def redact(text: str) -> tuple[str, list[str]]:
+    """Return ``(redacted_text, deduplicated_rule_ids)``.
+
+    Invokes ``gitleaks stdin`` with ``--redact`` (so raw secrets never
+    appear in the JSON output we parse) and splices
+    ``[REDACTED:<RuleID>]`` into ``text`` at each reported position.
+    Rule IDs in the returned list are deduplicated, order-preserved
+    (first occurrence wins).
+
+    Raises :class:`RedactionError` on missing binary, subprocess
+    timeout, non-zero exit, malformed JSON, or unexpected JSON shape.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603  # nosec B603 B607 — list form, read-only gitleaks only
+            [
+                "gitleaks",
+                "stdin",
+                "--no-banner",
+                "--exit-code",
+                "0",
+                "--report-format",
+                "json",
+                "--report-path",
+                "-",
+                "--redact",
+            ],
+            input=text,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GITLEAKS_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError as exc:
+        raise RedactionError(f"gitleaks binary not found on PATH: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RedactionError(
+            f"gitleaks stdin timed out after {_GITLEAKS_TIMEOUT_SECONDS}s"
+        ) from exc
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RedactionError(f"gitleaks subprocess failed: {exc}") from exc
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "non-zero exit"
+        raise RedactionError(f"gitleaks stdin failed: {stderr}")
+
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RedactionError(f"gitleaks stdin emitted unparseable JSON: {exc}") from exc
+
+    if not isinstance(parsed, list):
+        raise RedactionError(
+            f"gitleaks stdin returned non-list JSON (unexpected shape): {type(parsed).__name__}"
+        )
+
+    # Splice + dedup land in Task 1.2. For now: pass text through, empty flags.
+    if not parsed:
+        return text, []
+    # Placeholder — next task implements splicing.
+    return text, []
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest daemon/tests/test_specialist_redaction.py -v`
+Expected: all 8 tests PASS (pass-through test passes because findings list is empty; splicing tests come in Task 1.2).
+
+Also run the type-check:
+`uv run mypy --strict daemon/src daemon/tests`
+Expected: no new errors.
+
+Bandit check:
+`uv run bandit -ll -r daemon/src`
+Expected: no medium/high findings.
+
+**Step 5: Commit**
+
+```bash
+git add daemon/src/reachy_ducky_daemon/specialists/redaction.py daemon/tests/test_specialist_redaction.py
+git commit -m "feat(specialists): scaffold redaction helper with RedactionError
+
+Module entrypoint for pre-brain secret redaction per design doc §10 and
+issue #50. Mirrors pr_reviewer's subprocess helper shape: list-form args,
+check=False, stderr-as-diagnostic, 30s timeout, no shell=True. Raises
+RedactionError on any subprocess failure mode so specialists can route
+to a fail-closed diagnostic response rather than risk leaking secrets.
+
+Splicing logic lands in the next task."
+```
+
+---
+
+### Task 1.2: Splicing logic — single-line, multi-line, dedup
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/redaction.py`
+- Modify: `daemon/tests/test_specialist_redaction.py`
+
+**Step 1: Write the failing tests**
+
+Append to `daemon/tests/test_specialist_redaction.py`:
+
+```python
+def _finding_json(findings: list[dict[str, object]]) -> str:
+    """Render a list of gitleaks-shaped finding dicts as JSON."""
+    import json as _json
+
+    return _json.dumps(findings)
+
+
+def test_redact_splices_single_finding() -> None:
+    """One github-pat → marker replaces the match, rule id returned."""
+    # Use Python concatenation so the source file doesn't contain a
+    # contiguous ``ghp_[A-Za-z0-9]{36}`` that lefthook's gitleaks-staged
+    # would catch at commit time. The runtime value is a 40-char
+    # shape-matching fake (``ghp_`` + 36 chars); mock subprocess returns
+    # canned findings regardless.
+    input_text = "github_pat = ghp_" + ("x" * 36) + "\n"  # gitleaks:allow
+    findings = [
+        {
+            "RuleID": "github-pat",
+            "StartLine": 1,
+            "EndLine": 1,
+            "StartColumn": 15,  # 1-indexed; gitleaks' empirically-observed offset
+            "EndColumn": 54,
+        }
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact(input_text)
+
+    # The shape-matching "token" built by concatenation above must be gone.
+    assert "ghp_" + ("x" * 36) not in out  # gitleaks:allow
+    assert "[REDACTED:github-pat]" in out
+    assert flags == ["github-pat"]
+
+
+def test_redact_deduplicates_same_rule() -> None:
+    """Three github-pat findings → three splices, one flag entry (dedup)."""
+    # Concatenation form again — source text stays unscannable while the
+    # runtime value has three shape-matching 40-char tokens on separate lines.
+    input_text = (
+        "a = ghp_" + ("a" * 36) + "\n"  # gitleaks:allow
+        "b = ghp_" + ("b" * 36) + "\n"  # gitleaks:allow
+        "c = ghp_" + ("c" * 36) + "\n"  # gitleaks:allow
+    )
+    findings = [
+        {"RuleID": "github-pat", "StartLine": i, "EndLine": i, "StartColumn": 5, "EndColumn": 44}
+        for i in (1, 2, 3)
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact(input_text)
+
+    assert out.count("[REDACTED:github-pat]") == 3
+    assert flags == ["github-pat"]
+
+
+def test_redact_preserves_rule_order_across_types() -> None:
+    """Multiple distinct rules → flag list preserves first-occurrence order."""
+    input_text = "line1 with github\nline2 with aws\n"
+    findings = [
+        {
+            "RuleID": "github-pat",
+            "StartLine": 1,
+            "EndLine": 1,
+            "StartColumn": 12,
+            "EndColumn": 18,
+        },
+        {
+            "RuleID": "aws-access-key",
+            "StartLine": 2,
+            "EndLine": 2,
+            "StartColumn": 12,
+            "EndColumn": 15,
+        },
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        _, flags = redact(input_text)
+
+    assert flags == ["github-pat", "aws-access-key"]
+
+
+def test_redact_collapses_multi_line_finding_to_single_marker() -> None:
+    """Multi-line finding (e.g. a private-key block) → one marker for the whole range.
+
+    Uses generic placeholder lines rather than a real-looking
+    ``-----BEGIN PRIVATE KEY-----`` block — which would trip gitleaks'
+    ``private-key`` rule at commit time on this source file itself.
+    The mocked subprocess returns canned findings at coords we pick, so
+    the input text's content is arbitrary.
+    """
+    input_text = (
+        "context before\n"
+        "PLACEHOLDER_LINE_1\n"
+        "PLACEHOLDER_LINE_2_WITH_KEY_MATERIAL\n"
+        "PLACEHOLDER_LINE_3\n"
+        "context after\n"
+    )
+    findings = [
+        {
+            "RuleID": "private-key",
+            "StartLine": 2,
+            "EndLine": 4,
+            "StartColumn": 1,
+            "EndColumn": 18,  # length of "PLACEHOLDER_LINE_3"
+        }
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, flags = redact(input_text)
+
+    assert "PLACEHOLDER_LINE_1" not in out
+    assert "PLACEHOLDER_LINE_2_WITH_KEY_MATERIAL" not in out
+    assert "PLACEHOLDER_LINE_3" not in out
+    assert "[REDACTED:private-key]" in out
+    # Bookend context preserved.
+    assert "context before" in out
+    assert "context after" in out
+    assert flags == ["private-key"]
+
+
+def test_redact_splices_without_shifting_earlier_findings() -> None:
+    """Two findings on the same line: marker for the later one doesn't shift the earlier."""
+    input_text = "alpha AAAAAAAA beta BBBBBBBB end\n"
+    findings = [
+        {"RuleID": "rule-a", "StartLine": 1, "EndLine": 1, "StartColumn": 7, "EndColumn": 14},
+        {"RuleID": "rule-b", "StartLine": 1, "EndLine": 1, "StartColumn": 21, "EndColumn": 28},
+    ]
+    with patch("subprocess.run", return_value=_ok(_finding_json(findings))):
+        out, _ = redact(input_text)
+
+    assert "AAAAAAAA" not in out
+    assert "BBBBBBBB" not in out
+    assert out.count("[REDACTED:rule-a]") == 1
+    assert out.count("[REDACTED:rule-b]") == 1
+    # Bookend words still present and in order.
+    assert out.index("alpha") < out.index("[REDACTED:rule-a]") < out.index("beta")
+    assert out.index("beta") < out.index("[REDACTED:rule-b]") < out.index("end")
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest daemon/tests/test_specialist_redaction.py -v`
+Expected: the 5 new tests FAIL (helper still passes text through unchanged); the 8 Task-1.1 tests continue to PASS.
+
+**Step 3: Write minimal implementation**
+
+Replace the placeholder tail of `redact()` with real splicing logic. The new function body (replace everything from `# Splice + dedup land in Task 1.2.` to the end):
+
+```python
+    if not parsed:
+        return text, []
+
+    # Narrow: only entries with the five required int+str fields are
+    # processed. Anything malformed becomes a RedactionError since we
+    # can't safely splice without trustworthy coordinates.
+    findings: list[_Finding] = []
+    for entry in parsed:
+        if not isinstance(entry, dict):
+            raise RedactionError("gitleaks finding is not an object")
+        try:
+            findings.append(
+                {
+                    "RuleID": str(entry["RuleID"]),
+                    "StartLine": int(entry["StartLine"]),
+                    "EndLine": int(entry["EndLine"]),
+                    "StartColumn": int(entry["StartColumn"]),
+                    "EndColumn": int(entry["EndColumn"]),
+                }
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RedactionError(
+                f"gitleaks finding missing required field: {exc}"
+            ) from exc
+
+    # Splice from the end so earlier splices don't shift later indices.
+    # Sort by (StartLine, StartColumn) descending.
+    findings.sort(key=lambda f: (f["StartLine"], f["StartColumn"]), reverse=True)
+
+    lines = text.split("\n")
+    for f in findings:
+        marker = f"[REDACTED:{f['RuleID']}]"
+        start_line_idx = f["StartLine"] - 1
+        end_line_idx = f["EndLine"] - 1
+        start_col_idx = f["StartColumn"] - 1
+        end_col_idx = f["EndColumn"]  # gitleaks EndColumn is end-inclusive 1-indexed
+        # Defensive: clamp to the line list we have. Out-of-range indices
+        # would mean gitleaks and our line-split disagree about content —
+        # fail closed rather than silently skip.
+        if not (0 <= start_line_idx < len(lines)) or not (0 <= end_line_idx < len(lines)):
+            raise RedactionError(
+                f"gitleaks finding line {f['StartLine']}-{f['EndLine']} "
+                f"out of range (text has {len(lines)} lines)"
+            )
+
+        if start_line_idx == end_line_idx:
+            line = lines[start_line_idx]
+            lines[start_line_idx] = line[:start_col_idx] + marker + line[end_col_idx:]
+        else:
+            # Multi-line: collapse the whole range to a single marker,
+            # keeping any prefix on the start line and any suffix on the
+            # end line. Inner lines are removed entirely.
+            prefix = lines[start_line_idx][:start_col_idx]
+            suffix = lines[end_line_idx][end_col_idx:]
+            lines[start_line_idx] = prefix + marker + suffix
+            # Drop the inner + end lines.
+            del lines[start_line_idx + 1 : end_line_idx + 1]
+
+    # Dedup rule IDs in original occurrence order. The original findings
+    # list is in gitleaks' emission order (typically top-to-bottom), so
+    # iterate the un-reversed list for flag ordering.
+    seen: dict[str, None] = {}
+    for entry in parsed:
+        # We already validated shape above; just grab the RuleID.
+        rid = str(entry["RuleID"])  # type: ignore[index]
+        if rid not in seen:
+            seen[rid] = None
+
+    return "\n".join(lines), list(seen.keys())
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest daemon/tests/test_specialist_redaction.py -v`
+Expected: all 13 tests PASS (8 from Task 1.1 + 5 new).
+
+Run: `uv run mypy --strict daemon/src daemon/tests`
+Expected: clean.
+
+**Step 5: Commit**
+
+```bash
+git add daemon/src/reachy_ducky_daemon/specialists/redaction.py daemon/tests/test_specialist_redaction.py
+git commit -m "feat(specialists/redaction): splice findings with dedup + multi-line support
+
+Processes gitleaks findings from end to start so earlier splices don't
+shift later indices. Multi-line findings (private-key blocks) collapse
+the whole (StartLine, EndLine) range to a single marker, preserving
+prefix on StartLine and suffix on EndLine. Rule IDs returned in
+first-occurrence order, deduplicated.
+
+Empirical column convention (pr #51 brainstorm): gitleaks emits
+1-indexed StartColumn and end-inclusive 1-indexed EndColumn, so the
+Python slice is line[StartColumn-1:EndColumn]. Finding coords out of
+range fail closed — we don't know what text gitleaks actually scanned
+vs what we split, so silently skipping could leave secrets in.
+
+Per plan docs/plans/2026-04-23-secret-redaction-specialists.md Task 1.2."
+```
+
+---
+
+### Task 1.3: Gated integration smoke — real `gitleaks`
+
+**Files:**
+- Modify: `daemon/tests/test_specialist_redaction.py` (append)
+
+**Step 1: Write the failing test**
+
+Append:
+
+```python
+# ---------------------------------------------------------------------------
+# Integration (gated) — real gitleaks binary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_redact_real_gitleaks_catches_synthetic_pat() -> None:
+    """End-to-end smoke: pipe a synthetic GitHub PAT through real gitleaks.
+
+    Gated on ``REACHY_DUCKY_RUN_INTEGRATION=1`` — this is the only test
+    in this module that requires the actual binary on PATH. Mirrors the
+    gating pattern from ``test_specialist_pr_reviewer.test_pr_reviewer_live_claude``.
+
+    Uses a shape-matching but clearly-fake PAT value so we don't risk
+    tripping secret scanners in the source tree itself.
+    """
+    if not os.environ.get("REACHY_DUCKY_RUN_INTEGRATION"):
+        pytest.skip("set REACHY_DUCKY_RUN_INTEGRATION=1 to run")
+
+    synthetic = (
+        "benign preamble\n"
+        "github_pat = ghp_" + "A" * 36 + "\n"
+        "postamble line\n"
+    )
+
+    redacted, flags = redact(synthetic)
+
+    assert "ghp_" + "A" * 36 not in redacted
+    assert "[REDACTED:github-pat]" in redacted
+    assert "github-pat" in flags
+    # Non-secret content preserved.
+    assert "benign preamble" in redacted
+    assert "postamble line" in redacted
+```
+
+**Step 2: Run the gated test directly (with real binary)**
+
+Run: `REACHY_DUCKY_RUN_INTEGRATION=1 uv run pytest daemon/tests/test_specialist_redaction.py::test_redact_real_gitleaks_catches_synthetic_pat -v`
+Expected: PASS.
+
+Also confirm it skips cleanly when ungated:
+Run: `uv run pytest daemon/tests/test_specialist_redaction.py -v`
+Expected: 13 passed, 1 skipped.
+
+**Step 3: Commit**
+
+```bash
+git add daemon/tests/test_specialist_redaction.py
+git commit -m "test(specialists/redaction): gated real-gitleaks integration smoke
+
+Pipes a synthetic github_pat through the actual binary on PATH and
+asserts the marker appears + rule id flagged. Gated on
+REACHY_DUCKY_RUN_INTEGRATION=1 so CI unit runs don't gain a gitleaks
+prereq. Completes Milestone 1.
+
+Per plan Task 1.3."
+```
+
+---
+
+## Milestone 2 — PlanReviewer integration
+
+### Task 2.1: Wire `redact()` into `PlanReviewer.review` with fail-closed path
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py` (lines 237–255, the `review()` method)
+- Modify: `daemon/tests/test_specialist_plan_reviewer.py` (append)
+
+**Step 1: Write the failing tests**
+
+Append to `daemon/tests/test_specialist_plan_reviewer.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Redaction integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plan_reviewer_redacts_prompt_before_brain_query(
+    repo_with_plan_and_drift: Path,
+) -> None:
+    """Prompt reaching the brain is the redacted version; rule ids flow to flags."""
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=repo_with_plan_and_drift)
+
+    # Redact strips the "sensitive" token and tags it as 'fake-rule'.
+    def _fake_redact(text: str) -> tuple[str, list[str]]:
+        return text.replace("sensitive", "[REDACTED:fake-rule]"), ["fake-rule"]
+
+    # Inject a "sensitive" token into the prompt so we can observe it being
+    # scrubbed. The plan file is written fresh by the fixture.
+    plan_path = repo_with_plan_and_drift / "docs" / "plans" / "foo.md"
+    plan_path.write_text(plan_path.read_text() + "\nsensitive token here\n")
+
+    with patch(
+        "reachy_ducky_daemon.specialists.plan_reviewer.redact",
+        side_effect=_fake_redact,
+    ):
+        response = await reviewer.review()
+
+    assert len(brain.calls) == 1
+    prompt = brain.calls[0].user_utterance
+    assert "sensitive token here" not in prompt
+    assert "[REDACTED:fake-rule]" in prompt
+    assert "redacted:fake-rule" in response.flags
+
+
+@pytest.mark.asyncio
+async def test_plan_reviewer_aborts_on_redaction_failure(
+    repo_with_plan_and_drift: Path,
+) -> None:
+    """RedactionError → 200 SpecialistResponse with redaction-failed flag, no brain call."""
+    from reachy_ducky_daemon.specialists.redaction import RedactionError
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=repo_with_plan_and_drift)
+
+    with patch(
+        "reachy_ducky_daemon.specialists.plan_reviewer.redact",
+        side_effect=RedactionError("gitleaks binary not found"),
+    ):
+        response = await reviewer.review()
+
+    assert response.name == "plan-reviewer"
+    assert "redaction-failed" in response.flags
+    assert "gitleaks binary not found" in response.summary
+    assert "abort" in response.summary.lower() or "unavailable" in response.summary.lower()
+    assert len(brain.calls) == 0, "brain.query must not fire when redaction fails"
+```
+
+Note: the first test mutates the fixture to inject the sensitive token — acceptable because the fixture is a fresh `tmp_path` per test.
+
+The second test uses `patch` keyed on `reachy_ducky_daemon.specialists.plan_reviewer.redact` — so the production module must import `redact` at module scope (not inside the method) for this patch target to work.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest daemon/tests/test_specialist_plan_reviewer.py -v`
+Expected: 2 new tests FAIL — `redact` isn't imported into `plan_reviewer` yet, so the patch target doesn't exist and/or the production code doesn't call it. The mutation test's brain will receive the raw prompt including "sensitive token here".
+
+**Step 3: Modify `plan_reviewer.py`**
+
+Add import at the top of the file, after the existing `from reachy_ducky_daemon.brain.interface import BrainInterface`:
+
+```python
+from reachy_ducky_daemon.specialists.redaction import RedactionError, redact
+```
+
+Update `__all__` to include neither (both are internal; `PlanReviewer` is the exported entrypoint).
+
+Replace the `review()` method body (currently lines 237–255):
+
+```python
+    async def review(self) -> SpecialistResponse:
+        """Assemble the review prompt, redact secrets, dispatch to the brain.
+
+        Exactly one ``brain.query`` call per invocation — but only when
+        redaction succeeds. A :class:`RedactionError` short-circuits to
+        a fail-closed diagnostic response; no brain call fires, no
+        secret leaks.
+        """
+        branch, branch_error = _current_branch(self._repo)
+        plans = _collect_plans(self._repo)
+        diff, diff_error = _capture_diff(self._repo, branch)
+
+        prompt = _assemble_prompt(
+            branch=branch,
+            branch_error=branch_error,
+            plans=plans,
+            diff=diff,
+            diff_error=diff_error,
+        )
+
+        try:
+            redacted, rule_ids = redact(prompt)
+        except RedactionError as exc:
+            return SpecialistResponse(
+                name=_SPECIALIST_NAME,
+                summary=(
+                    f"Redaction unavailable: {exc}. Aborting review to "
+                    "prevent secret leaks — re-run once the redactor is back."
+                ),
+                flags=["redaction-failed"],
+            )
+
+        response = await self._brain.query(BrainRequest(user_utterance=redacted))
+        return SpecialistResponse(
+            name=_SPECIALIST_NAME,
+            summary=response.text,
+            flags=[f"redacted:{rid}" for rid in rule_ids],
+        )
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest daemon/tests/test_specialist_plan_reviewer.py -v`
+Expected: all existing tests + the 2 new ones PASS.
+
+Run: `uv run mypy --strict daemon/src daemon/tests`
+Expected: clean.
+
+**Step 5: Commit**
+
+```bash
+git add daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py daemon/tests/test_specialist_plan_reviewer.py
+git commit -m "feat(specialists/plan-reviewer): redact prompt before brain.query
+
+Wraps the brain.query call in a try/except RedactionError. On success,
+rule ids flow into SpecialistResponse.flags as redacted:<rule_id>. On
+failure, no brain call fires — we return a 200 response with a
+'redaction-failed' flag and a summary explaining the abort. Follows
+the design doc §10 'fail-closed' posture so a broken gitleaks install
+cannot leak secrets through the specialist.
+
+Per plan Task 2.1."
+```
+
+---
+
+## Milestone 3 — PRReviewer integration (happy + diagnostic paths)
+
+### Task 3.1: Wire `redact()` into both `PRReviewer.review` paths
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py` (the `review()` happy path around line 548, and `_diagnostic_response` around line 565)
+- Modify: `daemon/tests/test_specialist_pr_reviewer.py` (append)
+
+**Step 1: Write the failing tests**
+
+Append to `daemon/tests/test_specialist_pr_reviewer.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Redaction integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pr_reviewer_redacts_happy_path(tmp_path: Path) -> None:
+    """Happy path: prompt the brain sees is the redacted version; rule ids flagged."""
+    pr_view = _FIXTURES / "gh_pr_view_happy.json"
+    comments = _FIXTURES / "gh_api_comments.json"
+    check_runs = _FIXTURES / "gh_api_check_runs.json"
+
+    side_effect = _mock_by_argv(
+        {
+            ("gh", "pr", "view"): _ok(pr_view.read_text()),
+            ("gh", "pr", "diff"): _ok("diff context\nsensitive_token_here\nmore diff\n"),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/pulls/42/comments",
+            ): _ok(comments.read_text()),
+            (
+                "gh",
+                "api",
+                "/repos/Obsidian-Owl/reachy-ducky/commits/abc123def456/check-runs",
+            ): _ok(check_runs.read_text()),
+        }
+    )
+
+    def _fake_redact(text: str) -> tuple[str, list[str]]:
+        return text.replace("sensitive_token_here", "[REDACTED:fake-rule]"), ["fake-rule"]
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with (
+        patch("subprocess.run", side_effect=side_effect),
+        patch(
+            "reachy_ducky_daemon.specialists.pr_reviewer.redact",
+            side_effect=_fake_redact,
+        ),
+    ):
+        response = await reviewer.review(pr_number=42)
+
+    assert "sensitive_token_here" not in brain.calls[0].user_utterance
+    assert "[REDACTED:fake-rule]" in brain.calls[0].user_utterance
+    assert "redacted:fake-rule" in response.flags
+    # Existing derived flags still present — union not replacement.
+    assert "ci-red" in response.flags
+    assert "has-unresolved-comments" in response.flags
+
+
+@pytest.mark.asyncio
+async def test_pr_reviewer_redacts_diagnostic_path(tmp_path: Path) -> None:
+    """Diagnostic (no-PR-found) path also redacts — branch_error / find_error strings can embed credentials."""
+    side_effect = _mock_by_argv(
+        {
+            ("git", "rev-parse", "--abbrev-ref", "HEAD"): _ok("feat-x\n"),
+            # gh pr list fails with an auth error that embeds a credential-ish URL.
+            ("gh", "pr", "list"): subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="remote: url https://x:sensitive_token_here@github.com/...",
+            ),
+        }
+    )
+
+    def _fake_redact(text: str) -> tuple[str, list[str]]:
+        return text.replace("sensitive_token_here", "[REDACTED:fake-rule]"), ["fake-rule"]
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with (
+        patch("subprocess.run", side_effect=side_effect),
+        patch(
+            "reachy_ducky_daemon.specialists.pr_reviewer.redact",
+            side_effect=_fake_redact,
+        ),
+    ):
+        response = await reviewer.review(pr_number=None)
+
+    assert "sensitive_token_here" not in brain.calls[0].user_utterance
+    assert "[REDACTED:fake-rule]" in brain.calls[0].user_utterance
+    assert "redacted:fake-rule" in response.flags
+    assert "no-pr-found" in response.flags
+
+
+@pytest.mark.asyncio
+async def test_pr_reviewer_aborts_on_redaction_failure(tmp_path: Path) -> None:
+    """RedactionError on the happy path → 200 response with redaction-failed flag, no brain call."""
+    from reachy_ducky_daemon.specialists.redaction import RedactionError
+
+    pr_view = _FIXTURES / "gh_pr_view_happy.json"
+    side_effect = _mock_by_argv(
+        {
+            ("gh", "pr", "view"): _ok(pr_view.read_text()),
+            ("gh", "pr", "diff"): _ok(""),
+            ("gh", "api"): _ok("[]"),
+        }
+    )
+
+    brain = MockBrain()
+    reviewer = PRReviewer(
+        brain=brain,
+        repo=tmp_path,
+        owner="Obsidian-Owl",
+        repo_name="reachy-ducky",
+    )
+    with (
+        patch("subprocess.run", side_effect=side_effect),
+        patch(
+            "reachy_ducky_daemon.specialists.pr_reviewer.redact",
+            side_effect=RedactionError("gitleaks timed out"),
+        ),
+    ):
+        response = await reviewer.review(pr_number=42)
+
+    assert response.name == "pr-reviewer"
+    assert "redaction-failed" in response.flags
+    assert "timed out" in response.summary.lower()
+    assert len(brain.calls) == 0, "brain.query must not fire when redaction fails"
+```
+
+**Step 2: Run tests — confirm failures**
+
+Run: `uv run pytest daemon/tests/test_specialist_pr_reviewer.py -v`
+Expected: 3 new tests FAIL (redaction isn't wired into pr_reviewer yet).
+
+**Step 3: Modify `pr_reviewer.py`**
+
+Add the import at the top of the module, after `from reachy_ducky_daemon.brain.interface import BrainInterface`:
+
+```python
+from reachy_ducky_daemon.specialists.redaction import RedactionError, redact
+```
+
+Refactor `review()`. Replace the tail (from `prompt = _assemble_prompt(...)` through the end of the method) with:
+
+```python
+        prompt = _assemble_prompt(
+            pr=pr_meta,
+            diff=diff,
+            comments=comments,
+            check_runs=check_runs,
+            diff_error=diff_err,
+            comments_error=comments_err,
+            check_runs_error=check_runs_err,
+        )
+        base_flags = _derive_flags(pr=pr_meta, comments=comments, check_runs=check_runs)
+        return await self._query_with_redaction(prompt=prompt, base_flags=base_flags)
+```
+
+Replace `_diagnostic_response` with:
+
+```python
+    async def _diagnostic_response(
+        self,
+        *,
+        branch: str,
+        branch_error: str | None,
+        find_error: str | None,
+    ) -> SpecialistResponse:
+        """Dispatch the diagnostic prompt (redacted) and wrap the brain's reply."""
+        prompt = _assemble_diagnostic_prompt(
+            branch=branch or "unknown",
+            branch_error=branch_error,
+            find_error=find_error,
+        )
+        base_flags = _derive_flags(pr={}, comments=[], check_runs=[])
+        return await self._query_with_redaction(prompt=prompt, base_flags=base_flags)
+```
+
+Add the shared helper method on `PRReviewer`:
+
+```python
+    async def _query_with_redaction(
+        self,
+        *,
+        prompt: str,
+        base_flags: list[str],
+    ) -> SpecialistResponse:
+        """Redact, then query brain. Fail-closed on RedactionError.
+
+        Shared by both the happy review path and the diagnostic path
+        so every prompt that reaches ``brain.query()`` is run through
+        ``redact()`` first (design doc §10). RedactionError short-
+        circuits to a 200 SpecialistResponse with a ``redaction-failed``
+        flag and no brain call.
+        """
+        try:
+            redacted, rule_ids = redact(prompt)
+        except RedactionError as exc:
+            return SpecialistResponse(
+                name=_SPECIALIST_NAME,
+                summary=(
+                    f"Redaction unavailable: {exc}. Aborting review to "
+                    "prevent secret leaks — re-run once the redactor is back."
+                ),
+                flags=[*base_flags, "redaction-failed"],
+            )
+
+        brain_resp = await self._brain.query(BrainRequest(user_utterance=redacted))
+        return SpecialistResponse(
+            name=_SPECIALIST_NAME,
+            summary=brain_resp.text,
+            flags=[*base_flags, *(f"redacted:{rid}" for rid in rule_ids)],
+        )
+```
+
+The `base_flags` carry the objective CI / comments / no-pr-found flags so the failure path still communicates the state we could determine without the brain.
+
+**Step 4: Run tests**
+
+Run: `uv run pytest daemon/tests/test_specialist_pr_reviewer.py -v`
+Expected: all existing tests + 3 new ones PASS.
+
+Run: `uv run mypy --strict daemon/src daemon/tests`
+Expected: clean.
+
+**Step 5: Commit**
+
+```bash
+git add daemon/src/reachy_ducky_daemon/specialists/pr_reviewer.py daemon/tests/test_specialist_pr_reviewer.py
+git commit -m "feat(specialists/pr-reviewer): redact prompts before brain.query on both paths
+
+Introduces _query_with_redaction shared by review() happy path and
+_diagnostic_response. Every prompt that reaches brain.query is scanned
+first; rule ids flow into SpecialistResponse.flags as redacted:<rid>.
+RedactionError short-circuits to a 200 response with redaction-failed
+appended to the existing base flags — no brain call fires, no secret
+leaks.
+
+The diagnostic path is covered too because branch_error / find_error /
+stderr strings can legitimately embed credentials (auth URLs with
+embedded tokens, etc.). Design doc §10 posture: fail-closed across the
+board.
+
+Completes Milestone 3. Per plan Task 3.1."
+```
+
+---
+
+## Milestone 4 — Docs
+
+### Task 4.1: Update design doc §10 + link the closing issue
+
+**Files:**
+- Modify: `docs/plans/2026-04-21-reachy-ducky-design.md` (§10)
+
+**Step 1: Locate the §10 block**
+
+Current §10 text (from prior read) says redaction runs via `gitleaks`/`trufflehog` "pre-send". We need to replace the "not implemented" shape with the "landed" shape.
+
+**Step 2: Replace the block**
+
+Find the bullet starting with `- **Secret redaction pre-send.**` in §10 and replace it with:
+
+```markdown
+- **Secret redaction pre-send (landed 2026-04-23).** `gitleaks stdin`
+  runs over every specialist-assembled prompt before it reaches
+  `brain.query()`; matches are spliced with `[REDACTED:<RuleID>]` and
+  surface as `redacted:<rule_id>` flags on the `SpecialistResponse`.
+  Fail-closed: a broken `gitleaks` install aborts the review with a
+  `redaction-failed` flag — no brain call fires. Shared helper:
+  `daemon/src/reachy_ducky_daemon/specialists/redaction.py`. Gitleaks
+  config precedence mirrors lefthook's pre-commit hook, so "what's a
+  secret" stays unified across commit-time and brain-time. See
+  `docs/plans/2026-04-23-secret-redaction-specialists.md` and closed
+  issue #50.
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-04-21-reachy-ducky-design.md
+git commit -m "docs: mark §10 secret redaction landed; link implementation plan + #50
+
+Per plan Task 4.1."
+```
+
+---
+
+## Done / exit criteria
+
+When every task is committed on `secret-redaction` and the full-branch gate passes:
+
+```bash
+uv run ruff check . \
+  && uv run ruff format --check . \
+  && uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests \
+  && uv run pyright \
+  && uv run bandit -ll -r daemon/src app/src menubar/src protocol/src \
+  && uv run pytest -q --cov
+```
+
+Coverage ≥ 90% overall, helper ≥ 95%.
+
+Then:
+
+1. `git push -u origin secret-redaction`
+2. `gh pr create --title "feat(specialists): secret redaction across specialists (closes #50)" --body ...` with `Closes #50` in the body.
+3. Wait for Augment; address any valid findings in follow-up commits.
+4. Merge when green.
+5. Issue #50 auto-closes on merge via `Closes #50` in the PR body.
+
+### Acceptance criteria check (from issue #50)
+
+- [x] Helper module with ≥95% coverage → verified by final `pytest --cov` run
+- [x] Applied in `PlanReviewer` pre-query step → Task 2.1
+- [x] Applied in `PRReviewer` pre-query step → Task 3.1 (both paths)
+- [x] Integration test: synthetic secret emerges redacted → Task 1.3 (gated real-gitleaks smoke)
+- [x] Unit tests: no-secret pass-through, single match, multi match, flag contract → Tasks 1.1–1.2
+- [x] Design doc §10 updated with chosen approach → Task 4.1


### PR DESCRIPTION
## Summary

- Implements design doc §10's pre-brain secret redaction per #50. Every specialist-assembled prompt (`PlanReviewer` and `PRReviewer` — both happy and diagnostic paths) is piped through `gitleaks stdin` before `brain.query()`. Matches are spliced with `[REDACTED:<RuleID>]` inline; rule IDs surface as `redacted:<rule_id>` flags on the `SpecialistResponse` (deduplicated, first-occurrence order preserved).
- **Fail-closed**: if `gitleaks` is missing, times out, or crashes, the specialist returns a 200 `SpecialistResponse` with a `redaction-failed` flag and a summary explaining the abort. No brain call fires — secrets cannot leak through a broken redactor.
- **Coherence with commit-time**: `gitleaks stdin` honours any `.gitleaks.toml` via the same config-precedence chain as `lefthook pre-commit`'s `gitleaks protect --staged`, so "what's a secret" stays unified across commit-time and brain-time.

8 commits, TDD per task across 4 milestones per [`docs/plans/2026-04-23-secret-redaction-specialists.md`](docs/plans/2026-04-23-secret-redaction-specialists.md).

## Design decisions (from 2026-04-23 brainstorm)

- **Approach**: `gitleaks stdin` subprocess — already the trust anchor for `lefthook pre-commit`, zero new deps.
- **Fail policy**: Option C — fail-closed with diagnostic `SpecialistResponse`, no brain call on failure.
- **Flags**: `redacted:<RuleID>` per finding, deduplicated (e.g. `["redacted:github-pat", "redacted:aws-access-key"]`).
- **Tests**: mock `subprocess.run` in unit tier + one gated `@pytest.mark.integration` test with the real binary.

## Scope notes

- **Out of scope (intentional)**: brain-initiated live tool reads (`Read`/`Grep`/`Glob`/`mcp__github__*`) — existing `PreToolUse` secret-path blocklist covers those. `/brain/query` user utterances aren't scanned either (user-controlled input).
- **Helper coverage**: `redaction.py` at 100% (issue #50 asks for ≥95%). Uncovered defensive paths — non-dict findings, missing required fields, out-of-range coords — all exercise `RedactionError` by design.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean (75 files)
- [x] `uv run mypy --strict` across daemon/app/menubar/protocol (src + tests) — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run bandit -ll -r` — 0 issues
- [x] `uv run pytest -q --cov` — **569 passed**, 5 skipped, 4 deselected; **overall coverage 90.18%**; **`redaction.py` at 100%**
- [x] `REACHY_DUCKY_RUN_INTEGRATION=1 uv run pytest daemon/tests/test_specialist_redaction.py::test_redact_real_gitleaks_catches_synthetic_pat` — real-binary smoke passes (synthetic 40-char github-pat → `[REDACTED:github-pat]` marker, `github-pat` flag)
- [ ] Augment review addressed before merge
- [ ] Codex Cloud env setup pending (separate concern; doesn't block merge)

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)