### PR TITLE
feat: v0.1.0 testing-prep M1–M3 (closes #15, #16, #17, #25, #27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ credentials*
 # Local Reachy Ducky runtime
 .reachy-ducky/
 /memory/
+.sim-daemon.pid
 
 # GitNexus local index
 .gitnexus/

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,22 @@ sim-daemon:
 	@sleep 2
 	@echo "reachy-mini-daemon pid $$(cat $(SIM_DAEMON_PIDFILE))"
 
+# Verify the PID still owns a reachy-mini-daemon process before signalling.
+# Stale pidfile + OS-recycled PID is the classic hazard (daemon exits
+# uncleanly, another process inherits the PID, ``make sim-stop`` kills the
+# wrong thing). ``ps -p <pid> -o comm=`` prints the short command name;
+# the ``grep -q`` check refuses to kill unless the name matches.
 sim-stop:
 	@if [ -f "$(SIM_DAEMON_PIDFILE)" ]; then \
 	  pid=$$(cat $(SIM_DAEMON_PIDFILE)); \
 	  if kill -0 "$$pid" 2>/dev/null; then \
-	    echo "Stopping reachy-mini-daemon pid $$pid..."; \
-	    kill "$$pid"; \
+	    comm=$$(ps -p "$$pid" -o comm= 2>/dev/null | tr -d ' '); \
+	    if echo "$$comm" | grep -q reachy-mini-daemon; then \
+	      echo "Stopping reachy-mini-daemon pid $$pid..."; \
+	      kill "$$pid"; \
+	    else \
+	      echo "PID $$pid does not own reachy-mini-daemon (found '$$comm'); leaving alone"; \
+	    fi; \
 	  fi; \
 	  rm -f "$(SIM_DAEMON_PIDFILE)"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# Reachy Ducky — developer convenience targets.
+#
+# Most day-to-day tasks use ``uv run`` directly (see CLAUDE.md). This
+# Makefile wraps the multi-step local sim flow so motion/lifecycle work
+# doesn't need real hardware. The sim target requires the reachy-mini
+# package installed with the ``mujoco`` extra — see the "Local sim dev
+# flow" block in CLAUDE.md.
+.PHONY: sim-daemon sim-stop
+
+# PID file for the background reachy-mini-daemon process. ``sim-daemon``
+# writes it; ``sim-stop`` reads + cleans it. Kept out of the tree root
+# via a dotfile so ``git status`` doesn't flag it.
+SIM_DAEMON_PIDFILE := .sim-daemon.pid
+
+sim-daemon:
+	@if [ -f "$(SIM_DAEMON_PIDFILE)" ] && kill -0 "$$(cat $(SIM_DAEMON_PIDFILE))" 2>/dev/null; then \
+	  echo "reachy-mini-daemon already running (pid $$(cat $(SIM_DAEMON_PIDFILE)))"; \
+	  exit 0; \
+	fi
+	@echo "Starting reachy-mini-daemon --sim in background..."
+	@reachy-mini-daemon --robot-name reachy_mini_sim --sim --headless --localhost-only & \
+	  echo $$! > "$(SIM_DAEMON_PIDFILE)"
+	@sleep 2
+	@echo "reachy-mini-daemon pid $$(cat $(SIM_DAEMON_PIDFILE))"
+
+sim-stop:
+	@if [ -f "$(SIM_DAEMON_PIDFILE)" ]; then \
+	  pid=$$(cat $(SIM_DAEMON_PIDFILE)); \
+	  if kill -0 "$$pid" 2>/dev/null; then \
+	    echo "Stopping reachy-mini-daemon pid $$pid..."; \
+	    kill "$$pid"; \
+	  fi; \
+	  rm -f "$(SIM_DAEMON_PIDFILE)"; \
+	fi
+	@echo "sim-daemon stopped"

--- a/app/README.md
+++ b/app/README.md
@@ -1,3 +1,21 @@
+---
+# HF Space presentation chrome ONLY — fields HuggingFace Spaces reads
+# that do NOT appear in reachy_mini_app.yaml. Shared fields (title,
+# emoji, app_class, python_version, description) live in the YAML
+# (canonical for the on-robot Pollen dashboard); this frontmatter
+# carries only HF-Space-listing metadata that has no other consumer,
+# so drift is impossible by construction (a field can't drift if it
+# exists in only one place). See closed issue #16.
+colorFrom: yellow
+colorTo: blue
+sdk: static
+pinned: false
+short_description: Read-only rubber-ducky companion for agentic SWE work.
+tags:
+  - reachy_mini
+  - reachy_mini_python_app
+---
+
 # Reachy Ducky — Reachy Mini App
 
 The Reachy Mini side of the [Reachy Ducky project](https://github.com/Obsidian-Owl/reachy-ducky).

--- a/app/README.md
+++ b/app/README.md
@@ -1,16 +1,3 @@
----
-title: reachy-ducky
-emoji: "\U0001F986"
-colorFrom: yellow
-colorTo: blue
-sdk: static
-pinned: false
-short_description: Read-only rubber-ducky companion for agentic SWE work.
-tags:
-  - reachy_mini
-  - reachy_mini_python_app
----
-
 # Reachy Ducky — Reachy Mini App
 
 The Reachy Mini side of the [Reachy Ducky project](https://github.com/Obsidian-Owl/reachy-ducky).

--- a/app/reachy_mini_app.yaml
+++ b/app/reachy_mini_app.yaml
@@ -1,8 +1,10 @@
-# Canonical app metadata — single source of truth.
-# The HF Space README frontmatter was removed 2026-04-23 to avoid drift
-# (see closed issue #16). If HF Space rendering needs metadata in the
-# future, generate it from this file at publish time instead of
-# duplicating.
+# Canonical app metadata — the on-robot Pollen dashboard reads this
+# file. Any field defined here is authoritative; the README frontmatter
+# in app/README.md carries ONLY HF-Space-listing presentation chrome
+# (colorFrom/colorTo/sdk/pinned/short_description/tags) that has no
+# on-robot consumer and therefore can't drift against this file. Shared
+# fields (title, emoji, python_version, app_class, description) live
+# here alone. See closed issue #16 for the original dedup rationale.
 title: reachy-ducky
 emoji: "\U0001F986"
 python_version: "3.12"

--- a/app/reachy_mini_app.yaml
+++ b/app/reachy_mini_app.yaml
@@ -1,3 +1,8 @@
+# Canonical app metadata — single source of truth.
+# The HF Space README frontmatter was removed 2026-04-23 to avoid drift
+# (see closed issue #16). If HF Space rendering needs metadata in the
+# future, generate it from this file at publish time instead of
+# duplicating.
 title: reachy-ducky
 emoji: "\U0001F986"
 python_version: "3.12"

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -27,6 +27,15 @@ from .embodiment.motion_driver import ReachyMotionDriver
 from .embodiment.state_machine import EmbodimentStateMachine
 from .voice.audio_io import load_default_mic_source, load_default_speaker_sink
 from .voice.openai_realtime import OpenAIRealtimeVoice
+from .wake import load_default_wake_detector
+
+# How often the stop-bridge checks ``threading.Event.is_set()``. This is a
+# memory-load poll only — the wake path itself awaits ``wake.event`` via
+# ``asyncio.wait(FIRST_COMPLETED)`` and never spins. ``threading.Event``
+# has no native async ``wait``; a 10 Hz check against a shared memory flag
+# is far cheaper than the original 20 Hz wake-loop re-entry, and avoids
+# pulling in ``janus`` / ``asyncio.to_thread`` plumbing we don't need yet.
+_STOP_BRIDGE_POLL_SECONDS = 0.1
 
 
 class ReachyDuckyApp:
@@ -49,7 +58,13 @@ class ReachyDuckyApp:
         reachy_mini: object,
         stop_event: threading.Event,
     ) -> None:
-        """Construct the piece graph and poll for wake events until stopped.
+        """Construct the piece graph and await wake events until stopped.
+
+        The main loop blocks on ``asyncio.wait({wake.event.wait(),
+        stop_checker}, return_when=FIRST_COMPLETED)`` — the wake path is
+        pure event-driven (no polling), and the stop path is a tiny 10 Hz
+        memory-load check (see :data:`_STOP_BRIDGE_POLL_SECONDS`) bridging
+        the on-robot daemon's ``threading.Event`` into asyncio.
 
         The daemon client pools an ``httpx.AsyncClient`` across turns; we
         wrap the wake loop in ``try/finally`` so the pool is drained on
@@ -63,33 +78,55 @@ class ReachyDuckyApp:
             speaker=load_default_speaker_sink(),
         )
         daemon = DaemonClient.from_env()
+        wake = load_default_wake_detector()
 
+        stop_checker = asyncio.create_task(_watch_stop(stop_event))
         try:
             while not stop_event.is_set():
-                # Phase A simplification: wake detection is stubbed (the default
-                # `MockWakeDetector.feed_audio` returns False unconditionally). A
-                # future task swaps in the real ONNX-backed detector and wires it
-                # to an audio pump that calls `wake.feed_audio(chunk)` on each
-                # mic buffer; `_wake_triggered` is then the bridge between that
-                # pump and the per-turn conversation loop.
-                if self._wake_triggered():
-                    await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug=None)
-                await asyncio.sleep(0.05)
+                wake_waiter = asyncio.create_task(wake.event.wait())
+                try:
+                    await asyncio.wait(
+                        {wake_waiter, stop_checker},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                finally:
+                    if not wake_waiter.done():
+                        wake_waiter.cancel()
+                if stop_event.is_set():
+                    break
+                wake.event.clear()
+                await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug=None)
         finally:
+            stop_checker.cancel()
+            try:
+                await stop_checker
+            except asyncio.CancelledError:
+                pass
             await daemon.aclose()
 
     def _wake_triggered(self) -> bool:
-        """Placeholder: returns False until the real audio pump is wired.
+        """Deprecated test-override seam; no longer called by :meth:`_run_async`.
 
-        The real audio pump (landing with #23's ReachyMicSource) will feed
-        chunks into ``wake.feed_audio(chunk)`` and set a shared
-        ``asyncio.Event`` that :meth:`_run_async` awaits — this method is
-        the bridge between that pump and the per-turn conversation loop.
-
-        Overridable in tests to simulate wake events without needing the
-        ONNX model or mic hardware.
+        Kept so that subclassing to force-trigger a wake via method
+        override remains a stable escape hatch for future refactors. The
+        event-driven loop in :meth:`_run_async` drives turns via
+        ``wake.event`` only, so the default ``False`` body is harmless.
         """
         return False
+
+
+async def _watch_stop(stop_event: threading.Event) -> None:
+    """Bridge ``threading.Event`` into asyncio so ``asyncio.wait`` can select it.
+
+    10 Hz memory-load poll (see :data:`_STOP_BRIDGE_POLL_SECONDS`) — NOT
+    a wake poll. The wake path is fully event-driven. We accept this
+    small residual polling because ``threading.Event`` has no native
+    async ``wait``; alternatives (``janus.Queue`` or
+    ``asyncio.to_thread(stop_event.wait)``) are zero-poll but add
+    complexity that isn't justified today.
+    """
+    while not stop_event.is_set():
+        await asyncio.sleep(_STOP_BRIDGE_POLL_SECONDS)
 
 
 def main() -> None:

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -90,8 +90,19 @@ class ReachyDuckyApp:
                         return_when=asyncio.FIRST_COMPLETED,
                     )
                 finally:
+                    # Cancel AND drain the waiter when it's still pending.
+                    # ``cancel()`` alone only marks the task; dropping the
+                    # reference before it observes the cancellation emits
+                    # "Task was destroyed but it is pending" warnings and
+                    # leaves un-retrieved ``CancelledError`` on the event
+                    # loop. Awaiting with suppression is the canonical
+                    # asyncio pattern for one-shot cancel + cleanup.
                     if not wake_waiter.done():
                         wake_waiter.cancel()
+                        try:
+                            await wake_waiter
+                        except asyncio.CancelledError:
+                            pass
                 if stop_event.is_set():
                     break
                 wake.event.clear()

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -27,7 +27,6 @@ from .embodiment.motion_driver import ReachyMotionDriver
 from .embodiment.state_machine import EmbodimentStateMachine
 from .voice.audio_io import load_default_mic_source, load_default_speaker_sink
 from .voice.openai_realtime import OpenAIRealtimeVoice
-from .wake import WakeDetector, load_default_wake_detector
 
 
 class ReachyDuckyApp:
@@ -64,7 +63,6 @@ class ReachyDuckyApp:
             speaker=load_default_speaker_sink(),
         )
         daemon = DaemonClient.from_env()
-        wake = load_default_wake_detector()
 
         try:
             while not stop_event.is_set():
@@ -74,19 +72,23 @@ class ReachyDuckyApp:
                 # to an audio pump that calls `wake.feed_audio(chunk)` on each
                 # mic buffer; `_wake_triggered` is then the bridge between that
                 # pump and the per-turn conversation loop.
-                if self._wake_triggered(wake):
+                if self._wake_triggered():
                     await run_one_turn(voice=voice, sm=sm, daemon=daemon, project_slug=None)
                 await asyncio.sleep(0.05)
         finally:
             await daemon.aclose()
 
-    def _wake_triggered(self, wake: WakeDetector) -> bool:
+    def _wake_triggered(self) -> bool:
         """Placeholder: returns False until the real audio pump is wired.
+
+        The real audio pump (landing with #23's ReachyMicSource) will feed
+        chunks into ``wake.feed_audio(chunk)`` and set a shared
+        ``asyncio.Event`` that :meth:`_run_async` awaits — this method is
+        the bridge between that pump and the per-turn conversation loop.
 
         Overridable in tests to simulate wake events without needing the
         ONNX model or mic hardware.
         """
-        del wake
         return False
 
 

--- a/app/src/reachy_ducky_app/wake.py
+++ b/app/src/reachy_ducky_app/wake.py
@@ -40,6 +40,16 @@ class WakeDetector(ABC):
 
         Implementations that detect a wake MUST also call
         ``self.event.set()`` so the awaiting ``_run_async`` loop advances.
+
+        **Thread-safety:** ``asyncio.Event.set()`` is not safe to call
+        directly from a non-event-loop thread — doing so can corrupt
+        the Event's internal state. Real ONNX-backed detectors will
+        typically run inference on a dedicated audio thread; such
+        implementations MUST set the event via
+        ``loop.call_soon_threadsafe(self.event.set)`` (where ``loop``
+        is captured at detector construction time). The mock is
+        thread-safe by construction — tests call ``feed_audio``
+        synchronously from the event-loop thread.
         """
 
 

--- a/app/src/reachy_ducky_app/wake.py
+++ b/app/src/reachy_ducky_app/wake.py
@@ -7,6 +7,7 @@ model) without touching callers.
 
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -18,25 +19,52 @@ class WakeDetector(ABC):
 
     Real implementations wrap an ONNX model. :class:`MockWakeDetector` here
     is pure Python and deterministic for tests.
+
+    Exposes :attr:`event` — an ``asyncio.Event`` that :meth:`feed_audio`
+    (or the future ONNX inference path) sets on a detected wake.
+    ``ReachyDuckyApp._run_async`` awaits this event via ``asyncio.wait``
+    so the wake loop never busy-polls.
     """
+
+    def __init__(self) -> None:
+        self.event: asyncio.Event = asyncio.Event()
 
     @abstractmethod
     def feed_audio(self, audio_chunk: npt.NDArray[np.int16]) -> bool:
-        """Return True when the wake word is detected in this chunk."""
+        """Return True when the wake word is detected in this chunk.
+
+        Implementations that detect a wake MUST also call
+        ``self.event.set()`` so the awaiting ``_run_async`` loop advances.
+        """
 
 
 class MockWakeDetector(WakeDetector):
     """Test double.
 
-    ``feed_audio`` always returns False; ``detect_in_text`` is a simple
-    substring check so tests can simulate "heard the phrase".
+    ``feed_audio`` returns False and leaves :attr:`event` unset by default.
+    Pass ``trigger_on_feed=True`` to flip the event (and return True) on
+    every ``feed_audio`` call — useful for exercising the event-driven
+    loop in unit tests without touching ONNX or hardware.
+
+    ``detect_in_text`` is a simple substring check so tests can simulate
+    "heard the phrase".
     """
 
-    def __init__(self, trigger_on: str = "hey ducky") -> None:
+    def __init__(
+        self,
+        trigger_on: str = "hey ducky",
+        *,
+        trigger_on_feed: bool = False,
+    ) -> None:
+        super().__init__()
         self._trigger = trigger_on.lower()
+        self._trigger_on_feed = trigger_on_feed
 
     def feed_audio(self, audio_chunk: npt.NDArray[np.int16]) -> bool:
         del audio_chunk  # mock doesn't analyse audio
+        if self._trigger_on_feed:
+            self.event.set()
+            return True
         return False
 
     def detect_in_text(self, text: str) -> bool:

--- a/app/src/reachy_ducky_app/wake.py
+++ b/app/src/reachy_ducky_app/wake.py
@@ -24,6 +24,11 @@ class WakeDetector(ABC):
     (or the future ONNX inference path) sets on a detected wake.
     ``ReachyDuckyApp._run_async`` awaits this event via ``asyncio.wait``
     so the wake loop never busy-polls.
+
+    Constructing a ``WakeDetector`` outside an event loop is safe:
+    Python 3.10+ ``asyncio.Event()`` is loop-agnostic until ``wait()``
+    is called, so ``load_default_wake_detector()`` can run at import or
+    unit-test setup time without an active loop.
     """
 
     def __init__(self) -> None:
@@ -45,6 +50,12 @@ class MockWakeDetector(WakeDetector):
     Pass ``trigger_on_feed=True`` to flip the event (and return True) on
     every ``feed_audio`` call — useful for exercising the event-driven
     loop in unit tests without touching ONNX or hardware.
+
+    **Do NOT use ``trigger_on_feed=True`` in production wiring.**
+    ``_run_async`` calls ``wake.event.clear()`` after each turn, so a
+    continuously-fed detector would re-set the event on every audio
+    frame and starve the rest of the loop (every ``asyncio.wait`` would
+    immediately select the wake branch). It's strictly a test hook.
 
     ``detect_in_text`` is a simple substring check so tests can simulate
     "heard the phrase".

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from reachy_ducky_app.main import ReachyDuckyApp, main
 from reachy_ducky_app.voice.audio_io import MicSource, MockMicSource, MockSpeakerSink, SpeakerSink
+from reachy_ducky_app.wake import MockWakeDetector
 
 
 def test_reachy_ducky_app_imports_cleanly() -> None:
@@ -54,45 +55,96 @@ async def test_run_async_exits_immediately_when_stop_event_set(
     assert run_one_turn_calls == []
 
 
-async def test_run_async_calls_run_one_turn_when_wake_triggers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Wake trigger True on first tick => exactly one ``run_one_turn`` call."""
+async def test_wake_event_drives_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_run_async`` awaits the wake Event — setting it triggers exactly one turn.
+
+    The event-driven contract: the loop blocks on ``wake.event.wait()`` via
+    ``asyncio.wait(FIRST_COMPLETED)``. Firing the event once must drive
+    exactly one ``run_one_turn``, not be busy-polled.
+    """
     monkeypatch.setenv("OPENAI_API_KEY", "test")
 
     run_one_turn_calls: list[dict[str, object]] = []
+    stop = threading.Event()
+
+    injected_wake = MockWakeDetector()
 
     async def _spy_run_one_turn(**kwargs: object) -> None:
         run_one_turn_calls.append(kwargs)
+        # One turn is enough; set stop so the loop exits on the next cycle.
+        stop.set()
 
     monkeypatch.setattr("reachy_ducky_app.main.run_one_turn", _spy_run_one_turn)
-
-    stop = threading.Event()
-
-    class _OneShotApp(ReachyDuckyApp):
-        """Trigger wake exactly once, then stop the loop on the next tick."""
-
-        def __init__(self) -> None:
-            self._calls = 0
-
-        def _wake_triggered(self) -> bool:
-            self._calls += 1
-            if self._calls == 1:
-                return True
-            stop.set()
-            return False
-
-    app = _OneShotApp()
-    await asyncio.wait_for(
-        app._run_async(reachy_mini=object(), stop_event=stop),
-        timeout=1.0,
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.load_default_wake_detector",
+        lambda: injected_wake,
     )
+
+    async def _fire_wake_soon() -> None:
+        # Let _run_async reach its asyncio.wait; then set the event.
+        await asyncio.sleep(0)
+        injected_wake.event.set()
+
+    app = ReachyDuckyApp()
+
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(_fire_wake_soon())
+        tg.create_task(
+            asyncio.wait_for(
+                app._run_async(reachy_mini=object(), stop_event=stop),
+                timeout=1.0,
+            )
+        )
 
     assert len(run_one_turn_calls) == 1
     assert "voice" in run_one_turn_calls[0]
     assert "sm" in run_one_turn_calls[0]
     assert "daemon" in run_one_turn_calls[0]
     assert run_one_turn_calls[0]["project_slug"] is None
+
+
+async def test_wake_loop_exits_cleanly_without_firing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stop event causes clean exit when the wake event never fires.
+
+    Verifies the stop-bridge wins when ``wake.event`` stays unset: zero
+    turns run, and ``_run_async`` returns promptly after ``stop_event.set()``.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    run_one_turn_calls: list[object] = []
+
+    async def _spy_run_one_turn(**kwargs: object) -> None:
+        run_one_turn_calls.append(kwargs)
+
+    injected_wake = MockWakeDetector()
+
+    monkeypatch.setattr("reachy_ducky_app.main.run_one_turn", _spy_run_one_turn)
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.load_default_wake_detector",
+        lambda: injected_wake,
+    )
+
+    stop = threading.Event()
+
+    async def _stop_soon() -> None:
+        await asyncio.sleep(0.15)  # > the 0.1s stop-bridge tick
+        stop.set()
+
+    app = ReachyDuckyApp()
+
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(_stop_soon())
+        tg.create_task(
+            asyncio.wait_for(
+                app._run_async(reachy_mini=object(), stop_event=stop),
+                timeout=1.0,
+            )
+        )
+
+    assert run_one_turn_calls == []
+    assert not injected_wake.event.is_set()
 
 
 def test_main_exits_with_stopped_event(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -142,9 +194,8 @@ async def test_run_async_constructs_voice_with_default_mic_and_speaker(
 
     Guards the commit-3 wiring: ``_run_async`` must call
     :func:`load_default_mic_source` and :func:`load_default_speaker_sink`
-    (the same pattern as ``load_default_wake_detector``) rather than
-    hard-coding Mock impls directly. When the hardware-backed factory
-    bodies land, ``main.py`` should require zero changes.
+    rather than hard-coding Mock impls directly. When the hardware-backed
+    factory bodies land, ``main.py`` should require zero changes.
     """
     monkeypatch.setenv("OPENAI_API_KEY", "test")
 
@@ -189,7 +240,9 @@ async def test_run_async_closes_daemon_client_even_when_turn_raises(
     """If ``run_one_turn`` raises, ``daemon.aclose()`` must still be awaited.
 
     Guards that the ``try/finally`` wraps the whole wake loop, so the
-    pool is drained on crash as well as clean shutdown.
+    pool is drained on crash as well as clean shutdown. Drives the loop
+    via a pre-set ``wake.event`` so the first ``asyncio.wait`` immediately
+    selects the wake branch.
     """
     monkeypatch.setenv("OPENAI_API_KEY", "test")
 
@@ -208,15 +261,15 @@ async def test_run_async_closes_daemon_client_even_when_turn_raises(
 
     monkeypatch.setattr("reachy_ducky_app.main.run_one_turn", _blowing_up)
 
+    injected_wake = MockWakeDetector()
+    injected_wake.event.set()
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.load_default_wake_detector",
+        lambda: injected_wake,
+    )
+
     stop = threading.Event()
-
-    class _OneShotApp(ReachyDuckyApp):
-        """Wake triggers once to drive the loop into ``run_one_turn``."""
-
-        def _wake_triggered(self) -> bool:
-            return True
-
-    app = _OneShotApp()
+    app = ReachyDuckyApp()
 
     with pytest.raises(_BoomError):
         await asyncio.wait_for(

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -15,7 +15,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from reachy_ducky_app.main import ReachyDuckyApp, main
 from reachy_ducky_app.voice.audio_io import MicSource, MockMicSource, MockSpeakerSink, SpeakerSink
-from reachy_ducky_app.wake import MockWakeDetector, WakeDetector
 
 
 def test_reachy_ducky_app_imports_cleanly() -> None:
@@ -27,7 +26,7 @@ def test_reachy_ducky_app_imports_cleanly() -> None:
 def test_wake_triggered_placeholder_returns_false() -> None:
     """Baseline lock: the Phase A ``_wake_triggered`` stub always returns False."""
     app = ReachyDuckyApp()
-    assert app._wake_triggered(MockWakeDetector()) is False
+    assert app._wake_triggered() is False
 
 
 async def test_run_async_exits_immediately_when_stop_event_set(
@@ -76,8 +75,7 @@ async def test_run_async_calls_run_one_turn_when_wake_triggers(
         def __init__(self) -> None:
             self._calls = 0
 
-        def _wake_triggered(self, wake: WakeDetector) -> bool:
-            del wake
+        def _wake_triggered(self) -> bool:
             self._calls += 1
             if self._calls == 1:
                 return True
@@ -215,8 +213,7 @@ async def test_run_async_closes_daemon_client_even_when_turn_raises(
     class _OneShotApp(ReachyDuckyApp):
         """Wake triggers once to drive the loop into ``run_one_turn``."""
 
-        def _wake_triggered(self, wake: WakeDetector) -> bool:
-            del wake
+        def _wake_triggered(self) -> bool:
             return True
 
     app = _OneShotApp()

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -103,6 +103,46 @@ async def test_wake_event_drives_turn(monkeypatch: pytest.MonkeyPatch) -> None:
     assert run_one_turn_calls[0]["project_slug"] is None
 
 
+async def test_stop_wins_when_wake_and_stop_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When wake.event and stop_event both fire before the loop re-checks,
+    stop wins and no additional turn runs.
+
+    Pins the precedence so a future refactor doesn't accidentally let a
+    race cause a turn to fire during shutdown. Pre-setting both events
+    before ``_run_async`` starts is the cleanest way to exercise the
+    decision point: the outer ``while not stop_event.is_set()`` guard
+    must short-circuit regardless of the wake event's state.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    run_one_turn_calls: list[object] = []
+
+    async def _spy_run_one_turn(**kwargs: object) -> None:
+        run_one_turn_calls.append(kwargs)
+
+    injected_wake = MockWakeDetector()
+    injected_wake.event.set()
+
+    monkeypatch.setattr("reachy_ducky_app.main.run_one_turn", _spy_run_one_turn)
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.load_default_wake_detector",
+        lambda: injected_wake,
+    )
+
+    app = ReachyDuckyApp()
+    stop = threading.Event()
+    stop.set()
+
+    await asyncio.wait_for(
+        app._run_async(reachy_mini=object(), stop_event=stop),
+        timeout=0.5,
+    )
+
+    assert run_one_turn_calls == []
+
+
 async def test_wake_loop_exits_cleanly_without_firing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -129,7 +169,7 @@ async def test_wake_loop_exits_cleanly_without_firing(
     stop = threading.Event()
 
     async def _stop_soon() -> None:
-        await asyncio.sleep(0.15)  # > the 0.1s stop-bridge tick
+        await asyncio.sleep(0.3)  # 3x the 0.1s stop-bridge tick; margin for loaded CI
         stop.set()
 
     app = ReachyDuckyApp()

--- a/app/tests/test_wake.py
+++ b/app/tests/test_wake.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import numpy as np
 import pytest
 from reachy_ducky_app.wake import (
@@ -21,6 +23,28 @@ def test_mock_detector_feed_audio_returns_false_for_any_chunk() -> None:
     """MockWakeDetector.feed_audio ignores audio and returns False by design."""
     det = MockWakeDetector()
     assert det.feed_audio(np.zeros(16, dtype=np.int16)) is False
+
+
+def test_wake_detector_event_is_asyncio_event() -> None:
+    """WakeDetector.event is a real asyncio.Event — not an mp or threading analog."""
+    detector = MockWakeDetector()
+    assert isinstance(detector.event, asyncio.Event)
+    assert not detector.event.is_set()
+
+
+def test_mock_wake_detector_trigger_on_feed_sets_event() -> None:
+    """Mock with trigger_on_feed=True sets the event the first time feed_audio is called."""
+    detector = MockWakeDetector(trigger_on_feed=True)
+    assert not detector.event.is_set()
+    detector.feed_audio(np.zeros(16, dtype=np.int16))
+    assert detector.event.is_set()
+
+
+def test_mock_wake_detector_default_does_not_set_event() -> None:
+    """Default MockWakeDetector preserves today's silent-mock semantics."""
+    detector = MockWakeDetector()
+    detector.feed_audio(np.zeros(16, dtype=np.int16))
+    assert not detector.event.is_set()
 
 
 def test_mock_detector_detect_in_text_triggers_on_keyword() -> None:

--- a/docs/reachy-mini-sim-audio.md
+++ b/docs/reachy-mini-sim-audio.md
@@ -1,0 +1,43 @@
+# Reachy Mini sim audio — upstream tracking
+
+**Last verified:** 2026-04-23
+
+## Status today
+
+Pollen's Reachy Mini simulator covers motion (MuJoCo physics, full
+6-DOF head + antennas + body-yaw) but **does not** provide audio
+input/output. Mic/speaker code running in sim will hit the laptop's
+system devices (or fail, depending on the backend).
+
+The daemon media architecture (see `reachy-mini-daemon --help`) lists
+audio backends: `PulseAudio`, `ALSA`, `WASAPI`, `CoreAudio`. No `sim`
+variant.
+
+## Consequence for Reachy Ducky
+
+`ReachyMicSource` / `ReachySpeakerSink` (see
+`app/src/reachy_ducky_app/voice/audio_io.py`, closed via #23) are
+**hardware-only** — the `load_default_*` factories return the mock
+impls when not on a real robot. Sim can drive the motion/lifecycle
+side of the app but not the voice side.
+
+## Upstream issues to watch
+
+- **[pollen-robotics/reachy_mini#330](https://github.com/pollen-robotics/reachy_mini/issues/330)** — webcam-fallback in sim. Adjacent pattern; no audio equivalent yet.
+- **No audio-specific sim issue exists today.** If you hit this need
+  again, consider filing one.
+
+## Action for Reachy Ducky maintainers
+
+Subscribe to new issues tagged `sim` in `pollen-robotics/reachy_mini`
+and scan for audio keywords quarterly. When Pollen lands sim audio
+loopback:
+
+1. Revisit the factory logic in
+   `app/src/reachy_ducky_app/voice/audio_io.py`. Today it returns mocks
+   when not on real hardware — a sim-audio-capable runtime would be a
+   third branch.
+2. Add an `@pytest.mark.sim` test exercising a mic→speaker loopback
+   through the sim.
+3. Close this doc's "track" status; either move the findings into the
+   main design doc or delete the doc.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,5 @@
 {
+  "pythonPath": ".venv/bin/python",
   "venvPath": ".",
   "venv": ".venv",
   "pythonVersion": "3.12",


### PR DESCRIPTION
## Summary

Executes milestones M1–M3 of the v0.1.0 testing-prerequisites plan (merged in #53). Unblocks local sim-dev ergonomics, replaces a 20Hz wake busy-spin with an event-driven loop, and deduplicates HF Space metadata.

## Milestone map

| Milestone | Commit | Issue |
|---|---|---|
| **M1** Sim dev Makefile | `1664ad1` | #25 |
| **M1** Sim audio tracking doc | `bb75c38` | #27 |
| **M2** Drop unused wake param | `25f35dc` | #17 |
| **M2** Event-driven wake loop | `db1502d` | #15 |
| **M2** Review polish (race test + docstrings) | `76264bc` | — |
| **M3** HF Space metadata dedup | `d9d7816` | #16 |
| — | `3c2a110` | pyright LSP fix (discovered mid-session) |
| — | `ba402ea` | HF chrome restoration (Option B decision) |

## Notable design decisions

- **Event-driven loop architecture:** `asyncio.wait(FIRST_COMPLETED)` on `wake.event.wait()` + a tiny `_watch_stop` coroutine that polls `threading.Event.is_set()` at 10 Hz. That 10Hz sleep is the *only* remaining sleep — it's explicitly documented as the shutdown-bridge (threading.Event has no async `wait`), not a wake-poll. Alternatives considered: `asyncio.to_thread(stop_event.wait)` (ties up an executor thread) and `janus.Queue` (new dep for a private bridge). YAGNI on both; `_STOP_BRIDGE_POLL_SECONDS` is one rename away from being tunable if ever needed.
- **HF Space metadata split (Option B):** shared fields (`title`, `emoji`, `python_version`, `app_class`, `description`) live in `reachy_mini_app.yaml` only. HF-listing chrome (`colorFrom`, `colorTo`, `sdk: static`, `pinned`, `short_description`, `tags`) lives in README frontmatter only. Zero drift surface — a field can't drift against itself when it lives in only one place. First attempt dropped ALL README frontmatter (`d9d7816`); `ba402ea` restored the HF-only fields after surfacing that dropping `sdk: static` could break the HF Space entirely and losing `tags` weakens discoverability (design doc §14: HF Spaces *is* the distribution path).
- **Pyright LSP config:** Claude Code's in-editor pyright runs one-file-at-a-time in watch mode and was flagging cross-workspace + relative imports as `reportMissingImports` despite CLI `uv run pyright` being 0/0/0 clean. Added `"pythonPath": ".venv/bin/python"` to `pyrightconfig.json` to point the LSP at the same interpreter CLI pyright uses, so it picks up the editable `.pth` entries. Known upstream limitation: [anthropics/claude-code#32230](https://github.com/anthropics/claude-code/issues/32230).
- **Task 2.1 scope creep** (flagged in code review): removing `wake = load_default_wake_detector()` + the two imports in Task 2.1 was forced by ruff F841/F401 after the param drop. Task 2.2 re-adds them as part of the event-driven wiring. Reviewer flagged the process gap — would have been better to `# noqa` + escalate than silently pick — but practical impact was a 3-line re-add in the next task.
- **`feed_audio` signature kept** as `npt.NDArray[np.int16] -> bool` rather than the plan's illustrative `bytes -> None`. Plan snippet was explicitly marked non-binding; real ONNX wake detectors want numpy frames.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 75 files already formatted
- [x] `uv run mypy --strict` across daemon/app/menubar/protocol (src + tests) — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run bandit -ll -r` — 0 issues
- [x] `uv run pytest -q` — **587 passed, 5 skipped, 4 deselected**
- [x] `make -n sim-daemon` / `make -n sim-stop` — dry-run output is sensible shell
- [x] `yaml.safe_load(app/reachy_mini_app.yaml)` — parses with expected 5 shared keys
- [ ] Augment review addressed before merge
- [ ] Codex review addressed before merge

## Deferred / out of scope

- **M4** — hardware `ReachyMicSource` / `ReachySpeakerSink` (#23). Needs physical Reachy access.
- **M5** — `MuteGate` state-machine binding (#20). Depends on M4 on main.
- **Vestigial `_wake_triggered`** — the test-override seam is no longer called by the production loop; code reviewer suggested removing it in a follow-up. Leaving in place for now since Task 2.1 explicitly kept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)