### PR TITLE
docs: v0.1.0 testing-prerequisites implementation plan

### DIFF
--- a/docs/plans/2026-04-23-v0.1.0-testing-prerequisites.md
+++ b/docs/plans/2026-04-23-v0.1.0-testing-prerequisites.md
@@ -1,0 +1,1262 @@
+# v0.1.0 Testing Prerequisites Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Unblock end-to-end testing of Reachy Ducky on real hardware by resolving the 6-issue bundle needed to run the daemon + app against a physical Reachy Mini Wireless (with sim fallback where supported).
+
+**Architecture:** 5 milestones, each scoped to a single-PR-sized change and closing 1–2 issues. Milestones are ordered so lighter, independent work lands first (M1–M3), then the substantive hardware audio wiring (M4), then the mute-coordination binding that depends on it (M5).
+
+**Tech Stack:**
+- Python 3.12, `uv` workspace
+- `reachy_mini` SDK (on-robot only; behind the `robot` optional extra)
+- `asyncio` (event-driven wake loop)
+- `numpy` (PCM frame manipulation)
+- Makefile (sim dev ergonomics)
+- pytest markers: `sdk` (SDK API contract), `hardware` (real robot), `sim` (local-only sim)
+
+**Issues closed:**
+
+| Milestone | Issue | Subject |
+|---|---|---|
+| M1 | #25 | Makefile for local sim dev |
+| M1 | #27 | Watch/document Reachy Mini sim audio-loopback status |
+| M2 | #15 | Wake loop should be `asyncio.Event`-driven, not 20 Hz busy-spin |
+| M2 | #17 | `_wake_triggered` dead-code cleanup (bundled with #15) |
+| M3 | #16 | HF Space metadata declared in two files |
+| M4 | #23 | Wire `ReachyMicSource` / `ReachySpeakerSink` hardware-backed impls |
+| M5 | #20 | Bind `MuteGate` to state-machine MUTED transition + mic pump |
+
+**Conventions used throughout:**
+- TDD per task: failing test → run it (fails with expected shape) → minimal implementation → run it (passes) → commit.
+- Each milestone lands on its own feature branch with its own PR. The branch name convention is `<issue-topic>` (e.g. `wake-event-driven`, `hardware-audio-io`).
+- Per-task quality gate before commit: `uv run ruff check . && uv run ruff format --check . && uv run mypy --strict <touched> && uv run pytest -q`.
+- Full-branch gate before push: `uv run ruff check . && uv run ruff format --check . && uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests && uv run pyright && uv run bandit -ll -r daemon/src app/src menubar/src protocol/src && uv run pytest -q --cov`. Coverage floor 90%.
+- **`@pytest.mark.hardware`** tests are opt-in and do NOT run in CI. They require a physically connected Reachy Mini — invoke with `uv run pytest -m hardware` on the robot or a machine with the robot reachable.
+- **`@pytest.mark.sdk`** tests require the `reachy-mini` SDK installed (via `uv sync --all-packages --extra robot` on Linux/on-robot). They run automatically in the `sdk-contract` CI workflow.
+- **`@pytest.mark.sim`** tests are local-only; they require a running `reachy-mini-daemon --sim` on `localhost:8000` (see CLAUDE.md "Local sim dev flow").
+
+**Reference skills:** @superpowers:test-driven-development, @superpowers:verification-before-completion
+
+**Execution strategy:** Commit this plan first (it belongs on `main` as a durable artifact). Then each milestone gets its own feature branch off `main` and its own PR. Between PRs, rebase each next branch on the updated `main` so dependencies stay clean.
+
+**Session scope:** Don't try to finish in one session. M1–M3 are plausibly one session (6 commits, small scope). M4 is its own session (the reachy_mini SDK audio API investigation can surface surprises). M5 is its own session and depends on M4.
+
+---
+
+## Milestone 1 — Sim dev ergonomics + upstream audio-sim tracking
+
+Closes **#25** and **#27**. Two light tasks; independent of everything else; can land first so subsequent work inherits the Makefile convenience.
+
+### Task 1.1: Add `Makefile` with sim dev targets
+
+**Files:**
+- Create: `Makefile`
+
+**Step 1: Write the failing test**
+
+No unit test for a Makefile directly — the "test" is that each target runs and produces the documented effect. Add an entry to `docs/plans/2026-04-21-reachy-ducky-phase-a-plan.md`'s dev-flow section pointing at the new targets? (Optional.)
+
+Primary verification: run each target manually.
+
+**Step 2: Write the Makefile**
+
+```makefile
+# Reachy Ducky — developer convenience targets.
+#
+# Most day-to-day tasks use ``uv run`` directly (see CLAUDE.md). This
+# Makefile wraps the multi-step local sim flow so motion/lifecycle work
+# doesn't need real hardware. The sim target requires the reachy-mini
+# package installed with the ``mujoco`` extra — see the "Local sim dev
+# flow" block in CLAUDE.md.
+.PHONY: sim-daemon sim-app sim sim-stop
+
+# PID file for the background reachy-mini-daemon process. ``sim`` writes
+# it; ``sim-stop`` reads + cleans it. Kept out of the tree root via a
+# dotfile so ``git status`` doesn't flag it.
+SIM_DAEMON_PIDFILE := .sim-daemon.pid
+
+sim-daemon:
+	@if [ -f "$(SIM_DAEMON_PIDFILE)" ] && kill -0 "$$(cat $(SIM_DAEMON_PIDFILE))" 2>/dev/null; then \
+	  echo "reachy-mini-daemon already running (pid $$(cat $(SIM_DAEMON_PIDFILE)))"; \
+	  exit 0; \
+	fi
+	@echo "Starting reachy-mini-daemon --sim in background..."
+	@reachy-mini-daemon --robot-name reachy_mini_sim --sim --headless --localhost-only & \
+	  echo $$! > "$(SIM_DAEMON_PIDFILE)"
+	@sleep 2
+	@echo "reachy-mini-daemon pid $$(cat $(SIM_DAEMON_PIDFILE))"
+
+sim-app:
+	@echo "Running reachy-ducky-app in sim mode (stubbed wake; press Enter to trigger a turn)..."
+	uv run python -m reachy_ducky_app --sim
+
+sim: sim-daemon sim-app
+
+sim-stop:
+	@if [ -f "$(SIM_DAEMON_PIDFILE)" ]; then \
+	  pid=$$(cat $(SIM_DAEMON_PIDFILE)); \
+	  if kill -0 "$$pid" 2>/dev/null; then \
+	    echo "Stopping reachy-mini-daemon pid $$pid..."; \
+	    kill "$$pid"; \
+	  fi; \
+	  rm -f "$(SIM_DAEMON_PIDFILE)"; \
+	fi
+	@echo "sim-daemon stopped"
+```
+
+Add `.sim-daemon.pid` to `.gitignore`.
+
+**Note:** `sim-app` invokes `python -m reachy_ducky_app --sim`, which doesn't exist yet — the app doesn't accept a `--sim` flag today. This task intentionally stops here; a follow-up task (not in this plan) wires an app-side `--sim` entrypoint when that's actually useful. For now, `make sim` prints a diagnostic from `sim-app` that documents what to run manually.
+
+Alternative: drop the `sim-app` target entirely and just ship `sim-daemon` + `sim-stop`. **My lean** — only add the `sim-app` target once the app actually has a sim entrypoint. See the decision point below in Step 3.
+
+**Step 3: Decision — Makefile scope**
+
+Before writing the file, pick ONE:
+- **A.** Ship only `sim-daemon` + `sim-stop`. `sim-app` and `sim` (combined) wait for the app to grow a `--sim` entrypoint.
+- **B.** Ship all four with `sim-app` documenting what the user should run manually in the meantime (shown above).
+
+**Recommendation: A.** YAGNI — ship targets that actually work today. The app-sim entrypoint is out of scope for this plan.
+
+**Step 4: Commit (Option A)**
+
+```bash
+git add Makefile .gitignore
+git commit -m "feat(dev): Makefile with sim-daemon / sim-stop targets
+
+Wraps the reachy-mini-daemon --sim lifecycle in a two-step target pair
+so motion/lifecycle work doesn't need the raw command. Writes the pid
+to .sim-daemon.pid so sim-stop can clean up reliably.
+
+sim-app and the combined sim target are deferred — they'd need the
+app to accept a --sim flag, which doesn't exist yet.
+
+Closes #25."
+```
+
+---
+
+### Task 1.2: Document upstream Reachy Mini sim audio status
+
+**Files:**
+- Create: `docs/reachy-mini-sim-audio.md`
+
+**Step 1: Scope the write-up**
+
+#27 is a "watch this upstream" tracking task, not an implementation. Capture the current state of Pollen's sim audio support so future-us has a breadcrumb.
+
+**Step 2: Write the doc**
+
+```markdown
+# Reachy Mini sim audio — upstream tracking
+
+**Last verified:** 2026-04-23
+
+## Status today
+
+Pollen's Reachy Mini simulator covers motion (MuJoCo physics, full
+6-DOF head + antennas + body-yaw) but **does not** provide audio
+input/output. Mic/speaker code running in sim will hit the laptop's
+system devices (or fail, depending on the backend).
+
+The daemon media architecture (see `reachy-mini-daemon --help`) lists
+audio backends: `PulseAudio`, `ALSA`, `WASAPI`, `CoreAudio`. No `sim`
+variant.
+
+## Consequence for Reachy Ducky
+
+`ReachyMicSource` / `ReachySpeakerSink` (see
+`app/src/reachy_ducky_app/voice/audio_io.py`, closed via #23) are
+**hardware-only** — the `load_default_*` factories return the mock
+impls when not on a real robot. Sim can drive the motion/lifecycle
+side of the app but not the voice side.
+
+## Upstream issues to watch
+
+- **[pollen-robotics/reachy_mini#330](https://github.com/pollen-robotics/reachy_mini/issues/330)** — webcam-fallback in sim. Adjacent pattern; no audio equivalent yet.
+- **No audio-specific sim issue exists today.** If you hit this need
+  again, consider filing one.
+
+## Action for Reachy Ducky maintainers
+
+Subscribe to new issues tagged `sim` in `pollen-robotics/reachy_mini`
+and scan for audio keywords quarterly. When Pollen lands sim audio
+loopback:
+
+1. Revisit the factory logic in
+   `app/src/reachy_ducky_app/voice/audio_io.py`. Today it returns mocks
+   when not on real hardware — a sim-audio-capable runtime would be a
+   third branch.
+2. Add an `@pytest.mark.sim` test exercising a mic→speaker loopback
+   through the sim.
+3. Close this doc's "track" status; either move the findings into the
+   main design doc or delete the doc.
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/reachy-mini-sim-audio.md
+git commit -m "docs: track upstream Reachy Mini sim audio status (#27)
+
+Snapshot of Pollen's sim audio support (none today) + a breadcrumb for
+future maintainers revisiting hardware-only audio-I/O assumptions.
+Closes #27 as tracking."
+```
+
+---
+
+## Milestone 2 — Event-driven wake loop
+
+Closes **#15** and **#17**. Small scope (~30 lines + tests). Replaces the 20 Hz busy-spin with an `asyncio.Event`-driven wait.
+
+**Branch name:** `wake-event-driven`.
+
+### Task 2.1: Drop the unused `wake` parameter from `_wake_triggered`
+
+**Files:**
+- Modify: `app/src/reachy_ducky_app/main.py:77, 83-90`
+- Modify: `app/tests/test_main.py` (or wherever the test exists)
+
+**Step 1: Verify current state**
+
+Run: `uv run pytest app/tests -k main -v`
+Expected: current tests pass; `_wake_triggered` takes a `WakeDetector` argument that's immediately `del`ed.
+
+**Step 2: Remove the parameter**
+
+Change `app/src/reachy_ducky_app/main.py`:
+
+```python
+# Before:
+if self._wake_triggered(wake):
+    await run_one_turn(...)
+
+# After:
+if self._wake_triggered():
+    await run_one_turn(...)
+```
+
+```python
+# Before:
+def _wake_triggered(self, wake: WakeDetector) -> bool:
+    """Placeholder: returns False until the real audio pump is wired."""
+    del wake
+    return False
+
+# After:
+def _wake_triggered(self) -> bool:
+    """Placeholder: returns False until the real audio pump is wired.
+
+    The real audio pump (landing with #23's ReachyMicSource) will feed
+    chunks into ``wake.feed_audio(chunk)`` and set a shared
+    ``asyncio.Event`` that :meth:`_run_async` awaits — this method is
+    the bridge between that pump and the per-turn conversation loop.
+    """
+    return False
+```
+
+**Step 3: Update tests**
+
+If `app/tests/test_main.py` subclasses `ReachyDuckyApp` to override `_wake_triggered`, drop the `wake` kwarg from the override.
+
+**Step 4: Run tests + type-check**
+
+Run:
+```bash
+uv run pytest app/tests -q
+uv run mypy --strict app/src app/tests
+```
+
+Expected: all pass; no signature mismatches.
+
+**Step 5: Commit**
+
+```bash
+git add app/src/reachy_ducky_app/main.py app/tests/test_main.py
+git commit -m "refactor(app): drop unused wake param from _wake_triggered
+
+The parameter was threaded through three call sites and then del'd in
+the body — confusing readers about whether wake was consumed. Drops it
+now (preparation for the #15 event-driven rework); reintroduces only
+when the real audio pump lands with #23's ReachyMicSource.
+
+Closes #17."
+```
+
+---
+
+### Task 2.2: Refactor wake loop to be `asyncio.Event`-driven
+
+**Files:**
+- Modify: `app/src/reachy_ducky_app/main.py:48-81`
+- Modify / Create: `app/tests/test_main.py`
+
+**Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_wake_event_drives_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_run_async waits on a wake Event, not a 20Hz poll.
+
+    Verifies: (1) setting the Event triggers exactly one turn, (2) the
+    implementation awaits the event rather than polling (no turn fires
+    if the event never sets, even after several seconds of real time).
+    """
+    # Given: a ReachyDuckyApp with an injected mock wake Event and a
+    # DaemonClient/voice/sm that count turns.
+    app = ReachyDuckyApp()
+    stop = threading.Event()
+    turns: list[int] = []
+
+    async def fake_run_one_turn(*args: object, **kwargs: object) -> None:
+        turns.append(len(turns))
+
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.run_one_turn",
+        fake_run_one_turn,
+    )
+
+    # Monkey-patch wake loading to return a detector whose event we control.
+    wake_event = asyncio.Event()
+
+    class FakeWake:
+        event = wake_event
+
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.load_default_wake_detector",
+        lambda: FakeWake(),
+    )
+
+    # When: the app runs; we fire the event after a short delay and stop.
+    async def fire_and_stop() -> None:
+        await asyncio.sleep(0.01)
+        wake_event.set()
+        await asyncio.sleep(0.01)
+        stop.set()
+
+    await asyncio.gather(
+        app._run_async(reachy_mini=object(), stop_event=stop),
+        fire_and_stop(),
+    )
+
+    # Then: exactly one turn fired (not busy-polled in between).
+    assert turns == [0]
+
+
+@pytest.mark.asyncio
+async def test_wake_loop_exits_cleanly_without_firing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stop event causes clean exit even when wake event never fires."""
+    app = ReachyDuckyApp()
+    stop = threading.Event()
+    turns: list[int] = []
+
+    async def fake_run_one_turn(*args: object, **kwargs: object) -> None:
+        turns.append(len(turns))
+
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.run_one_turn",
+        fake_run_one_turn,
+    )
+
+    wake_event = asyncio.Event()
+
+    class FakeWake:
+        event = wake_event
+
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.load_default_wake_detector",
+        lambda: FakeWake(),
+    )
+
+    async def stop_soon() -> None:
+        await asyncio.sleep(0.01)
+        stop.set()
+
+    await asyncio.gather(
+        app._run_async(reachy_mini=object(), stop_event=stop),
+        stop_soon(),
+    )
+    assert turns == []
+```
+
+**Step 2: Run the failing test**
+
+Run: `uv run pytest app/tests -k wake -v`
+Expected: FAIL — `FakeWake.event` is accessed but `load_default_wake_detector`'s current return type doesn't expose one.
+
+**Step 3: Implement the event-driven loop**
+
+Change `app/src/reachy_ducky_app/wake.py` to give `WakeDetector` an `event: asyncio.Event` attribute (or a `wait()` coroutine). Mock detector sets it when `feed_audio` would have triggered. Real detector (future) sets it from the ONNX inference path.
+
+```python
+# wake.py (illustrative; pin exact shape in the test)
+class WakeDetector(ABC):
+    """ABC for wake-word detectors.
+
+    Exposes an ``event`` that ``_run_async`` awaits. Implementations set
+    the event when they detect a wake signal from audio fed via
+    :meth:`feed_audio`.
+    """
+
+    def __init__(self) -> None:
+        self.event: asyncio.Event = asyncio.Event()
+
+    @abstractmethod
+    def feed_audio(self, chunk: bytes) -> None:
+        """Feed a PCM16 mono 24 kHz frame. Set ``self.event`` on wake."""
+```
+
+Update `MockWakeDetector` to accept a constructor kwarg `trigger_on_feed: bool` (default False for the silent mock; True for tests that want wake on first frame).
+
+Refactor `_run_async`:
+
+```python
+async def _run_async(
+    self,
+    reachy_mini: object,
+    stop_event: threading.Event,
+) -> None:
+    """Construct the piece graph and await wake events until stopped."""
+    driver = ReachyMotionDriver(reachy_mini)
+    sm = EmbodimentStateMachine(driver=driver)
+    voice = OpenAIRealtimeVoice(
+        mic=load_default_mic_source(),
+        speaker=load_default_speaker_sink(),
+    )
+    daemon = DaemonClient.from_env()
+    wake = load_default_wake_detector()
+
+    # Bridge threading.Event → asyncio cancellation so the loop wakes up
+    # promptly when the on-robot daemon calls stop_event.set() from
+    # another thread. Polling stop_event in the loop is fine at the
+    # stop-check interval; the turn work itself awaits on the wake event.
+    stop_checker = asyncio.create_task(_watch_stop(stop_event))
+    try:
+        while not stop_event.is_set():
+            done, _pending = await asyncio.wait(
+                {
+                    asyncio.create_task(wake.event.wait()),
+                    stop_checker,
+                },
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if stop_event.is_set():
+                break
+            # Clear the event so the next loop iteration waits fresh.
+            wake.event.clear()
+            await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug=None)
+    finally:
+        stop_checker.cancel()
+        await daemon.aclose()
+
+
+async def _watch_stop(stop_event: threading.Event) -> None:
+    """Yield until the threading Event is set; lets asyncio.wait pick it up."""
+    while not stop_event.is_set():
+        await asyncio.sleep(0.1)  # NOT the wake loop's spin — this is just for stop.
+```
+
+**Note:** the sleep(0.1) on `_watch_stop` still polls once per 100ms — but only against a `threading.Event.is_set()` memory load, not against a mock wake detector. That's 10 Hz of a no-op memory read, negligible vs the original 20 Hz of re-entering the async loop, and necessary because `threading.Event` doesn't have an async `wait`.
+
+Alternative: use `janus.Queue` or `asyncio.to_thread(stop_event.wait)` for a truly zero-poll bridge. YAGNI for now — 10 Hz stop-check is fine.
+
+**Step 4: Run tests**
+
+Run: `uv run pytest app/tests -v`
+Expected: new wake tests pass; existing `test_run_loop_*` tests pass too (adjust them if they relied on polling cadence; they probably don't).
+
+Run: `uv run mypy --strict app/src app/tests`
+Expected: clean.
+
+**Step 5: Commit**
+
+```bash
+git add app/src/reachy_ducky_app/wake.py app/src/reachy_ducky_app/main.py app/tests/test_main.py app/tests/test_wake.py
+git commit -m "feat(app): wake loop is asyncio.Event-driven, not 20Hz polling
+
+WakeDetector exposes ``event: asyncio.Event`` that ``_run_async``
+awaits via ``asyncio.wait``. Stop-event bridging is a tiny 10Hz memory
+check against ``threading.Event.is_set()`` — no longer conflating
+shutdown polling with wake polling.
+
+Phase A wake detection is still stubbed (MockWakeDetector never sets
+the event unless a test opts in via ``trigger_on_feed=True``); real
+ONNX-backed detector lands with the audio pump (#23).
+
+Closes #15."
+```
+
+Open PR for M2: `wake-event-driven` → main. `Closes #15, #17`.
+
+---
+
+## Milestone 3 — HF Space metadata single-source-of-truth
+
+Closes **#16**. Small but requires a decision on which source wins.
+
+**Branch name:** `hf-space-metadata-dedup`.
+
+### Task 3.1: Decide which file is canonical
+
+**Files:**
+- Research only; no code changes.
+
+**Step 1: Verify what each consumer reads**
+
+- `app/reachy_mini_app.yaml` — read by the on-robot Pollen daemon's dashboard. Format: `reachy_mini_app` schema (see Pollen docs).
+- `app/README.md` frontmatter — read by HuggingFace Spaces when the repo is mirrored there.
+
+Action: confirm by reading the `reachy_mini_app` package source for which file it actually loads. Search: `grep -r "reachy_mini_app.yaml\|metadata" $(python -c 'import reachy_mini_app; print(reachy_mini_app.__path__[0])')`.
+
+**Step 2: Pick the canonical source**
+
+Options (pick one):
+
+- **A. `reachy_mini_app.yaml` wins.** Drop README frontmatter. HF Spaces is a mirror; on-robot dashboard is primary.
+- **B. README frontmatter wins.** Drop `reachy_mini_app.yaml`. Fewer files, and HF Spaces' rendering benefits from frontmatter.
+- **C. Generate one from the other at publish time.** Most work; defer.
+
+**Recommendation: A.** The on-robot path is what we ship to end users; the HF Space is a mirror. If the on-robot dashboard requires `reachy_mini_app.yaml`, that's the one file that must exist. HF Spaces can render without frontmatter.
+
+**Step 3: Record the decision**
+
+Add a comment to whichever file survives, noting the retirement of the other. No commit yet — the actual removal lands in Task 3.2.
+
+---
+
+### Task 3.2: Remove the duplicate + update CLAUDE.md
+
+**Files (Option A — `reachy_mini_app.yaml` wins):**
+- Modify: `app/README.md` (remove the `---`-delimited frontmatter block)
+- Modify: `app/reachy_mini_app.yaml` (add a `# Canonical source; HF Space README frontmatter removed 2026-04-23.` comment)
+- Modify: `CLAUDE.md` (the "App deployment" section, if any mentions the dual files)
+
+**Step 1: Verify the README frontmatter is removable**
+
+If HF Spaces renders README.md without frontmatter (just as Markdown), dropping it doesn't break rendering. If HF Spaces *requires* frontmatter for Space metadata, dropping breaks the mirror.
+
+Action: push a test branch to a scratch HF Space to verify, OR read the current HF Space page to confirm rendering source.
+
+**Step 2: Remove the frontmatter**
+
+Open `app/README.md`; delete lines from the first `---` through the second `---` inclusive.
+
+**Step 3: Annotate the surviving file**
+
+Prepend to `app/reachy_mini_app.yaml`:
+
+```yaml
+# Canonical app metadata — single source of truth.
+# The HF Space README frontmatter was removed 2026-04-23 to avoid drift
+# (see closed issue #16). If HF Space rendering needs metadata in the
+# future, generate it from this file at publish time instead of
+# duplicating.
+```
+
+**Step 4: Run tests + gate**
+
+```bash
+uv run pytest -q
+uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests
+```
+
+Expected: no test exercises these files directly; all pass.
+
+**Step 5: Commit**
+
+```bash
+git add app/README.md app/reachy_mini_app.yaml
+git commit -m "chore(app): single-source-of-truth HF Space metadata
+
+reachy_mini_app.yaml is canonical. README frontmatter removed to stop
+the drift surface (both files declared metadata that could diverge
+silently on a version bump). On-robot dashboard reads the YAML; HF
+Space mirror renders the README as plain Markdown.
+
+Closes #16."
+```
+
+Open PR for M3: `hf-space-metadata-dedup` → main. `Closes #16`.
+
+---
+
+## Milestone 4 — Hardware audio I/O
+
+Closes **#23**. The substantive item. Wires real `ReachyMini` mic/speaker primitives through the existing `MicSource`/`SpeakerSink` ABCs.
+
+**Branch name:** `hardware-audio-io`.
+
+**Prereqs:**
+- `uv sync --all-packages --extra robot` — installs the `reachy-mini` SDK (Linux/on-robot only; dev macOS will skip these tasks).
+- Physical Reachy Mini OR a Linux host where the robot extra installs cleanly.
+
+**Session budget:** expect M4 to take its own session. #23 has real unknowns (the SDK audio surface isn't fully pinned in our codebase yet).
+
+### Task 4.1: Pin the Reachy Mini audio SDK surface via a contract test
+
+**Files:**
+- Create: `app/tests/test_sdk_audio_contract.py`
+
+**Step 1: Understand what the SDK exposes**
+
+Design doc §11 cites `mini.media.get_audio_sample` and `mini.media.push_audio_sample` as the mic/speaker primitives. Verify by introspecting the installed SDK:
+
+```bash
+uv run --extra robot python -c "
+import reachy_mini
+import inspect
+mini = reachy_mini.ReachyMini()
+print('Media attrs:', [a for a in dir(mini.media) if not a.startswith('_')])
+print(inspect.signature(mini.media.get_audio_sample))
+print(inspect.signature(mini.media.push_audio_sample))
+"
+```
+
+Record what you learn. The exact signature + return type drive the impls.
+
+**Step 2: Write the failing contract test**
+
+```python
+"""SDK contract — pin the ReachyMini audio surface our impls depend on.
+
+Catches upstream SDK renames / signature changes before they hit real
+hardware. Gated on the ``sdk`` marker; runs in the sdk-contract CI
+workflow where the robot extra is installed.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.sdk
+
+
+def test_reachy_mini_media_exposes_audio_sample_methods() -> None:
+    """ReachyMini.media has the two audio methods our impls call."""
+    from reachy_mini import ReachyMini  # type: ignore[import-not-found]
+
+    mini = ReachyMini()
+    assert hasattr(mini.media, "get_audio_sample"), (
+        "ReachyMini.media.get_audio_sample missing — ReachyMicSource can't source frames"
+    )
+    assert hasattr(mini.media, "push_audio_sample"), (
+        "ReachyMini.media.push_audio_sample missing — ReachySpeakerSink can't sink frames"
+    )
+
+
+def test_get_audio_sample_returns_pcm_bytes() -> None:
+    """get_audio_sample returns a PCM buffer compatible with our contract."""
+    from reachy_mini import ReachyMini  # type: ignore[import-not-found]
+
+    mini = ReachyMini()
+    sample = mini.media.get_audio_sample()
+    # Shape/format asserts filled in once Step 1 investigation confirms
+    # the return type. Expected: bytes or np.ndarray of int16.
+    assert sample is not None
+    # TODO: pin exact dtype + sample rate once Step 1 lands.
+
+
+def test_push_audio_sample_accepts_pcm_bytes() -> None:
+    """push_audio_sample accepts the PCM buffer shape we'll hand it."""
+    from reachy_mini import ReachyMini  # type: ignore[import-not-found]
+    import numpy as np
+
+    mini = ReachyMini()
+    silent_frame = np.zeros(960, dtype=np.int16).tobytes()  # 40ms @ 24kHz mono PCM16
+    # Should not raise on a well-formed frame; the SDK may no-op
+    # silently if no speaker is attached in sim.
+    mini.media.push_audio_sample(silent_frame)
+```
+
+**Step 3: Run the tests on the robot / Linux**
+
+Run: `uv run --extra robot pytest -m sdk -v`
+Expected: at least the hasattr tests pass; the dtype/signature assertions may need refinement.
+
+**Step 4: Refine based on reality**
+
+After seeing the actual Step 1 output, tighten the signature/dtype assertions. This test pins them — if Pollen renames or changes shape, CI catches it.
+
+**Step 5: Commit**
+
+```bash
+git add app/tests/test_sdk_audio_contract.py
+git commit -m "test(sdk): pin ReachyMini audio surface used by #23 impls
+
+SDK-contract tests that run on the sdk-contract CI workflow. Catches
+upstream audio-API renames / signature changes before they hit real
+hardware. Refine the dtype/shape asserts once Step 1 introspection
+lands."
+```
+
+---
+
+### Task 4.2: Implement `ReachyMicSource`
+
+**Files:**
+- Modify: `app/src/reachy_ducky_app/voice/audio_io.py`
+- Modify: `app/tests/voice/test_audio_io.py` (or wherever `MicSource` tests live)
+
+**Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_reachy_mic_source_yields_frames_from_media_get_audio_sample() -> None:
+    """ReachyMicSource calls mini.media.get_audio_sample() in a loop and yields frames."""
+    # Fake ReachyMini that scripts 3 successive audio samples.
+    frames_script = [b"A" * 960, b"B" * 960, b"C" * 960]
+    call_count = 0
+
+    class FakeMedia:
+        def get_audio_sample(self) -> bytes:
+            nonlocal call_count
+            if call_count >= len(frames_script):
+                raise StopIteration  # sentinel for the test loop
+            frame = frames_script[call_count]
+            call_count += 1
+            return frame
+
+    class FakeMini:
+        media = FakeMedia()
+
+    from reachy_ducky_app.voice.audio_io import ReachyMicSource
+
+    src = ReachyMicSource(FakeMini())
+    collected: list[bytes] = []
+    try:
+        async for frame in src.frames():
+            collected.append(frame)
+            if len(collected) == len(frames_script):
+                break
+    except StopIteration:
+        pass
+    assert collected == frames_script
+```
+
+**Step 2: Run the failing test**
+
+Run: `uv run pytest app/tests -k mic_source -v`
+Expected: FAIL — `ReachyMicSource` doesn't exist yet.
+
+**Step 3: Implement `ReachyMicSource`**
+
+```python
+class ReachyMicSource(MicSource):
+    """Hardware-backed mic source: pulls PCM frames from the ReachyMini SDK.
+
+    Wraps ``ReachyMini.media.get_audio_sample()`` in an async generator.
+    Format + sample-rate conversion lives here if the SDK's native
+    output doesn't match the PCM16 mono 24 kHz contract; today we
+    assume the SDK returns the contract format directly (pinned by the
+    sdk-contract test).
+
+    **Hardware-only:** requires a ReachyMini instance passed by the
+    on-robot Pollen daemon. The mock factory still returns
+    :class:`MockMicSource` on dev machines; switch is made by
+    :func:`load_default_mic_source` based on the runtime environment.
+    """
+
+    def __init__(self, mini: object) -> None:
+        self._mini = mini
+
+    async def frames(self) -> AsyncIterator[bytes]:
+        """Yield PCM frames until the underlying source raises / ends."""
+        loop = asyncio.get_running_loop()
+        while True:
+            # get_audio_sample is (likely) synchronous — run it in the
+            # default executor so the event loop isn't blocked.
+            frame = await loop.run_in_executor(
+                None,
+                self._mini.media.get_audio_sample,  # type: ignore[attr-defined]
+            )
+            if frame is None or len(frame) == 0:
+                return
+            yield frame
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest app/tests -k mic_source -v`
+Expected: PASS.
+
+Type-check:
+`uv run mypy --strict app/src app/tests`
+
+**Step 5: Commit**
+
+```bash
+git add app/src/reachy_ducky_app/voice/audio_io.py app/tests/voice/test_audio_io.py
+git commit -m "feat(app/voice): ReachyMicSource wraps mini.media.get_audio_sample
+
+Hardware-backed mic source per #23. Uses an executor to keep the sync
+SDK call off the event loop. Sample-rate/format conversion deferred —
+the sdk-contract test (4.1) pins the SDK returning PCM16 mono 24 kHz
+directly."
+```
+
+---
+
+### Task 4.3: Implement `ReachySpeakerSink`
+
+**Files:**
+- Modify: `app/src/reachy_ducky_app/voice/audio_io.py`
+- Modify: `app/tests/voice/test_audio_io.py`
+
+**Step 1: Failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_reachy_speaker_sink_forwards_to_media_push_audio_sample() -> None:
+    """ReachySpeakerSink.play(pcm) calls mini.media.push_audio_sample(pcm)."""
+    pushed: list[bytes] = []
+
+    class FakeMedia:
+        def push_audio_sample(self, pcm: bytes) -> None:
+            pushed.append(pcm)
+
+    class FakeMini:
+        media = FakeMedia()
+
+    from reachy_ducky_app.voice.audio_io import ReachySpeakerSink
+
+    sink = ReachySpeakerSink(FakeMini())
+    await sink.play(b"frame-1")
+    await sink.play(b"frame-2")
+    assert pushed == [b"frame-1", b"frame-2"]
+```
+
+**Step 2: Run — expect ImportError.**
+
+**Step 3: Implement**
+
+```python
+class ReachySpeakerSink(SpeakerSink):
+    """Hardware-backed speaker sink: pushes PCM frames to the ReachyMini SDK.
+
+    Wraps ``ReachyMini.media.push_audio_sample()``. Same format
+    contract as :class:`ReachyMicSource`: PCM16 mono 24 kHz.
+    """
+
+    def __init__(self, mini: object) -> None:
+        self._mini = mini
+
+    async def play(self, pcm: bytes) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            self._mini.media.push_audio_sample,  # type: ignore[attr-defined]
+            pcm,
+        )
+```
+
+**Step 4: Tests pass.**
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(app/voice): ReachySpeakerSink wraps mini.media.push_audio_sample
+
+Hardware-backed speaker sink per #23. Symmetric with ReachyMicSource."
+```
+
+---
+
+### Task 4.4: Factory update — return hardware impls when on-robot
+
+**Files:**
+- Modify: `app/src/reachy_ducky_app/voice/audio_io.py:67-86`
+- Modify: `app/src/reachy_ducky_app/main.py:62-65` (pass `reachy_mini` into the factories)
+- Modify: `app/tests/voice/test_audio_io.py` (factory selection tests)
+
+**Step 1: Decide the selection signal**
+
+Options:
+- **A.** Pass `reachy_mini` into `load_default_*` explicitly. If it's a truthy object, return hardware impls; else mock.
+- **B.** Detect the `reachy_mini` module import at factory call time. Fragile (module may be installed but not in use).
+
+**Recommendation: A.** Explicit over implicit. Call sites in `main.py` already have `reachy_mini`; threading it through is a small refactor.
+
+**Step 2: Write the failing test**
+
+```python
+def test_load_default_mic_source_returns_hardware_impl_when_mini_given() -> None:
+    """Passing a ReachyMini-like object to the factory returns the hardware impl."""
+    class FakeMini:
+        pass
+
+    src = load_default_mic_source(reachy_mini=FakeMini())
+    assert isinstance(src, ReachyMicSource)
+
+
+def test_load_default_mic_source_returns_mock_when_mini_is_none() -> None:
+    """No ReachyMini given → MockMicSource (the dev-machine path)."""
+    src = load_default_mic_source(reachy_mini=None)
+    assert isinstance(src, MockMicSource)
+```
+
+Same two tests for `load_default_speaker_sink`.
+
+**Step 3: Update factories + call sites**
+
+```python
+def load_default_mic_source(reachy_mini: object | None = None) -> MicSource:
+    """Return hardware source when ``reachy_mini`` is given, mock otherwise.
+
+    The on-robot Pollen daemon hands :class:`ReachyDuckyApp.run` a live
+    ``ReachyMini`` instance; the app threads it through this factory.
+    Dev machines pass ``None`` and get the silent mock — unit tests
+    and local runs stay hardware-free.
+    """
+    if reachy_mini is None:
+        return MockMicSource()
+    return ReachyMicSource(reachy_mini)
+
+
+def load_default_speaker_sink(reachy_mini: object | None = None) -> SpeakerSink:
+    """Return hardware sink when ``reachy_mini`` is given, mock otherwise."""
+    if reachy_mini is None:
+        return MockSpeakerSink()
+    return ReachySpeakerSink(reachy_mini)
+```
+
+Update `app/src/reachy_ducky_app/main.py:62-65`:
+
+```python
+voice = OpenAIRealtimeVoice(
+    mic=load_default_mic_source(reachy_mini=reachy_mini),
+    speaker=load_default_speaker_sink(reachy_mini=reachy_mini),
+)
+```
+
+**Step 4: Tests pass.**
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(app/voice): factories return hardware impls when reachy_mini given
+
+load_default_mic_source / load_default_speaker_sink take an optional
+reachy_mini kwarg — truthy → hardware, None → mock. main.py threads
+the on-robot daemon's ReachyMini instance through so production is
+hardware by default, tests/dev stay mock by default."
+```
+
+---
+
+### Task 4.5: Hardware smoke test
+
+**Files:**
+- Create: `app/tests/voice/test_audio_io_hardware.py`
+
+**Step 1: Write the gated test**
+
+```python
+"""Hardware smoke for the audio-I/O plumbing.
+
+Gated on ``@pytest.mark.hardware`` — runs only with a real Reachy Mini
+attached (invoke with ``uv run pytest -m hardware``). Verifies end-to-
+end that PCM frames flow through the real SDK and come out the speaker
+without the process crashing. Does NOT assert audio content — that's a
+human-in-the-loop judgment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import numpy as np
+
+pytestmark = pytest.mark.hardware
+
+
+@pytest.mark.asyncio
+async def test_reachy_speaker_sink_plays_silent_frame_without_error() -> None:
+    from reachy_mini import ReachyMini  # type: ignore[import-not-found]
+    from reachy_ducky_app.voice.audio_io import ReachySpeakerSink
+
+    mini = ReachyMini()
+    sink = ReachySpeakerSink(mini)
+    silent = np.zeros(960, dtype=np.int16).tobytes()  # 40ms @ 24 kHz mono
+    await sink.play(silent)
+    # If we didn't crash, the SDK accepted the frame. Human listener
+    # confirms audible silence (not static / garbage).
+
+
+@pytest.mark.asyncio
+async def test_reachy_mic_source_yields_at_least_one_frame() -> None:
+    from reachy_mini import ReachyMini  # type: ignore[import-not-found]
+    from reachy_ducky_app.voice.audio_io import ReachyMicSource
+
+    mini = ReachyMini()
+    src = ReachyMicSource(mini)
+
+    # Pull exactly one frame; cancel the generator after.
+    async def pull_one() -> bytes | None:
+        async for frame in src.frames():
+            return frame
+        return None
+
+    frame = await asyncio.wait_for(pull_one(), timeout=5.0)
+    assert frame is not None
+    assert len(frame) > 0
+```
+
+**Step 2: Run (on hardware)**
+
+Run: `uv run --extra robot pytest -m hardware -v`
+Expected: PASS on a connected Reachy Mini. FAIL with clear SDK-import error on a dev machine (which is correct — this marker is opt-in).
+
+**Step 3: Commit**
+
+```bash
+git commit -m "test(app/voice): hardware smoke for ReachyMic/SpeakerSink
+
+Gated on @pytest.mark.hardware. Plays a silent frame, pulls one mic
+frame. Doesn't assert audio content — that's a human-in-the-loop
+check. Completes the #23 acceptance criteria."
+```
+
+Open PR for M4: `hardware-audio-io` → main. `Closes #23`.
+
+---
+
+## Milestone 5 — Mute coordination
+
+Closes **#20**. Binds the now-real mic pump (#23) to the embodiment state machine so MUTED state actually zeroes the audio path.
+
+**Branch name:** `mute-coordination`.
+
+**Depends on:** M4 merged into main.
+
+### Task 5.1: Inject `MuteGate` into `EmbodimentStateMachine`
+
+**Files:**
+- Modify: `app/src/reachy_ducky_app/embodiment/state_machine.py`
+- Modify: `app/tests/embodiment/test_state_machine.py`
+
+**Step 1: Failing test**
+
+```python
+def test_state_machine_sets_mute_gate_on_muted_transition() -> None:
+    """Transitioning to MUTED calls mute_gate.set_muted(True)."""
+    gate = MuteGate()
+    driver = _FakeDriver()
+    sm = EmbodimentStateMachine(driver=driver, mute_gate=gate)
+    assert gate.muted is False
+
+    sm.transition(State.MUTED)
+    assert gate.muted is True
+
+
+def test_state_machine_clears_mute_gate_on_leaving_muted() -> None:
+    """Transitioning OUT of MUTED calls mute_gate.set_muted(False)."""
+    gate = MuteGate()
+    gate.set_muted(True)
+    driver = _FakeDriver()
+    sm = EmbodimentStateMachine(driver=driver, mute_gate=gate, initial=State.MUTED)
+
+    sm.transition(State.IDLE)
+    assert gate.muted is False
+```
+
+**Step 2: Run — FAIL** (constructor doesn't accept `mute_gate` yet).
+
+**Step 3: Implement**
+
+Add `mute_gate: MuteGate | None = None` to `EmbodimentStateMachine.__init__`. In `transition`, call `self._mute_gate.set_muted(True)` when entering MUTED, `set_muted(False)` when leaving.
+
+Keep `mute_gate=None` working (ABC-level state machine still usable without a physical mute, for tests).
+
+**Step 4: Pass.**
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(embodiment): state machine binds MuteGate on MUTED transitions
+
+Entering MUTED calls mute_gate.set_muted(True); leaving MUTED calls
+set_muted(False). mute_gate is optional (None preserves today's
+test-only usage). Real wiring happens in main.py (#20 next task)."
+```
+
+---
+
+### Task 5.2: Wire `MuteGate` + `ReachyMicSource` in `main.py`
+
+**Files:**
+- Modify: `app/src/reachy_ducky_app/main.py`
+- Modify: `app/src/reachy_ducky_app/voice/audio_io.py` — `ReachyMicSource` takes an optional `mute_gate`
+- Modify: `app/tests/test_main.py`
+- Modify: `app/tests/voice/test_audio_io.py`
+
+**Step 1: Failing tests**
+
+(a) Unit — `ReachyMicSource` with a muted gate yields zero frames:
+
+```python
+@pytest.mark.asyncio
+async def test_reachy_mic_source_zeroes_frames_when_muted() -> None:
+    """ReachyMicSource applies mute_gate.process to each frame; muted → zeros."""
+    class FakeMedia:
+        _count = 0
+        def get_audio_sample(self) -> bytes:
+            FakeMedia._count += 1
+            if FakeMedia._count > 2:
+                return b""  # end-of-stream sentinel
+            return np.full(960, fill_value=1234, dtype=np.int16).tobytes()
+
+    class FakeMini:
+        media = FakeMedia()
+
+    gate = MuteGate()
+    gate.set_muted(True)
+    src = ReachyMicSource(FakeMini(), mute_gate=gate)
+    collected = [f async for f in src.frames()]
+
+    # All frames zeroed.
+    for frame in collected:
+        assert frame == np.zeros(960, dtype=np.int16).tobytes()
+```
+
+(b) End-to-end — `main._run_async` constructs one `MuteGate`, threads it into the state machine AND the mic source:
+
+```python
+@pytest.mark.asyncio
+async def test_run_async_shares_one_mute_gate_across_sm_and_mic(...) -> None:
+    # Exercise: trigger MUTED transition via sm; verify mic source's gate sees it.
+    ...
+```
+
+**Step 2: Run — FAIL.**
+
+**Step 3: Implement**
+
+`ReachyMicSource`:
+
+```python
+class ReachyMicSource(MicSource):
+    def __init__(self, mini: object, mute_gate: MuteGate | None = None) -> None:
+        self._mini = mini
+        self._mute_gate = mute_gate
+
+    async def frames(self) -> AsyncIterator[bytes]:
+        loop = asyncio.get_running_loop()
+        while True:
+            frame = await loop.run_in_executor(
+                None, self._mini.media.get_audio_sample,
+            )
+            if frame is None or len(frame) == 0:
+                return
+            if self._mute_gate is not None and self._mute_gate.muted:
+                frame = np.zeros_like(
+                    np.frombuffer(frame, dtype=np.int16)
+                ).tobytes()
+            yield frame
+```
+
+`main.py._run_async`:
+
+```python
+mute_gate = MuteGate()
+sm = EmbodimentStateMachine(driver=driver, mute_gate=mute_gate)
+voice = OpenAIRealtimeVoice(
+    mic=load_default_mic_source(reachy_mini=reachy_mini, mute_gate=mute_gate),
+    speaker=load_default_speaker_sink(reachy_mini=reachy_mini),
+)
+```
+
+Update `load_default_mic_source` to thread `mute_gate` into `ReachyMicSource`.
+
+**Step 4: Tests pass.**
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(app): bind one MuteGate across state machine + mic source
+
+main._run_async constructs a single MuteGate and threads it into both
+the EmbodimentStateMachine (for the MUTED state transition) and the
+ReachyMicSource (for per-frame zeroing). Now a MUTED robot actually
+has a zeroed mic path — previously the gate was unused.
+
+Closes #20."
+```
+
+---
+
+### Task 5.3: Hardware end-to-end mute test
+
+**Files:**
+- Create or modify: `app/tests/test_main_hardware.py`
+
+**Step 1: Write the gated test**
+
+```python
+pytestmark = pytest.mark.hardware
+
+
+@pytest.mark.asyncio
+async def test_muting_during_a_turn_zeros_the_mic_path() -> None:
+    """End-to-end: trigger MUTED mid-loop, observe the mic source emitting zeros.
+
+    Requires a real ReachyMini with a mic. Human-in-the-loop verifies
+    the robot's body also goes_to_sleep (visible cue).
+    """
+    # Construction identical to main._run_async; intercept at the mic
+    # layer to verify zeroing.
+    ...
+```
+
+**Step 2: Run on hardware.**
+
+**Step 3: Commit**
+
+```bash
+git commit -m "test(hardware): end-to-end mute zeroes mic path + sleeps body
+
+@pytest.mark.hardware. Verifies the #20 seam actually works on real
+hardware — MUTED state transitions go_to_sleep on the body AND zero
+the mic input. Human-in-the-loop confirms the audible silence."
+```
+
+Open PR for M5: `mute-coordination` → main. `Closes #20`. **Depends on M4 merged.**
+
+---
+
+## Done / exit criteria
+
+When all five milestone PRs are merged:
+
+1. Run on the robot: `uv sync --all-packages --extra robot && uv run pytest -m hardware -v`
+   → At least the smoke tests added in 4.5 and 5.3 pass; no crashes.
+
+2. Run locally: `uv run pytest -q --cov && uv run mypy --strict ... && uv run ruff check . && uv run bandit -ll -r ...`
+   → All green, coverage ≥ 90%.
+
+3. Open issues audit: #15, #16, #17, #20, #23, #25, #27 all closed by their respective PR merges.
+
+4. Spot-verify via the Makefile: `make sim-daemon` launches; `make sim-stop` cleans up.
+
+5. End-to-end hardware walkthrough (manual, once):
+   - Install the app on a real Reachy Mini.
+   - Press the mute toggle; verify the body goes to sleep AND speaking into the mic produces no transcript.
+   - Unmute; verify speech → daemon → response → audible reply.
+
+### Follow-ups explicitly NOT in this plan
+
+- **#22** — project-slug selector on the on-robot app. Multi-project UX; single-project works fine for initial testing.
+- **#5, #6, #8, #19** — specialist / config polish; independent of testing prerequisites.
+- **#28–#30, #40, #47** — v0.1.0 release plumbing (PyPI distribution decision, HF Space sync, release workflow). Gated behind "testing works" → do after this plan.
+- **#48** — Dependabot runtime alerts. Separate investigation session.
+
+### Session split suggestion
+
+- **Session A:** M1 + M2 + M3 (small PRs, same-day cadence).
+- **Session B:** M4 (the substantive one; SDK investigation + hardware testing).
+- **Session C:** M5 (depends on M4 on main).


### PR DESCRIPTION
## Summary

Durable plan artifact for unblocking end-to-end testing of Reachy Ducky on real hardware. Sequences the 6-issue bundle confirmed in-scope during the 2026-04-23 scoping pass into 5 single-PR-sized milestones.

Plan doc: [`docs/plans/2026-04-23-v0.1.0-testing-prerequisites.md`](docs/plans/2026-04-23-v0.1.0-testing-prerequisites.md)

## Milestone bundle

| | Issue | |
|---|---|---|
| M1 | #25, #27 | Sim dev Makefile + upstream sim-audio tracking |
| M2 | #15, #17 | Event-driven wake loop + dead-code cleanup |
| M3 | #16 | HF Space metadata single-source-of-truth |
| M4 | #23 | Hardware `ReachyMicSource` / `ReachySpeakerSink` (the substantive one) |
| M5 | #20 | Bind `MuteGate` to state-machine MUTED transition + mic pump |

Each milestone lands on its own feature branch with its own PR. M5 depends on M4 on main.

## Explicitly NOT in scope

- **#22** — project-slug UX; single-project testing works as-is.
- **#5, #6, #8, #19** — specialist/config polish.
- **#28–#30, #40, #47** — v0.1.0 release plumbing (do after testing works).
- **#48** — Dependabot runtime alerts (separate investigation session).

## Test plan

- [x] Plan doc gitleaks-clean
- [ ] Plan merges cleanly to main before M1 branch spins off
- [ ] Augment review addressed (unlikely to have much on a plan doc, but wait for it)

No code changes in this PR — plan doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)