### PR TITLE
refactor(specialists): PlanReviewer polish sweep (closes #2, #3, #4, #5, #8)

### DIFF
--- a/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
+++ b/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
@@ -28,7 +28,7 @@ anywhere readable. Closing over the resolved root inside the tool factory
 makes that forgery impossible — the parameter simply does not exist on the
 tool's input schema.
 
-Single source of truth. Both layers call :func:`_discover` — ``_list_plans``
+Single source of truth. Both layers call :func:`_discover` — ``list_plans``
 returns its output as relative POSIX strings, and ``_read_plan`` validates by
 checking membership in the same set. This collapses what used to be two
 matchers (``Path.glob`` for discovery, ``PurePath.match`` for validation) into
@@ -36,11 +36,11 @@ one, which matters because those two engines are NOT parity-equivalent:
 
 * ``PurePath.match("docs/plans/**/*.md")`` rejects ``docs/plans/a/b/c/d.md``
   that ``Path.glob("docs/plans/**/*.md")`` finds — under-approximation, making
-  ``_read_plan`` deny paths ``_list_plans`` advertised.
+  ``_read_plan`` deny paths ``list_plans`` advertised.
 * ``PurePath.match("AGENTS.md")`` is a **tail match** (no leading anchor), so
   ``nested/AGENTS.md`` matches even though ``base.glob("AGENTS.md")`` only
   matches at the root — over-approximation, making attacker-droppable files
-  readable even though ``_list_plans`` wouldn't advertise them. That was the
+  readable even though ``list_plans`` wouldn't advertise them. That was the
   security widening we are eliminating here.
 
 One ``_discover`` call per ``_read_plan`` is slightly more expensive than a
@@ -77,13 +77,14 @@ from claude_agent_sdk import SdkMcpTool, create_sdk_mcp_server, tool
 from claude_agent_sdk.types import McpSdkServerConfig
 
 __all__ = [
+    "list_plans",
     "plans_mcp_server",
 ]
 
 # Conventional plan/spec locations. This set is the read surface of
 # ``read_plan``; widening it widens what the brain can read via this server.
 #
-# ``Path.glob`` is the canonical matcher: both ``_list_plans`` (discovery) and
+# ``Path.glob`` is the canonical matcher: both ``list_plans`` (discovery) and
 # ``_read_plan`` (validation) resolve paths through :func:`_discover`, which
 # uses this pattern list. ``fnmatch`` / ``PurePath.match`` are deliberately NOT
 # used: the former has no recursive ``**`` operator and the latter is a tail
@@ -103,7 +104,7 @@ def _discover(base: Path) -> set[Path]:
     """Return the absolute paths of every file under ``base`` matched by any
     conventional pattern.
 
-    The single source of truth for both :func:`_list_plans` (discovery) and
+    The single source of truth for both :func:`list_plans` (discovery) and
     :func:`_read_plan` (validation). ``Path.glob`` handles ``**`` correctly
     (including the zero-intermediate-dir case) and anchors each pattern to
     ``base`` — i.e. ``base.glob("AGENTS.md")`` matches only ``base/AGENTS.md``,
@@ -120,7 +121,7 @@ def _discover(base: Path) -> set[Path]:
     return results
 
 
-def _list_plans(project_root: Path) -> list[str]:
+def list_plans(project_root: Path) -> list[str]:
     """Return sorted, deduplicated project-relative paths to conventional plans.
 
     Pure helper, testable without the SDK. ``set``-based dedup handles the
@@ -158,7 +159,7 @@ def _read_plan(project_root: Path, rel_path: str) -> str:
         raise PermissionError(f"path escapes project root: {rel_path}") from exc
 
     if target not in _discover(base):
-        # Single source of truth: the target must be something _list_plans
+        # Single source of truth: the target must be something list_plans
         # would advertise. ``_discover`` only returns files that exist, so a
         # missing file here falls into this branch rather than a separate
         # FileNotFoundError check.
@@ -194,14 +195,14 @@ def _make_plans_tools(project_root: Path) -> tuple[SdkMcpTool[Any], SdkMcpTool[A
         {},
     )
     async def find_plans(_args: dict[str, Any]) -> dict[str, Any]:
-        """MCP ``find_plans`` wrapper: format :func:`_list_plans` as a text block.
+        """MCP ``find_plans`` wrapper: format :func:`list_plans` as a text block.
 
         Catches ``OSError`` (filesystem errors during ``resolve()`` / ``glob``)
         and ``ValueError`` (null bytes, etc.) so the handler never raises — the
         SDK dispatcher can rely on a well-formed response.
         """
         try:
-            paths = _list_plans(resolved_root)
+            paths = list_plans(resolved_root)
         except (OSError, ValueError) as exc:
             return {
                 "content": [{"type": "text", "text": f"error: failed to list plans: {exc}"}],

--- a/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
+++ b/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
@@ -110,14 +110,29 @@ def _discover(base: Path) -> set[Path]:
     ``base`` — i.e. ``base.glob("AGENTS.md")`` matches only ``base/AGENTS.md``,
     not ``base/nested/AGENTS.md``. That anchoring is what makes the read
     surface exactly as wide as the discover surface.
+
+    Symlink-escape filter: a hit whose ``.resolve()`` lands outside ``base`` is
+    silently dropped. The plans MCP tool surface — :func:`list_plans`
+    (discovery) and :func:`_read_plan` (read with membership check) — both
+    read from this set, so neither can return or accept an escape-resolving
+    path. Closed via #8.
     """
     results: set[Path] = set()
     for pattern in _CONVENTIONAL_PATTERNS:
         for hit in base.glob(pattern):
-            if hit.is_file():
-                # Resolve so symlink-based dedup and membership tests agree
-                # with the resolved ``target`` computed in ``_read_plan``.
-                results.add(hit.resolve())
+            if not hit.is_file():
+                continue
+            resolved = hit.resolve()
+            # Reject symlinks whose resolved target escapes ``base``.
+            # ``is_relative_to`` (Python 3.9+) is the non-raising form
+            # of the same check ``_read_plan`` uses. Filtering here
+            # means both ``list_plans`` (discovery) and ``_read_plan``
+            # (membership check) inherit the property for free — no
+            # escaping path can be advertised, read, or leaked via
+            # diagnostic. (#8)
+            if not resolved.is_relative_to(base):
+                continue
+            results.add(resolved)
     return results
 
 

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -136,34 +136,37 @@ def _capture_diff(repo: Path, branch: str) -> tuple[str, str | None]:
     return fallback.stdout, fallback_err
 
 
-def _collect_plans(repo: Path) -> list[tuple[str, str]]:
-    """Return ``[(relative_path, contents)]`` for every plan file under ``repo``.
+def _collect_plans(
+    repo: Path,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return ``(readable, unreadable)``.
 
-    Files whose ``read_text`` raises (non-UTF-8, vanished between the
-    ``list_plans`` walk and the read, permission denied, etc.) are
-    skipped silently — the assembled prompt already includes the file's
-    path via neighbouring plan files or via the missing-plans
-    diagnostic, and bubbling the error up would defeat the "no
-    exceptions escape to callers" design constraint.
+    ``readable`` is ``[(rel, content)]`` for every plan that loaded
+    cleanly. ``unreadable`` is ``[(rel, error_string)]`` for every plan
+    ``list_plans`` advertised but ``read_text`` rejected (non-UTF-8,
+    permission-denied, vanished mid-walk, etc.). Both lists are sorted
+    by ``rel``; either may be empty. Mirrors the error-surface pattern
+    used by ``_current_branch`` and ``_capture_diff`` — the diagnostic
+    surfaces to the brain via the ``=== UNREADABLE PLANS ===`` prompt
+    section in ``_assemble_prompt`` rather than being silently swallowed.
     """
-    # TODO(#5): instead of silently skipping, accumulate (rel, error_string)
-    # entries and surface them under an "=== UNREADABLE PLANS ===" prompt
-    # header. Current silent skip is asymmetric with `_capture_diff` and
-    # `_current_branch` (both surface errors as diagnostics).
-    out: list[tuple[str, str]] = []
+    readable: list[tuple[str, str]] = []
+    unreadable: list[tuple[str, str]] = []
     for rel in list_plans(repo):
         try:
             content = (repo / rel).read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        except (OSError, UnicodeDecodeError) as exc:
+            unreadable.append((rel, f"{type(exc).__name__}: {exc}"))
             continue
-        out.append((rel, content))
-    return out
+        readable.append((rel, content))
+    return readable, unreadable
 
 
 def _assemble_prompt(
     branch: str,
     branch_error: str | None,
     plans: list[tuple[str, str]],
+    unreadable_plans: list[tuple[str, str]],
     diff: str,
     diff_error: str | None,
 ) -> str:
@@ -173,6 +176,12 @@ def _assemble_prompt(
     and uppercase labels) so the brain's attention has fixed landmarks
     between the plan block and the diff block. The directive goes last
     so it sits closest to where the model starts generating.
+
+    When ``unreadable_plans`` is non-empty, a dedicated
+    ``=== UNREADABLE PLANS ===`` section sits between ``=== PLANS ===``
+    and ``=== DIFF ===`` so the brain can tell "file listed but
+    unreadable" from "file never existed". The section is omitted when
+    every plan loads cleanly to avoid cluttering the common case.
 
     TODO(#2): add per-file and total byte caps with a truncation marker.
     Repos with many large plans risk silent context-window overflow at
@@ -198,6 +207,18 @@ def _assemble_prompt(
             parts.append(content.rstrip("\n"))
             parts.append("")
     parts.append("")
+
+    if unreadable_plans:
+        parts.append("=== UNREADABLE PLANS ===")
+        parts.append(
+            "(These files were discovered under conventional locations but "
+            "could not be read. Listed here so you can note them in the "
+            "review — they do not participate in drift analysis.)",
+        )
+        for rel, err in unreadable_plans:
+            parts.append(f"--- {rel} ---")
+            parts.append(f"(diagnostic: {err})")
+        parts.append("")
 
     parts.append("=== DIFF ===")
     if diff_error is not None:
@@ -235,13 +256,14 @@ class PlanReviewer:
         secret leaks.
         """
         branch, branch_error = _current_branch(self._repo)
-        plans = _collect_plans(self._repo)
+        plans, unreadable_plans = _collect_plans(self._repo)
         diff, diff_error = _capture_diff(self._repo, branch)
 
         prompt = _assemble_prompt(
             branch=branch,
             branch_error=branch_error,
             plans=plans,
+            unreadable_plans=unreadable_plans,
             diff=diff,
             diff_error=diff_error,
         )

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -106,10 +106,6 @@ def _capture_diff(repo: Path, branch: str) -> tuple[str, str | None]:
     Both paths are ``check=False``; a git failure becomes a diagnostic
     string in the returned ``error`` rather than a raised exception.
     """
-    # TODO(#3): add test coverage for the merge-base-failure fallback branch
-    # below (feature branch + `main` ref absent). Also prepend a "using
-    # working-tree-vs-HEAD fallback" banner to the returned diff text when
-    # this path engages so the brain can distinguish fallback from primary.
     if branch != "main":
         try:
             proc = _run_git(["diff", "main...HEAD"], cwd=repo)
@@ -133,6 +129,16 @@ def _capture_diff(repo: Path, branch: str) -> tuple[str, str | None]:
         if fallback_err is not None:
             return "", f"{fallback_err}; git diff (fallback) failed: {combined}"
         return "", f"git diff failed: {combined}"
+    # Prepend a banner when we actually fell back from a merge-base diff
+    # (i.e., not the on-main path where fallback_err is None because there
+    # was no merge-base attempt in the first place). Lets the brain tell
+    # 'working-tree diff because on main' from 'working-tree diff because
+    # main ref is absent / merge-base failed'.
+    if fallback_err is not None and fallback.stdout:
+        banner = (
+            "(fallback: using working-tree-vs-HEAD diff; merge-base against main was unavailable)\n"
+        )
+        return banner + fallback.stdout, fallback_err
     return fallback.stdout, fallback_err
 
 

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -136,8 +136,22 @@ def _capture_diff(repo: Path, branch: str) -> tuple[str, str | None]:
     return fallback.stdout, fallback_err
 
 
+def _truncate_plan_body(body: str, max_chars: int) -> str:
+    """Truncate ``body`` to ``max_chars`` with an inline marker if cut.
+
+    Returns ``body`` unchanged when it fits; otherwise returns
+    ``body[:max_chars] + "\\n[... truncated: N chars elided ...]\\n"``
+    where N is the dropped char count.
+    """
+    if len(body) <= max_chars:
+        return body
+    elided = len(body) - max_chars
+    return body[:max_chars] + f"\n[... truncated: {elided} chars elided ...]\n"
+
+
 def _collect_plans(
     repo: Path,
+    max_chars_per_plan: int,
 ) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
     """Return ``(readable, unreadable)``.
 
@@ -149,6 +163,11 @@ def _collect_plans(
     used by ``_current_branch`` and ``_capture_diff`` — the diagnostic
     surfaces to the brain via the ``=== UNREADABLE PLANS ===`` prompt
     section in ``_assemble_prompt`` rather than being silently swallowed.
+
+    ``max_chars_per_plan`` caps each individual readable body via
+    :func:`_truncate_plan_body`; oversize bodies are cut with a visible
+    inline marker so the brain knows truncation occurred. The cap is
+    applied after the successful read, before appending to ``readable``.
     """
     readable: list[tuple[str, str]] = []
     unreadable: list[tuple[str, str]] = []
@@ -168,8 +187,52 @@ def _collect_plans(
             # UnicodeDecodeError.__str__ doesn't embed a path; safe as-is.
             unreadable.append((rel, f"UnicodeDecodeError: {exc}"))
             continue
-        readable.append((rel, content))
+        readable.append((rel, _truncate_plan_body(content, max_chars_per_plan)))
     return readable, unreadable
+
+
+def _assemble_plans_block(
+    plans: list[tuple[str, str]],
+    max_total_chars: int,
+) -> list[str]:
+    """Build the ``=== PLANS ===`` section under a total-char budget.
+
+    Concatenates plan bodies in order; once the cumulative body length
+    would exceed ``max_total_chars`` (after at least one plan has
+    landed), appends a single ``[... N plan(s) omitted ...]`` marker
+    and stops. The ``(no plans)`` branch is unchanged.
+
+    The "at least one plan included" guard means a single oversized
+    plan (longer than the total budget) still lands — so the brain
+    always gets at least one plan when any exist. Per-file truncation
+    in :func:`_collect_plans` bounds the damage in that edge case.
+    """
+    parts: list[str] = ["=== PLANS ==="]
+    if not plans:
+        parts.append(
+            "(no plan or spec files discovered under conventional locations — "
+            "docs/plans/**/*.md, specs/**/*.md, root AGENTS.md/CLAUDE.md/SPEC.md, "
+            "*.plan.md)",
+        )
+        return parts
+
+    used = 0
+    included = 0
+    for rel, body in plans:
+        block = f"--- {rel} ---\n{body.rstrip(chr(10))}\n"
+        if used + len(block) > max_total_chars and included > 0:
+            remaining = len(plans) - included
+            parts.append(
+                f"[... {remaining} plan(s) omitted: total body "
+                f"budget of {max_total_chars} chars exhausted ...]",
+            )
+            break
+        parts.append(f"--- {rel} ---")
+        parts.append(body.rstrip("\n"))
+        parts.append("")
+        used += len(block)
+        included += 1
+    return parts
 
 
 def _assemble_prompt(
@@ -179,6 +242,8 @@ def _assemble_prompt(
     unreadable_plans: list[tuple[str, str]],
     diff: str,
     diff_error: str | None,
+    *,
+    max_total_chars: int,
 ) -> str:
     """Build the final single-string prompt the brain receives.
 
@@ -193,10 +258,12 @@ def _assemble_prompt(
     unreadable" from "file never existed". The section is omitted when
     every plan loads cleanly to avoid cluttering the common case.
 
-    TODO(#2): add per-file and total byte caps with a truncation marker.
-    Repos with many large plans risk silent context-window overflow at
-    the SDK layer; a marked in-prompt truncation is better than opaque
-    SDK-level cutoff.
+    ``max_total_chars`` caps the cumulative body length across all
+    plans; once exhausted, remaining plans are replaced by a single
+    ``[... N plan(s) omitted ...]`` marker (see
+    :func:`_assemble_plans_block`). Visible in-prompt truncation is
+    better than silent SDK-layer cutoff when Claude's context window
+    would be blown by the concatenated plan bodies.
     """
     parts: list[str] = []
     parts.append(f"Branch: {branch}")
@@ -204,18 +271,7 @@ def _assemble_prompt(
         parts.append(f"(diagnostic: {branch_error})")
     parts.append("")
 
-    parts.append("=== PLANS ===")
-    if not plans:
-        parts.append(
-            "(no plan or spec files discovered under conventional locations — "
-            "docs/plans/**/*.md, specs/**/*.md, root AGENTS.md/CLAUDE.md/SPEC.md, "
-            "*.plan.md)",
-        )
-    else:
-        for rel, content in plans:
-            parts.append(f"--- {rel} ---")
-            parts.append(content.rstrip("\n"))
-            parts.append("")
+    parts.extend(_assemble_plans_block(plans, max_total_chars))
     parts.append("")
 
     if unreadable_plans:
@@ -247,15 +303,41 @@ def _assemble_prompt(
 class PlanReviewer:
     """Hybrid specialist: pre-load plans + diff, then query the brain."""
 
-    def __init__(self, brain: BrainInterface, repo: Path) -> None:
+    def __init__(
+        self,
+        brain: BrainInterface,
+        repo: Path,
+        *,
+        max_plan_chars: int = 50_000,
+        max_total_plan_chars: int = 200_000,
+    ) -> None:
         """Bind the specialist to a brain and a repo root.
 
         ``repo`` is expected to be a checked-out git working tree. The
         specialist treats it as a read-only boundary — no command
         issued from here can mutate its state.
+
+        ``max_plan_chars`` (default 50,000) caps each individual plan's
+        body length in the assembled prompt. Bodies over the cap are
+        truncated with an inline ``[... truncated: N chars elided ...]``
+        marker. Calibrated to typical plan sizes in this repo (the
+        Phase A plan is ~3,000 lines / ~140KB); raise via constructor
+        for a repo with much larger plans.
+
+        ``max_total_plan_chars`` (default 200,000) caps the cumulative
+        body length across all plans. Once the budget is exhausted,
+        the remaining plans are replaced by a single
+        ``[... N plan(s) omitted ...]`` marker. Calibrated against
+        Claude's 200k-token context — chars × ~4-bytes-per-token leaves
+        headroom for the diff, the brain's response, and other sections.
+
+        Both caps are keyword-only so a future signature evolution can
+        add positional kwargs without ambiguity. (#2)
         """
         self._brain = brain
         self._repo = repo
+        self._max_plan_chars = max_plan_chars
+        self._max_total_plan_chars = max_total_plan_chars
 
     async def review(self) -> SpecialistResponse:
         """Assemble the review prompt, redact secrets, dispatch to the brain.
@@ -266,7 +348,10 @@ class PlanReviewer:
         secret leaks.
         """
         branch, branch_error = _current_branch(self._repo)
-        plans, unreadable_plans = _collect_plans(self._repo)
+        plans, unreadable_plans = _collect_plans(
+            self._repo,
+            max_chars_per_plan=self._max_plan_chars,
+        )
         diff, diff_error = _capture_diff(self._repo, branch)
 
         prompt = _assemble_prompt(
@@ -276,6 +361,7 @@ class PlanReviewer:
             unreadable_plans=unreadable_plans,
             diff=diff,
             diff_error=diff_error,
+            max_total_chars=self._max_total_plan_chars,
         )
 
         try:

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -105,6 +105,14 @@ def _capture_diff(repo: Path, branch: str) -> tuple[str, str | None]:
 
     Both paths are ``check=False``; a git failure becomes a diagnostic
     string in the returned ``error`` rather than a raised exception.
+
+    When the merge-base diff fails and the working-tree fallback
+    produces output, the returned ``diff_text`` is prefixed with a
+    one-line ``(fallback: ...)`` banner so the brain can distinguish a
+    deliberate on-main working-tree diff from a degraded feature-branch
+    one. The banner is omitted on the on-main path (``fallback_err`` is
+    ``None`` there — no merge-base was attempted) and on empty-stdout
+    fallbacks.
     """
     if branch != "main":
         try:
@@ -135,6 +143,9 @@ def _capture_diff(repo: Path, branch: str) -> tuple[str, str | None]:
     # 'working-tree diff because on main' from 'working-tree diff because
     # main ref is absent / merge-base failed'.
     if fallback_err is not None and fallback.stdout:
+        # Uses ``(fallback: ...)`` rather than the ``(diagnostic: ...)`` pattern
+        # used by _current_branch and _collect_plans error surfaces — this is a
+        # mode switch ("we changed strategy"), not an error diagnostic.
         banner = (
             "(fallback: using working-tree-vs-HEAD diff; merge-base against main was unavailable)\n"
         )

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -211,6 +211,8 @@ def _collect_plans(
 def _assemble_plans_block(
     plans: list[tuple[str, str]],
     max_total_chars: int,
+    *,
+    has_unreadable: bool = False,
 ) -> list[str]:
     """Build the ``=== PLANS ===`` section under a total-char budget.
 
@@ -224,14 +226,24 @@ def _assemble_plans_block(
     plan (longer than the total budget) still lands — so the brain
     always gets at least one plan when any exist. Per-file truncation
     in :func:`_collect_plans` bounds the damage in that edge case.
+
+    ``has_unreadable``: when True AND ``plans`` is empty, emits a
+    message that points to the UNREADABLE PLANS section rather than
+    claiming nothing was discovered — the caller has detected that
+    plans exist but all failed to read.
     """
     parts: list[str] = ["=== PLANS ==="]
     if not plans:
-        parts.append(
-            "(no plan or spec files discovered under conventional locations — "
-            "docs/plans/**/*.md, specs/**/*.md, root AGENTS.md/CLAUDE.md/SPEC.md, "
-            "*.plan.md)",
-        )
+        if has_unreadable:
+            parts.append(
+                "(no readable plan or spec files — see UNREADABLE PLANS below)",
+            )
+        else:
+            parts.append(
+                "(no plan or spec files discovered under conventional locations — "
+                "docs/plans/**/*.md, specs/**/*.md, root AGENTS.md/CLAUDE.md/SPEC.md, "
+                "*.plan.md)",
+            )
         return parts
 
     used = 0
@@ -292,7 +304,13 @@ def _assemble_prompt(
         parts.append(f"(diagnostic: {branch_error})")
     parts.append("")
 
-    parts.extend(_assemble_plans_block(plans, max_total_chars))
+    parts.extend(
+        _assemble_plans_block(
+            plans,
+            max_total_chars,
+            has_unreadable=bool(unreadable_plans),
+        ),
+    )
     parts.append("")
 
     if unreadable_plans:

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -43,16 +43,7 @@ from pathlib import Path
 from reachy_ducky_protocol.messages import BrainRequest, SpecialistResponse
 
 from reachy_ducky_daemon.brain.interface import BrainInterface
-
-# Reuse the module-private plan-discovery helper from plans_mcp. Importing
-# by its underscore name across modules is unconventional but here it's
-# deliberate: promoting ``_list_plans`` to a public ``list_plans`` would
-# require touching every existing test import, and duplicating the logic
-# would create a drift surface between specialist and MCP tool.
-# TODO(#4): promote `_list_plans` to public `list_plans` before the 2nd
-# Phase A specialist lands, so this cross-subpackage private import doesn't
-# become precedent.
-from reachy_ducky_daemon.brain.plans_mcp import _list_plans
+from reachy_ducky_daemon.brain.plans_mcp import list_plans
 from reachy_ducky_daemon.specialists.redaction import RedactionError, redact
 
 __all__ = ["PlanReviewer"]
@@ -149,7 +140,7 @@ def _collect_plans(repo: Path) -> list[tuple[str, str]]:
     """Return ``[(relative_path, contents)]`` for every plan file under ``repo``.
 
     Files whose ``read_text`` raises (non-UTF-8, vanished between the
-    ``_list_plans`` walk and the read, permission denied, etc.) are
+    ``list_plans`` walk and the read, permission denied, etc.) are
     skipped silently — the assembled prompt already includes the file's
     path via neighbouring plan files or via the missing-plans
     diagnostic, and bubbling the error up would defeat the "no
@@ -160,7 +151,7 @@ def _collect_plans(repo: Path) -> list[tuple[str, str]]:
     # header. Current silent skip is asymmetric with `_capture_diff` and
     # `_current_branch` (both surface errors as diagnostics).
     out: list[tuple[str, str]] = []
-    for rel in _list_plans(repo):
+    for rel in list_plans(repo):
         try:
             content = (repo / rel).read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -200,7 +200,8 @@ def _assemble_plans_block(
     Concatenates plan bodies in order; once the cumulative body length
     would exceed ``max_total_chars`` (after at least one plan has
     landed), appends a single ``[... N plan(s) omitted ...]`` marker
-    and stops. The ``(no plans)`` branch is unchanged.
+    (``plan`` / ``plans`` grammatically matched to ``N``) and stops.
+    The ``(no plans)`` branch is unchanged.
 
     The "at least one plan included" guard means a single oversized
     plan (longer than the total budget) still lands — so the brain
@@ -219,16 +220,19 @@ def _assemble_plans_block(
     used = 0
     included = 0
     for rel, body in plans:
-        block = f"--- {rel} ---\n{body.rstrip(chr(10))}\n"
+        body_clean = body.rstrip("\n")
+        block = f"--- {rel} ---\n{body_clean}\n"
+        # Guarantee at least one plan lands even if it exceeds the budget alone —
+        # per-file truncation in _collect_plans bounds that worst case.
         if used + len(block) > max_total_chars and included > 0:
             remaining = len(plans) - included
+            plan_word = "plan" if remaining == 1 else "plans"
             parts.append(
-                f"[... {remaining} plan(s) omitted: total body "
+                f"[... {remaining} {plan_word} omitted: total body "
                 f"budget of {max_total_chars} chars exhausted ...]",
             )
             break
-        parts.append(f"--- {rel} ---")
-        parts.append(body.rstrip("\n"))
+        parts.append(block.rstrip("\n"))
         parts.append("")
         used += len(block)
         included += 1
@@ -330,6 +334,15 @@ class PlanReviewer:
         ``[... N plan(s) omitted ...]`` marker. Calibrated against
         Claude's 200k-token context — chars × ~4-bytes-per-token leaves
         headroom for the diff, the brain's response, and other sections.
+
+        Intended invariant: ``max_plan_chars <= max_total_plan_chars``.
+        This is not enforced at construction (individual reviewers may
+        deliberately tune one cap above the other), but worst-case
+        overshoot of the total budget is bounded at
+        ``max_total_plan_chars + max_plan_chars`` because the per-file
+        truncation in :func:`_collect_plans` caps any single plan's
+        contribution before it reaches the total-budget check in
+        :func:`_assemble_plans_block`.
 
         Both caps are keyword-only so a future signature evolution can
         add positional kwargs without ambiguity. (#2)

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -216,11 +216,17 @@ def _assemble_plans_block(
 ) -> list[str]:
     """Build the ``=== PLANS ===`` section under a total-char budget.
 
-    Concatenates plan bodies in order; once the cumulative body length
-    would exceed ``max_total_chars`` (after at least one plan has
-    landed), appends a single ``[... N plan(s) omitted ...]`` marker
-    (``plan`` / ``plans`` grammatically matched to ``N``) and stops.
-    The ``(no plans)`` branch is unchanged.
+    Concatenates plan blocks (``--- rel ---`` header + body + trailing
+    separator) in order; once the cumulative block length would exceed
+    ``max_total_chars`` (after at least one plan has landed), appends a
+    single ``[... N plan(s) omitted ...]`` marker (``plan`` / ``plans``
+    grammatically matched to ``N``) and stops. The ``(no plans)``
+    branch is unchanged.
+
+    The budget measures the rendered block — header + body + separator
+    — so the char count matches what actually flows into the prompt,
+    not just the plan body. This is a small (~40 chars per plan)
+    overhead but honest about what consumes the brain's context.
 
     The "at least one plan included" guard means a single oversized
     plan (longer than the total budget) still lands — so the brain
@@ -257,7 +263,7 @@ def _assemble_plans_block(
             remaining = len(plans) - included
             plan_word = "plan" if remaining == 1 else "plans"
             parts.append(
-                f"[... {remaining} {plan_word} omitted: total body "
+                f"[... {remaining} {plan_word} omitted: total plans-block "
                 f"budget of {max_total_chars} chars exhausted ...]",
             )
             break

--- a/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
+++ b/daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py
@@ -155,8 +155,18 @@ def _collect_plans(
     for rel in list_plans(repo):
         try:
             content = (repo / rel).read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError) as exc:
-            unreadable.append((rel, f"{type(exc).__name__}: {exc}"))
+        except OSError as exc:
+            # exc.strerror omits the absolute filename that str(exc) embeds —
+            # avoids leaking client-project paths / usernames into the prompt
+            # that flows to Claude. The relative path is already in the section
+            # header at _assemble_prompt's '--- {rel} ---' line, so the brain
+            # has the context it needs. (Code-review I1 follow-up to #5.)
+            detail = exc.strerror or str(exc)
+            unreadable.append((rel, f"OSError: {detail}"))
+            continue
+        except UnicodeDecodeError as exc:
+            # UnicodeDecodeError.__str__ doesn't embed a path; safe as-is.
+            unreadable.append((rel, f"UnicodeDecodeError: {exc}"))
             continue
         readable.append((rel, content))
     return readable, unreadable

--- a/daemon/tests/test_brain_plans_mcp.py
+++ b/daemon/tests/test_brain_plans_mcp.py
@@ -41,12 +41,12 @@ def _require_dict_schema(schema: Any, *, tool_name: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def testlist_plans_empty_project(tmp_path: Path) -> None:
+def test_list_plans_empty_project(tmp_path: Path) -> None:
     """An empty project tree returns an empty list."""
     assert list_plans(tmp_path) == []
 
 
-def testlist_plans_single_docs_plan(tmp_path: Path) -> None:
+def test_list_plans_single_docs_plan(tmp_path: Path) -> None:
     """A plan under docs/plans/ is discovered and returned relative to root."""
     plan = tmp_path / "docs" / "plans" / "foo.md"
     plan.parent.mkdir(parents=True)
@@ -55,7 +55,7 @@ def testlist_plans_single_docs_plan(tmp_path: Path) -> None:
     assert list_plans(tmp_path) == ["docs/plans/foo.md"]
 
 
-def testlist_plans_nested_docs_plans(tmp_path: Path) -> None:
+def test_list_plans_nested_docs_plans(tmp_path: Path) -> None:
     """Recursive ``**`` glob picks up plans in subdirectories under docs/plans/."""
     (tmp_path / "docs" / "plans" / "sub").mkdir(parents=True)
     (tmp_path / "docs" / "plans" / "sub" / "deep.md").write_text("deep")
@@ -63,7 +63,7 @@ def testlist_plans_nested_docs_plans(tmp_path: Path) -> None:
     assert list_plans(tmp_path) == ["docs/plans/sub/deep.md"]
 
 
-def testlist_plans_multiple_locations_sorted_dedup(tmp_path: Path) -> None:
+def test_list_plans_multiple_locations_sorted_dedup(tmp_path: Path) -> None:
     """Plans from every conventional location are merged, sorted, and deduplicated."""
     (tmp_path / "docs" / "plans").mkdir(parents=True)
     (tmp_path / "specs").mkdir()
@@ -91,14 +91,14 @@ def testlist_plans_multiple_locations_sorted_dedup(tmp_path: Path) -> None:
     ]
 
 
-def testlist_plans_readme_excluded(tmp_path: Path) -> None:
+def test_list_plans_readme_excluded(tmp_path: Path) -> None:
     """README.md at the root is not a conventional plan and is not returned."""
     (tmp_path / "README.md").write_text("readme")
 
     assert list_plans(tmp_path) == []
 
 
-def testlist_plans_daemon_src_excluded(tmp_path: Path) -> None:
+def test_list_plans_daemon_src_excluded(tmp_path: Path) -> None:
     """Markdown under daemon/src/ (not a plans location) is not returned."""
     (tmp_path / "daemon" / "src").mkdir(parents=True)
     (tmp_path / "daemon" / "src" / "foo.md").write_text("arbitrary md")
@@ -106,7 +106,7 @@ def testlist_plans_daemon_src_excluded(tmp_path: Path) -> None:
     assert list_plans(tmp_path) == []
 
 
-def testlist_plans_excludes_directories(tmp_path: Path) -> None:
+def test_list_plans_excludes_directories(tmp_path: Path) -> None:
     """A directory whose name matches the glob is not returned (only files)."""
     target = tmp_path / "docs" / "plans" / "sub.md"
     target.mkdir(parents=True)
@@ -114,14 +114,14 @@ def testlist_plans_excludes_directories(tmp_path: Path) -> None:
     assert list_plans(tmp_path) == []
 
 
-def testlist_plans_dot_plan_md_at_root(tmp_path: Path) -> None:
+def test_list_plans_dot_plan_md_at_root(tmp_path: Path) -> None:
     """``*.plan.md`` files at the root are returned."""
     (tmp_path / "foo.plan.md").write_text("foo plan")
 
     assert list_plans(tmp_path) == ["foo.plan.md"]
 
 
-def testlist_plans_root_name_non_plan_md_excluded(tmp_path: Path) -> None:
+def test_list_plans_root_name_non_plan_md_excluded(tmp_path: Path) -> None:
     """Root ``.md`` files that aren't one of the three named specs nor ``*.plan.md``
     are excluded (e.g., ``NOTES.md``)."""
     (tmp_path / "NOTES.md").write_text("notes")
@@ -130,7 +130,7 @@ def testlist_plans_root_name_non_plan_md_excluded(tmp_path: Path) -> None:
     assert list_plans(tmp_path) == []
 
 
-def testlist_plans_dedup_when_file_matches_multiple_patterns(tmp_path: Path) -> None:
+def test_list_plans_dedup_when_file_matches_multiple_patterns(tmp_path: Path) -> None:
     """A file matching multiple conventional globs is returned only once.
 
     ``foo.plan.md`` living under ``docs/plans/`` matches both ``docs/plans/**/*.md``

--- a/daemon/tests/test_brain_plans_mcp.py
+++ b/daemon/tests/test_brain_plans_mcp.py
@@ -685,3 +685,59 @@ async def test_plans_mcp_server_dispatches_through_registered_handlers(
     read_block = read_payload.content[0]
     assert isinstance(read_block, mcp_types.TextContent)
     assert read_block.text == "alpha plan"
+
+
+# ---------------------------------------------------------------------------
+# M2 Task 2.1 — _discover filters paths resolving outside project_root (#8)
+# ---------------------------------------------------------------------------
+
+
+def test_discover_rejects_escaped_symlink(tmp_path: Path) -> None:
+    """A symlink under docs/plans/ that resolves outside project_root is dropped.
+
+    Security property: a plan-shaped path whose ``.resolve()`` escapes
+    ``base`` cannot be advertised by ``list_plans`` or read by
+    ``_read_plan``. Enforced in ``_discover`` so both inherit the
+    filter for free — no escaping path can be advertised, read, or
+    leaked via diagnostic.
+    """
+    # Create a real file outside the project root.
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret content")
+
+    # Create a project with docs/plans/, a legitimate plan, and an
+    # escape symlink at the same conventional location.
+    project = tmp_path / "project"
+    plans_dir = project / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    (plans_dir / "ok.md").write_text("# Legitimate plan\n")
+    escape = plans_dir / "escape.md"
+    escape.symlink_to(outside)
+
+    listed = list_plans(project)
+
+    assert "docs/plans/ok.md" in listed
+    assert "docs/plans/escape.md" not in listed
+    # Defensive: nothing in the list should reference the outside path.
+    assert not any("outside" in p for p in listed)
+
+
+def test_read_plan_rejects_escaped_symlink(tmp_path: Path) -> None:
+    """``_read_plan`` refuses a symlink that resolves outside project_root.
+
+    Two fail-closed gates cover this: ``_read_plan``'s own
+    ``relative_to(base)`` check fires first (yielding "escapes project
+    root"), and even if that were ever bypassed, ``_discover``'s new
+    ``is_relative_to`` filter keeps the resolved path out of the
+    membership set. Either way, no ValueError leaks out of
+    ``_read_plan`` and the fail-closed contract is intact.
+    """
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret content")
+    project = tmp_path / "project"
+    plans_dir = project / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    (plans_dir / "escape.md").symlink_to(outside)
+
+    with pytest.raises(PermissionError, match="escapes project root|not a plan"):
+        _read_plan(project, "docs/plans/escape.md")

--- a/daemon/tests/test_brain_plans_mcp.py
+++ b/daemon/tests/test_brain_plans_mcp.py
@@ -1,6 +1,6 @@
 """Unit tests for the in-process plans MCP server.
 
-Exercises the pure helpers (``_list_plans``, ``_read_plan``) directly so the
+Exercises the pure helpers (``list_plans``, ``_read_plan``) directly so the
 security properties are locked in without going through the SDK layer, plus a
 hello-world integration assertion that the @tool-decorated wrappers are wired
 through ``create_sdk_mcp_server`` with the right names/descriptions.
@@ -14,9 +14,9 @@ from typing import Any
 import pytest
 from reachy_ducky_daemon.brain.plans_mcp import (
     _CONVENTIONAL_PATTERNS,
-    _list_plans,
     _make_plans_tools,
     _read_plan,
+    list_plans,
     plans_mcp_server,
 )
 
@@ -37,33 +37,33 @@ def _require_dict_schema(schema: Any, *, tool_name: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# _list_plans
+# list_plans
 # ---------------------------------------------------------------------------
 
 
-def test_list_plans_empty_project(tmp_path: Path) -> None:
+def testlist_plans_empty_project(tmp_path: Path) -> None:
     """An empty project tree returns an empty list."""
-    assert _list_plans(tmp_path) == []
+    assert list_plans(tmp_path) == []
 
 
-def test_list_plans_single_docs_plan(tmp_path: Path) -> None:
+def testlist_plans_single_docs_plan(tmp_path: Path) -> None:
     """A plan under docs/plans/ is discovered and returned relative to root."""
     plan = tmp_path / "docs" / "plans" / "foo.md"
     plan.parent.mkdir(parents=True)
     plan.write_text("# foo")
 
-    assert _list_plans(tmp_path) == ["docs/plans/foo.md"]
+    assert list_plans(tmp_path) == ["docs/plans/foo.md"]
 
 
-def test_list_plans_nested_docs_plans(tmp_path: Path) -> None:
+def testlist_plans_nested_docs_plans(tmp_path: Path) -> None:
     """Recursive ``**`` glob picks up plans in subdirectories under docs/plans/."""
     (tmp_path / "docs" / "plans" / "sub").mkdir(parents=True)
     (tmp_path / "docs" / "plans" / "sub" / "deep.md").write_text("deep")
 
-    assert _list_plans(tmp_path) == ["docs/plans/sub/deep.md"]
+    assert list_plans(tmp_path) == ["docs/plans/sub/deep.md"]
 
 
-def test_list_plans_multiple_locations_sorted_dedup(tmp_path: Path) -> None:
+def testlist_plans_multiple_locations_sorted_dedup(tmp_path: Path) -> None:
     """Plans from every conventional location are merged, sorted, and deduplicated."""
     (tmp_path / "docs" / "plans").mkdir(parents=True)
     (tmp_path / "specs").mkdir()
@@ -76,7 +76,7 @@ def test_list_plans_multiple_locations_sorted_dedup(tmp_path: Path) -> None:
     (tmp_path / "SPEC.md").write_text("root spec")
     (tmp_path / "bravo.plan.md").write_text("bravo plan")
 
-    result = _list_plans(tmp_path)
+    result = list_plans(tmp_path)
 
     assert result == sorted(result), "results must be sorted lexicographically"
     assert len(result) == len(set(result)), "results must be deduplicated"
@@ -91,56 +91,56 @@ def test_list_plans_multiple_locations_sorted_dedup(tmp_path: Path) -> None:
     ]
 
 
-def test_list_plans_readme_excluded(tmp_path: Path) -> None:
+def testlist_plans_readme_excluded(tmp_path: Path) -> None:
     """README.md at the root is not a conventional plan and is not returned."""
     (tmp_path / "README.md").write_text("readme")
 
-    assert _list_plans(tmp_path) == []
+    assert list_plans(tmp_path) == []
 
 
-def test_list_plans_daemon_src_excluded(tmp_path: Path) -> None:
+def testlist_plans_daemon_src_excluded(tmp_path: Path) -> None:
     """Markdown under daemon/src/ (not a plans location) is not returned."""
     (tmp_path / "daemon" / "src").mkdir(parents=True)
     (tmp_path / "daemon" / "src" / "foo.md").write_text("arbitrary md")
 
-    assert _list_plans(tmp_path) == []
+    assert list_plans(tmp_path) == []
 
 
-def test_list_plans_excludes_directories(tmp_path: Path) -> None:
+def testlist_plans_excludes_directories(tmp_path: Path) -> None:
     """A directory whose name matches the glob is not returned (only files)."""
     target = tmp_path / "docs" / "plans" / "sub.md"
     target.mkdir(parents=True)
 
-    assert _list_plans(tmp_path) == []
+    assert list_plans(tmp_path) == []
 
 
-def test_list_plans_dot_plan_md_at_root(tmp_path: Path) -> None:
+def testlist_plans_dot_plan_md_at_root(tmp_path: Path) -> None:
     """``*.plan.md`` files at the root are returned."""
     (tmp_path / "foo.plan.md").write_text("foo plan")
 
-    assert _list_plans(tmp_path) == ["foo.plan.md"]
+    assert list_plans(tmp_path) == ["foo.plan.md"]
 
 
-def test_list_plans_root_name_non_plan_md_excluded(tmp_path: Path) -> None:
+def testlist_plans_root_name_non_plan_md_excluded(tmp_path: Path) -> None:
     """Root ``.md`` files that aren't one of the three named specs nor ``*.plan.md``
     are excluded (e.g., ``NOTES.md``)."""
     (tmp_path / "NOTES.md").write_text("notes")
     (tmp_path / "CHANGELOG.md").write_text("cl")
 
-    assert _list_plans(tmp_path) == []
+    assert list_plans(tmp_path) == []
 
 
-def test_list_plans_dedup_when_file_matches_multiple_patterns(tmp_path: Path) -> None:
+def testlist_plans_dedup_when_file_matches_multiple_patterns(tmp_path: Path) -> None:
     """A file matching multiple conventional globs is returned only once.
 
     ``foo.plan.md`` living under ``docs/plans/`` matches both ``docs/plans/**/*.md``
     and ``*.plan.md``-style checks (depending on cwd); the ``set``-based dedup
-    inside ``_list_plans`` must guarantee one entry.
+    inside ``list_plans`` must guarantee one entry.
     """
     (tmp_path / "docs" / "plans").mkdir(parents=True)
     (tmp_path / "docs" / "plans" / "foo.plan.md").write_text("x")
 
-    result = _list_plans(tmp_path)
+    result = list_plans(tmp_path)
 
     assert result.count("docs/plans/foo.plan.md") == 1
 
@@ -306,7 +306,7 @@ def test_read_plan_symlink_to_file_inside_project_allowed(tmp_path: Path) -> Non
 
 
 def test_read_plan_deep_docs_plans_path_matches_discover_surface(tmp_path: Path) -> None:
-    """_read_plan must accept any path _list_plans advertises, regardless of depth.
+    """_read_plan must accept any path list_plans advertises, regardless of depth.
 
     Regression for Bug 1: ``PurePath.match("docs/plans/**/*.md")`` rejects
     ``docs/plans/a/b/c/d.md`` (pathlib's match requires at least one ``**``
@@ -318,7 +318,7 @@ def test_read_plan_deep_docs_plans_path_matches_discover_surface(tmp_path: Path)
     deep.parent.mkdir(parents=True)
     deep.write_text("deep plan contents")
 
-    listed = _list_plans(tmp_path)
+    listed = list_plans(tmp_path)
     assert "docs/plans/a/b/c/d.md" in listed
     assert _read_plan(tmp_path, "docs/plans/a/b/c/d.md") == "deep plan contents"
 
@@ -329,7 +329,7 @@ def test_read_plan_deep_specs_path_matches_discover_surface(tmp_path: Path) -> N
     deep.parent.mkdir(parents=True)
     deep.write_text("deep spec contents")
 
-    listed = _list_plans(tmp_path)
+    listed = list_plans(tmp_path)
     assert "specs/a/b/c.md" in listed
     assert _read_plan(tmp_path, "specs/a/b/c.md") == "deep spec contents"
 
@@ -344,7 +344,7 @@ def test_read_plan_denies_agents_md_outside_root(tmp_path: Path) -> None:
 
     Regression for Bug 2 (security): ``PurePath.match("AGENTS.md")`` is a
     tail match with no leading anchor, so ``nested/AGENTS.md`` matched under
-    the old matcher and became readable even though ``_list_plans`` (which
+    the old matcher and became readable even though ``list_plans`` (which
     uses ``base.glob("AGENTS.md")``) correctly anchored the pattern to the
     root. The single-source fix restores parity.
     """
@@ -352,7 +352,7 @@ def test_read_plan_denies_agents_md_outside_root(tmp_path: Path) -> None:
     nested.parent.mkdir(parents=True)
     nested.write_text("attacker dropped")
 
-    assert "nested/AGENTS.md" not in _list_plans(tmp_path)
+    assert "nested/AGENTS.md" not in list_plans(tmp_path)
     with pytest.raises(PermissionError, match="not a plan or spec"):
         _read_plan(tmp_path, "nested/AGENTS.md")
 
@@ -369,7 +369,7 @@ def test_read_plan_denies_plan_md_outside_root(tmp_path: Path) -> None:
     hidden.parent.mkdir(parents=True)
     hidden.write_text("attacker dropped")
 
-    assert "daemon/src/secrets.plan.md" not in _list_plans(tmp_path)
+    assert "daemon/src/secrets.plan.md" not in list_plans(tmp_path)
     with pytest.raises(PermissionError, match="not a plan or spec"):
         _read_plan(tmp_path, "daemon/src/secrets.plan.md")
 
@@ -380,7 +380,7 @@ def test_read_plan_denies_nested_claude_md(tmp_path: Path) -> None:
     nested.parent.mkdir(parents=True)
     nested.write_text("nested claude")
 
-    assert "nested/CLAUDE.md" not in _list_plans(tmp_path)
+    assert "nested/CLAUDE.md" not in list_plans(tmp_path)
     with pytest.raises(PermissionError, match="not a plan or spec"):
         _read_plan(tmp_path, "nested/CLAUDE.md")
 
@@ -391,7 +391,7 @@ def test_read_plan_denies_nested_spec_md(tmp_path: Path) -> None:
     nested.parent.mkdir(parents=True)
     nested.write_text("nested spec")
 
-    assert "nested/SPEC.md" not in _list_plans(tmp_path)
+    assert "nested/SPEC.md" not in list_plans(tmp_path)
     with pytest.raises(PermissionError, match="not a plan or spec"):
         _read_plan(tmp_path, "nested/SPEC.md")
 
@@ -402,7 +402,7 @@ def test_read_plan_denies_nested_spec_md(tmp_path: Path) -> None:
 
 
 async def test_find_plans_tool_returns_text_block(tmp_path: Path) -> None:
-    """The find_plans tool wraps _list_plans output in the MCP text-block shape."""
+    """The find_plans tool wraps list_plans output in the MCP text-block shape."""
     (tmp_path / "docs" / "plans").mkdir(parents=True)
     (tmp_path / "docs" / "plans" / "a.md").write_text("a")
     (tmp_path / "CLAUDE.md").write_text("claude")

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -379,3 +379,69 @@ async def test_plan_reviewer_aborts_on_redaction_failure(
     assert "gitleaks binary not found" in response.summary
     assert "abort" in response.summary.lower() or "unavailable" in response.summary.lower()
     assert len(brain.calls) == 0, "brain.query must not fire when redaction fails"
+
+
+# ---------------------------------------------------------------------------
+# Unreadable-plan diagnostic surfacing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_surfaces_unreadable_plan_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """A plan file that can't be read (non-UTF-8) surfaces under UNREADABLE PLANS.
+
+    Phase-A parity: _current_branch and _capture_diff already surface
+    errors as '(diagnostic: ...)' in the prompt. _collect_plans
+    previously swallowed OSError/UnicodeDecodeError silently; now the
+    brain sees 'these files exist but we couldn't read them' instead of
+    'these files never existed'.
+    """
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    # A legitimate, readable plan
+    (plans_dir / "ok.md").write_text("# OK Plan\nreadable body\n")
+    # A binary blob that isn't valid UTF-8
+    (plans_dir / "bad.md").write_bytes(b"\xff\xfe\x00\x00not utf-8")
+    _commit(tmp_path, "plans")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=tmp_path)
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # Readable plan still present
+    assert "# OK Plan" in prompt
+    # New section header present
+    assert "=== UNREADABLE PLANS ===" in prompt
+    # Failing file's path is named in the diagnostic
+    unreadable_section = prompt.split("=== UNREADABLE PLANS ===", 1)[1]
+    assert "bad.md" in unreadable_section
+    # Diagnostic mentions the failure mode
+    assert "utf-8" in unreadable_section.lower() or "decode" in unreadable_section.lower()
+
+
+@pytest.mark.asyncio
+async def test_review_omits_unreadable_section_when_all_plans_load(
+    tmp_path: Path,
+) -> None:
+    """When every plan reads cleanly, the UNREADABLE PLANS section is absent.
+
+    Avoids cluttering the prompt with an empty diagnostic header.
+    """
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    (plans_dir / "ok.md").write_text("# OK Plan\nreadable body\n")
+    _commit(tmp_path, "plans")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=tmp_path)
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    assert "# OK Plan" in prompt
+    # No empty section header
+    assert "=== UNREADABLE PLANS ===" not in prompt

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -445,3 +445,52 @@ async def test_review_omits_unreadable_section_when_all_plans_load(
     assert "# OK Plan" in prompt
     # No empty section header
     assert "=== UNREADABLE PLANS ===" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_review_oserror_diagnostic_omits_absolute_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OSError diagnostics use exc.strerror, not str(exc) — no absolute path leak.
+
+    str(OSError) embeds the full filesystem path, e.g.
+    'OSError: [Errno 13] Permission denied: /Users/.../docs/plans/x.md'.
+    The brain already has the relative path via the '--- {rel} ---'
+    section header; surfacing the absolute path again is a needless
+    leak of usernames / client-project names through the prompt.
+    """
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    secret = plans_dir / "x.md"
+    secret.write_text("# X\n")
+    _commit(tmp_path, "plans")
+
+    # Inject a synthetic OSError via monkeypatch: chmod 0 is unreliable
+    # across platforms (owner reads can still succeed on some setups),
+    # so swap Path.read_text for an implementation that raises OSError
+    # with the absolute path embedded — mirroring real PermissionError
+    # behaviour on POSIX.
+    real_read_text = Path.read_text
+
+    def fake_read_text(
+        self: Path,
+        *args: object,
+        **kwargs: object,
+    ) -> str:
+        if self == secret:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=tmp_path)
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # The relative path appears in the section header (expected).
+    assert "x.md" in prompt
+    # The ABSOLUTE path must NOT appear — that's the leak we're closing.
+    assert str(tmp_path) not in prompt

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -582,3 +582,39 @@ def test_caps_have_sensible_defaults(tmp_path: Path) -> None:
     reviewer = PlanReviewer(brain=MockBrain(), repo=tmp_path)
     assert reviewer._max_plan_chars == 50_000  # noqa: SLF001
     assert reviewer._max_total_plan_chars == 200_000  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Merge-base fallback banner (#3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capture_diff_falls_back_when_main_ref_absent(tmp_path: Path) -> None:
+    """Feature branch but no 'main' ref → fall back to working-tree-vs-HEAD.
+
+    Banner: the fallback diff text starts with a one-line marker telling
+    the brain it came from the fallback path, not the merge-base diff.
+    """
+    # Init with default branch 'feat-alone' instead of 'main'.
+    _run("git", "init", "-b", "feat-alone", cwd=tmp_path)
+    _run("git", "config", "user.email", "test@example.com", cwd=tmp_path)
+    _run("git", "config", "user.name", "Test User", cwd=tmp_path)
+    _run("git", "config", "commit.gpgsign", "false", cwd=tmp_path)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    (tmp_path / "docs" / "plans" / "foo.md").write_text("# Plan Foo\n")
+    _commit(tmp_path, "initial")
+    # Make an uncommitted edit so `git diff` has output.
+    (tmp_path / "docs" / "plans" / "foo.md").write_text("# Plan Foo\nUNCOMMITTED_EDIT\n")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=tmp_path)
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # Fallback engaged — uncommitted edit surfaces.
+    assert "UNCOMMITTED_EDIT" in prompt
+    # Banner line sits at the top of the diff section.
+    diff_section = prompt.split("=== DIFF ===", 1)[1]
+    assert "(fallback:" in diff_section or "fallback:" in diff_section
+    assert "working-tree" in diff_section.lower() or "working tree" in diff_section.lower()

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -530,7 +530,18 @@ async def test_per_file_cap_truncates_individual_plans(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_total_cap_drops_remaining_plans(tmp_path: Path) -> None:
-    """Plans beyond max_total_plan_chars are replaced by an omission marker."""
+    """Plans beyond max_total_plan_chars are replaced by an omission marker.
+
+    Asserts the full policy, not just the marker's presence:
+
+    * Insertion order of the plans that *do* land is preserved
+      (``p0 < p1 < p2``).
+    * The last plan is omitted (``p4.md`` does not appear).
+    * The marker names the exact remaining count (``"2 plans omitted"``;
+      grammatically plural since two are dropped).
+    * The marker sits *after* the last included plan, not before —
+      proving the early-exit ordering rather than a stray substring.
+    """
     _init_repo(tmp_path)
     plans_dir = tmp_path / "docs" / "plans"
     plans_dir.mkdir(parents=True)
@@ -549,11 +560,17 @@ async def test_total_cap_drops_remaining_plans(tmp_path: Path) -> None:
     await reviewer.review()
 
     prompt = brain.calls[-1].user_utterance
-    # At least one plan landed (early ones) and at least one was omitted.
+    # At least the first plan landed and the budget number is named.
     assert "p0.md" in prompt
-    # Omission marker present somewhere in the prompt.
-    assert "plan(s) omitted" in prompt
-    assert "200000" in prompt  # the budget number is named in the marker
+    assert "200000" in prompt
+    # Ordering property: insertion order preserved for included plans.
+    assert prompt.index("p0.md") < prompt.index("p1.md") < prompt.index("p2.md")
+    # Last-plan-dropped property: p4 is past the budget, so it never appears.
+    assert "p4.md" not in prompt
+    # Exact count in marker — 5 plans in, 3 land, 2 are omitted.
+    assert "2 plans omitted" in prompt
+    # Position property: marker follows the last included plan, not precedes it.
+    assert prompt.index("p2.md") < prompt.index("plans omitted")
 
 
 def test_caps_have_sensible_defaults(tmp_path: Path) -> None:

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -494,3 +494,74 @@ async def test_review_oserror_diagnostic_omits_absolute_path(
     assert "x.md" in prompt
     # The ABSOLUTE path must NOT appear — that's the leak we're closing.
     assert str(tmp_path) not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Size caps — per-file + total-budget (#2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_file_cap_truncates_individual_plans(tmp_path: Path) -> None:
+    """Plans longer than max_plan_chars get a truncation marker."""
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    big = "x" * 120_000
+    (plans_dir / "big.md").write_text(big)
+    _commit(tmp_path, "big plan")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(
+        brain=brain,
+        repo=tmp_path,
+        max_plan_chars=50_000,
+        max_total_plan_chars=200_000,
+    )
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # Per-file truncation marker present with the exact elided count.
+    assert "[... truncated: 70000 chars elided ...]" in prompt
+    # The full 120k body must NOT appear; allow modest overhead for
+    # other prompt sections that don't contain 'x'.
+    assert prompt.count("x") <= 60_000  # 50k truncated body + small slack
+
+
+@pytest.mark.asyncio
+async def test_total_cap_drops_remaining_plans(tmp_path: Path) -> None:
+    """Plans beyond max_total_plan_chars are replaced by an omission marker."""
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    # 5 plans × 50k each = 250k, exceeds 200k total cap.
+    for i in range(5):
+        (plans_dir / f"p{i}.md").write_text("y" * 50_000)
+    _commit(tmp_path, "many plans")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(
+        brain=brain,
+        repo=tmp_path,
+        max_plan_chars=60_000,
+        max_total_plan_chars=200_000,
+    )
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # At least one plan landed (early ones) and at least one was omitted.
+    assert "p0.md" in prompt
+    # Omission marker present somewhere in the prompt.
+    assert "plan(s) omitted" in prompt
+    assert "200000" in prompt  # the budget number is named in the marker
+
+
+def test_caps_have_sensible_defaults(tmp_path: Path) -> None:
+    """Defaults: max_plan_chars=50_000, max_total_plan_chars=200_000.
+
+    Pins the defaults so a future change is deliberate. Constructor is
+    keyword-only on these kwargs.
+    """
+    reviewer = PlanReviewer(brain=MockBrain(), repo=tmp_path)
+    assert reviewer._max_plan_chars == 50_000  # noqa: SLF001
+    assert reviewer._max_total_plan_chars == 200_000  # noqa: SLF001

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -228,6 +228,9 @@ async def test_main_branch_fallback_includes_uncommitted_diff(
 
     prompt = brain.calls[-1].user_utterance
     assert "UNCOMMITTED_EDIT" in prompt
+    # Banner is gated on fallback_err is not None — the on-main path
+    # never attempted a merge-base diff, so no banner appears.
+    assert "(fallback:" not in prompt
 
 
 @pytest.mark.asyncio
@@ -614,7 +617,29 @@ async def test_capture_diff_falls_back_when_main_ref_absent(tmp_path: Path) -> N
     prompt = brain.calls[-1].user_utterance
     # Fallback engaged — uncommitted edit surfaces.
     assert "UNCOMMITTED_EDIT" in prompt
-    # Banner line sits at the top of the diff section.
     diff_section = prompt.split("=== DIFF ===", 1)[1]
-    assert "(fallback:" in diff_section or "fallback:" in diff_section
-    assert "working-tree" in diff_section.lower() or "working tree" in diff_section.lower()
+    diff_lines = [line for line in diff_section.splitlines() if line.strip()]
+    assert diff_lines, "diff section was unexpectedly empty"
+
+    # Banner must appear in the diff section, and it must sit ABOVE the
+    # first ``diff --git`` hunk header. That is the real property:
+    # the brain sees the mode switch before the content it is interpreting.
+    # Position-anchoring on the hunk (not the diagnostic region) keeps the
+    # test robust to future changes in how ``_assemble_prompt`` renders
+    # ``(diagnostic: ...)`` — which is multi-line because git stderr is.
+    fallback_idx = next(
+        (i for i, line in enumerate(diff_lines) if line.startswith("(fallback:")),
+        None,
+    )
+    assert fallback_idx is not None, (
+        f"banner missing from diff section; first 5 lines: {diff_lines[:5]}"
+    )
+    hunk_idx = next(
+        (i for i, line in enumerate(diff_lines) if line.startswith("diff --git ")),
+        len(diff_lines),
+    )
+    assert fallback_idx < hunk_idx, (
+        f"banner must appear before the first diff hunk header; "
+        f"fallback_idx={fallback_idx}, hunk_idx={hunk_idx}"
+    )
+    assert "working-tree" in diff_lines[fallback_idx].lower(), diff_lines[fallback_idx]

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -427,6 +427,42 @@ async def test_review_surfaces_unreadable_plan_diagnostic(
 
 
 @pytest.mark.asyncio
+async def test_prompt_has_no_contradiction_when_all_plans_unreadable(
+    tmp_path: Path,
+) -> None:
+    """When every discovered plan is unreadable, the PLANS section must not
+    claim 'no plan or spec files discovered' — that contradicts the
+    UNREADABLE PLANS section which names specific discovered-but-unreadable
+    files.
+    """
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    # Two non-UTF-8 blobs — no readable plan at all.
+    (plans_dir / "bad1.md").write_bytes(b"\xff\xfe\x00\x00not utf-8 one")
+    (plans_dir / "bad2.md").write_bytes(b"\xff\xfe\x00\x00not utf-8 two")
+    _commit(tmp_path, "only-bad-plans")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=tmp_path)
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # Must surface both filenames as unreadable diagnostics.
+    assert "=== UNREADABLE PLANS ===" in prompt
+    assert "bad1.md" in prompt
+    assert "bad2.md" in prompt
+    # Must NOT claim nothing was discovered — that contradicts the list above.
+    assert "no plan or spec files discovered" not in prompt
+    # Must still signal the empty-readable state somehow, pointing to the
+    # UNREADABLE PLANS section.
+    plans_section = prompt.split("=== PLANS ===", 1)[1].split("=== UNREADABLE PLANS ===", 1)[0]
+    assert "no readable plan" in plans_section.lower(), (
+        f"PLANS section should say 'no readable plan...'; got: {plans_section!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_review_omits_unreadable_section_when_all_plans_load(
     tmp_path: Path,
 ) -> None:

--- a/docs/plans/2026-04-23-plan-reviewer-polish-sweep.md
+++ b/docs/plans/2026-04-23-plan-reviewer-polish-sweep.md
@@ -1,0 +1,765 @@
+# PlanReviewer Polish Sweep Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Close 5 open `TODO(#N)` issues in `daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py` (#2, #3, #4, #5, #8) as a single coherent sweep — promote the underscore import, harden the plan-discovery security boundary, surface read-error diagnostics, cap prompt size, and fix the missing fallback-banner/test — before Phase B adds more specialists built on the same patterns.
+
+**Architecture:** 5 milestones, each a single commit on one branch (`plan-reviewer-polish-sweep`), all shipped in one PR. Ordering is dictated by dependency (#4's rename must land before the other fixes reference the public symbol; #8's security filter in `_discover` reshapes what `_collect_plans` sees; #5/#2/#3 are all independent of each other once #4/#8 are in).
+
+**Tech Stack:** Python 3.12, `uv` workspace, Pydantic v2, pytest + `subprocess` for the existing `@pytest.mark.asyncio` specialist tests. No new dependencies.
+
+**Issues closed:**
+
+| Milestone | Issue | Subject |
+|---|---|---|
+| M1 | #4 | Promote `_list_plans` → `list_plans` |
+| M2 | #8 | `_discover` filters paths that resolve outside `base` (escaped symlinks) |
+| M3 | #5 | `_collect_plans` surfaces per-file read errors as `=== UNREADABLE PLANS ===` |
+| M4 | #2 | Constructor-kwarg size caps on `_assemble_prompt` (per-file + total) |
+| M5 | #3 | `_capture_diff` prepends fallback banner; add missing merge-base-absent test |
+
+**Conventions used throughout:**
+- TDD per task: failing test → run it (fails with the expected shape) → minimal implementation → run it (passes) → commit.
+- Per-task gate before commit: `uv run ruff check . && uv run ruff format --check . && uv run mypy --strict daemon/src daemon/tests && uv run pytest -q daemon/tests/test_brain_plans_mcp.py daemon/tests/test_specialist_plan_reviewer.py`.
+- Full-branch gate before push: `uv run ruff check . && uv run ruff format --check . && uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests && uv run pyright && uv run bandit -ll -r daemon/src app/src menubar/src protocol/src && uv run pytest -q --cov`. Coverage floor 90%.
+- One commit per milestone. Conventional commits (`feat:` / `fix:` / `refactor:` / `test:`).
+
+**Reference skills:** @superpowers:test-driven-development, @superpowers:verification-before-completion
+
+**Key design decisions (locked during 2026-04-23 brainstorm):**
+- **#4**: clean rename, no `_list_plans` compat alias. Only callers: `plan_reviewer.py` (via underscore import) + `plans_mcp.py`'s own tests.
+- **#8**: fix in `_discover` (not `_collect_plans`). Security property belongs where the resolution happens; keeps the `_read_plan` membership check correct for free.
+- **#5**: unreadable files surface as a separate `=== UNREADABLE PLANS ===` section (not inline in `=== PLANS ===`) — easier for the brain's attention to anchor on.
+- **#2**: caps are constructor kwargs, not class constants. Defaults: `max_plan_chars=50_000`, `max_total_plan_chars=200_000`. Per-file truncation inside `_collect_plans`; total-budget truncation inside `_assemble_prompt`. Marker: `[... truncated: N chars elided ...]`.
+- **#3**: fallback banner is a one-line prefix on the diff text (not a separate `=== DIFF (FALLBACK) ===` section).
+
+**Session scope:** One session is realistic. 5 milestones, small file, no hardware. Expect ~1 hour across all implementer + reviewer dispatches.
+
+---
+
+## Milestone 1 — Promote `_list_plans` → `list_plans` (#4)
+
+Foundational rename. Drops the cross-subpackage underscore import that `plan_reviewer.py` currently relies on.
+
+### Task 1.1: Rename + update callers
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/brain/plans_mcp.py` (rename `_list_plans` → `list_plans`; update `__all__` if the symbol is exported).
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py` (change the import + the one call site).
+- Modify: `daemon/tests/test_brain_plans_mcp.py` (find+replace `_list_plans` → `list_plans` — mechanical).
+
+**Step 1: Sanity-grep the symbol first**
+
+```bash
+grep -rn "_list_plans" daemon/
+```
+
+Expected hits:
+- `daemon/src/reachy_ducky_daemon/brain/plans_mcp.py` — the definition + internal references.
+- `daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py` — the cross-subpackage import + one call.
+- `daemon/tests/test_brain_plans_mcp.py` — tests.
+
+No daemon-side consumers beyond these three files (verify before editing).
+
+**Step 2: Rename in `plans_mcp.py`**
+
+Change `def _list_plans(project_root: Path) -> list[str]:` → `def list_plans(project_root: Path) -> list[str]:`. Update any internal docstrings that mention `_list_plans`. Update `__all__` if the module declares one (check — if not, no change needed).
+
+**Step 3: Update the cross-subpackage import + TODO comment**
+
+In `plan_reviewer.py` around lines 47–55 — the block with the `TODO(#4): promote _list_plans to public list_plans` comment — delete the TODO comment entirely (it's now resolved) and change the import:
+
+```python
+from reachy_ducky_daemon.brain.plans_mcp import list_plans
+```
+
+Update the one call site (around line 162 in `_collect_plans`): `for rel in _list_plans(repo):` → `for rel in list_plans(repo):`.
+
+**Step 4: Update tests**
+
+In `daemon/tests/test_brain_plans_mcp.py`, find+replace every `_list_plans` → `list_plans` — purely mechanical. Do NOT touch `_read_plan` or `_discover` references; those stay private.
+
+**Step 5: Run tests + gate**
+
+```bash
+uv run pytest daemon/tests/test_brain_plans_mcp.py daemon/tests/test_specialist_plan_reviewer.py -q
+uv run mypy --strict daemon/src daemon/tests
+uv run ruff check .
+```
+
+All three must be clean.
+
+**Step 6: Commit**
+
+```bash
+git add daemon/src/reachy_ducky_daemon/brain/plans_mcp.py daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py daemon/tests/test_brain_plans_mcp.py
+git commit -m "refactor(brain): promote _list_plans to public list_plans
+
+The cross-subpackage underscore import from plan_reviewer was Python's
+'do not touch' convention being bent for convenience. Promoting the
+function to public collapses the precedent risk — the second specialist
+(pr-reviewer already landed; future ones likely to follow) won't inherit
+an ambiguous 'is this off-limits or not' signal.
+
+_read_plan and _discover stay private — they're the security-validated
+read path (closes-over project root, blocks path escapes + non-listed
+reads) and have no legitimate cross-subpackage consumer.
+
+Resolves the TODO(#4) in plan_reviewer.py:52. Closes #4."
+```
+
+---
+
+## Milestone 2 — Symlink-escape filter in `_discover` (#8)
+
+Quietly drop paths that resolve outside `project_root`. Security property lives at the resolution seam, not at the caller.
+
+### Task 2.1: Filter in `_discover`
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/brain/plans_mcp.py` (the `_discover` function).
+- Modify: `daemon/tests/test_brain_plans_mcp.py` (new test for escaped symlink).
+
+**Step 1: Write the failing test**
+
+Append to `daemon/tests/test_brain_plans_mcp.py`:
+
+```python
+def test_discover_rejects_escaped_symlink(tmp_path: Path) -> None:
+    """A symlink under docs/plans/ that resolves outside project_root is dropped.
+
+    Security property: a plan-shaped path whose ``.resolve()`` escapes
+    ``base`` cannot be advertised by list_plans or read by read_plan.
+    Enforced in _discover so _list_plans + _read_plan both inherit the
+    filter for free.
+    """
+    # Create a real file outside the project root.
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret content")
+
+    # Create a project with docs/plans/, and a symlink there pointing OUT.
+    project = tmp_path / "project"
+    plans_dir = project / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    legitimate = plans_dir / "ok.md"
+    legitimate.write_text("# Legitimate plan")
+    escape = plans_dir / "escape.md"
+    escape.symlink_to(outside)
+
+    # list_plans must NOT advertise escape.md; only ok.md.
+    listed = list_plans(project)
+    assert "docs/plans/ok.md" in listed
+    assert "docs/plans/escape.md" not in listed
+    assert not any("outside" in p for p in listed)
+
+
+def test_read_plan_rejects_escaped_symlink(tmp_path: Path) -> None:
+    """read_plan returns 'not a plan' for paths _discover would silently drop.
+
+    Uses the same fixture shape as the discover test but asserts the
+    per-file read guard still refuses. No ValueError leaks out of
+    read_plan — the fail-closed contract is intact.
+    """
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret content")
+    project = tmp_path / "project"
+    plans_dir = project / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    escape = plans_dir / "escape.md"
+    escape.symlink_to(outside)
+
+    with pytest.raises(PermissionError, match="not a plan"):
+        _read_plan(project, "docs/plans/escape.md")
+```
+
+**Step 2: Run tests — expect failure**
+
+```bash
+uv run pytest daemon/tests/test_brain_plans_mcp.py -k "escaped_symlink" -v
+```
+
+Expected: `test_discover_rejects_escaped_symlink` FAILS because `escape.md` currently appears in `list_plans`'s output; `test_read_plan_rejects_escaped_symlink` may PASS (the existing `relative_to` guard in `_read_plan` should already catch it via its try/except → `PermissionError`). If both fail, great — the fix handles both.
+
+**Step 3: Implement the filter in `_discover`**
+
+In `plans_mcp.py`, change the `_discover` function from:
+
+```python
+def _discover(base: Path) -> set[Path]:
+    results: set[Path] = set()
+    for pattern in _CONVENTIONAL_PATTERNS:
+        for hit in base.glob(pattern):
+            if hit.is_file():
+                results.add(hit.resolve())
+    return results
+```
+
+To:
+
+```python
+def _discover(base: Path) -> set[Path]:
+    """..."""  # (keep existing docstring, extend it — see below)
+    results: set[Path] = set()
+    for pattern in _CONVENTIONAL_PATTERNS:
+        for hit in base.glob(pattern):
+            if not hit.is_file():
+                continue
+            resolved = hit.resolve()
+            # Reject symlinks whose resolved target escapes ``base``.
+            # ``is_relative_to`` (Python 3.9+) is the non-raising form
+            # of the same check ``_read_plan`` uses. Filtering here
+            # means both list_plans (discovery) and _read_plan
+            # (validation) inherit the property for free — no escaping
+            # path can be advertised, read, or leaked via diagnostic.
+            if not resolved.is_relative_to(base):
+                continue
+            results.add(resolved)
+    return results
+```
+
+Extend the docstring to note the new filter. Update the reference in the module docstring if it mentions "symlink escapes are denied" (good place to cite this change).
+
+**Step 4: Run tests — expect pass**
+
+```bash
+uv run pytest daemon/tests/test_brain_plans_mcp.py -q
+uv run mypy --strict daemon/src daemon/tests
+```
+
+Both clean.
+
+**Step 5: Commit**
+
+```bash
+git commit -m "fix(brain): _discover filters paths that resolve outside base (#8)
+
+Security property belongs at the resolution seam. A symlink
+docs/plans/x.md -> /etc/passwd previously was silently listed by
+list_plans (its relative_to(base) would raise ValueError and propagate
+up through PlanReviewer._collect_plans → review() → a 500 on the
+/specialists/plan-reviewer endpoint). read_plan's existing
+relative_to guard caught it one layer later, but discovery leaked
+before that.
+
+Filter at _discover using is_relative_to (non-raising). Both
+list_plans (what we advertise) and _read_plan's membership check
+(what we allow to be read) now inherit the property for free —
+escaping paths cannot enter the discover set at all.
+
+Closes #8."
+```
+
+---
+
+## Milestone 3 — Unreadable-plan diagnostics (#5)
+
+`_collect_plans` accumulates per-file read errors; `_assemble_prompt` surfaces them as a new section.
+
+### Task 3.1: Accumulate + surface read errors
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py` (`_collect_plans`, `_assemble_prompt`, `review`).
+- Modify: `daemon/tests/test_specialist_plan_reviewer.py` (new test for a non-UTF-8 plan).
+
+**Step 1: Write the failing test**
+
+Append to `daemon/tests/test_specialist_plan_reviewer.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_review_surfaces_unreadable_plan_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """A plan file that can't be read (non-UTF-8) surfaces under UNREADABLE PLANS.
+
+    Phase-A parity: _current_branch and _capture_diff already surface
+    errors as '(diagnostic: ...)' in the prompt. _collect_plans
+    previously swallowed OSError/UnicodeDecodeError silently; now the
+    brain sees 'these files exist but we couldn't read them' instead of
+    'these files never existed'.
+    """
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    # Write a legitimate plan…
+    (plans_dir / "ok.md").write_text("# OK Plan\nreadable body\n")
+    # …and a binary blob that isn't valid UTF-8.
+    (plans_dir / "bad.md").write_bytes(b"\xff\xfe\x00\x00not utf-8")
+    _commit(tmp_path, "plans")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=tmp_path)
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    assert "# OK Plan" in prompt  # readable plan still present
+    assert "=== UNREADABLE PLANS ===" in prompt  # new section present
+    assert "bad.md" in prompt  # the failing file's path is named
+    # The UTF-8 decode failure shows up as a diagnostic string; exact
+    # message depends on Python's error but 'utf-8' substring is stable.
+    unreadable_section = prompt.split("=== UNREADABLE PLANS ===", 1)[1]
+    assert "bad.md" in unreadable_section
+    assert "utf-8" in unreadable_section.lower() or "decode" in unreadable_section.lower()
+```
+
+**Step 2: Run test — expect failure**
+
+Expected: FAIL because `=== UNREADABLE PLANS ===` section doesn't exist yet; also the bad file is silently skipped so its path isn't in the prompt at all.
+
+**Step 3: Refactor `_collect_plans` + `_assemble_prompt` + `review`**
+
+Change `_collect_plans` to return a tuple of `(readable, unreadable)`:
+
+```python
+def _collect_plans(
+    repo: Path,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return ``(readable, unreadable)`` — ``readable`` is ``[(rel, content)]``
+    for every plan that loaded cleanly; ``unreadable`` is ``[(rel, err)]``
+    for every plan ``list_plans`` advertised but ``read_text`` rejected.
+
+    Both lists are sorted by ``rel``; either may be empty.
+
+    TODO(#5) [resolved]: previously this function silently swallowed
+    OSError/UnicodeDecodeError. Now the diagnostic surfaces to the
+    brain via the ``=== UNREADABLE PLANS ===`` prompt section (see
+    ``_assemble_prompt``).
+    """
+    readable: list[tuple[str, str]] = []
+    unreadable: list[tuple[str, str]] = []
+    for rel in list_plans(repo):
+        try:
+            content = (repo / rel).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            unreadable.append((rel, f"{type(exc).__name__}: {exc}"))
+            continue
+        readable.append((rel, content))
+    return readable, unreadable
+```
+
+Update `review()` to receive both lists:
+
+```python
+async def review(self) -> SpecialistResponse:
+    branch, branch_error = _current_branch(self._repo)
+    plans, unreadable_plans = _collect_plans(self._repo)
+    diff, diff_error = _capture_diff(self._repo, branch)
+
+    prompt = _assemble_prompt(
+        branch=branch,
+        branch_error=branch_error,
+        plans=plans,
+        unreadable_plans=unreadable_plans,
+        diff=diff,
+        diff_error=diff_error,
+    )
+    # ... rest unchanged
+```
+
+Update `_assemble_prompt` to accept `unreadable_plans` and emit the section:
+
+```python
+def _assemble_prompt(
+    branch: str,
+    branch_error: str | None,
+    plans: list[tuple[str, str]],
+    unreadable_plans: list[tuple[str, str]],
+    diff: str,
+    diff_error: str | None,
+) -> str:
+    """..."""  # (extend existing docstring)
+    parts: list[str] = []
+    # ... existing branch + plans blocks unchanged
+    # New section — immediately after the plans block, before the diff:
+    if unreadable_plans:
+        parts.append("=== UNREADABLE PLANS ===")
+        parts.append(
+            "(These files were discovered under conventional locations but "
+            "could not be read. Listed here so you can note them in the "
+            "review — they do not participate in drift analysis.)"
+        )
+        for rel, err in unreadable_plans:
+            parts.append(f"--- {rel} ---")
+            parts.append(f"(diagnostic: {err})")
+        parts.append("")
+    # ... existing diff block + directive unchanged
+```
+
+**Step 4: Run tests — expect pass**
+
+Existing tests may need small updates because `_collect_plans` now returns a tuple. Check + adjust any direct-call tests. `review()` tests shouldn't need changes (they only inspect the prompt content).
+
+```bash
+uv run pytest daemon/tests/test_specialist_plan_reviewer.py -q
+uv run mypy --strict daemon/src daemon/tests
+```
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(specialists/plan-reviewer): surface unreadable-plan diagnostics (#5)
+
+_collect_plans previously swallowed OSError/UnicodeDecodeError and
+silently dropped the file — the brain couldn't tell 'file listed but
+unreadable' from 'file never existed'. Most-likely real case: a
+non-UTF-8 plan file confuses the review silently.
+
+Now _collect_plans returns (readable, unreadable) tuples;
+_assemble_prompt renders unreadable entries under a new
+'=== UNREADABLE PLANS ===' section (separate from the main plans
+block so the brain's attention anchors cleanly). Fail-closed contract
+intact: no exception escapes review().
+
+Parity with _current_branch and _capture_diff, both of which already
+surface errors as '(diagnostic: ...)' in the prompt."
+```
+
+---
+
+## Milestone 4 — Size caps on `_assemble_prompt` (#2)
+
+Per-file truncation in `_collect_plans`, total-budget truncation in `_assemble_prompt`. Thresholds are constructor kwargs with defaults.
+
+### Task 4.1: Per-file + total caps
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py` (`PlanReviewer.__init__`, `_collect_plans`, `_assemble_prompt`).
+- Modify: `daemon/tests/test_specialist_plan_reviewer.py` (new tests for per-file + total caps).
+
+**Step 1: Failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_per_file_cap_truncates_individual_plans(tmp_path: Path) -> None:
+    """Plans longer than max_plan_chars get a truncation marker."""
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    big = "x" * 120_000
+    (plans_dir / "big.md").write_text(big)
+    _commit(tmp_path, "big plan")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(
+        brain=brain, repo=tmp_path, max_plan_chars=50_000, max_total_plan_chars=200_000
+    )
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # First 50,000 chars present; the rest elided with the marker.
+    assert "[... truncated:" in prompt
+    assert "70000" in prompt  # 120k − 50k = 70k elided
+    # The full 120k body must NOT appear.
+    assert prompt.count("x") <= 55_000  # small fuzzy margin for surrounding text
+
+
+@pytest.mark.asyncio
+async def test_total_cap_drops_remaining_plans(tmp_path: Path) -> None:
+    """Plans beyond max_total_plan_chars are replaced by a single summary marker."""
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    # 5 plans × 50k each = 250k, exceeds 200k total cap.
+    for i in range(5):
+        (plans_dir / f"p{i}.md").write_text("y" * 50_000)
+    _commit(tmp_path, "many plans")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(
+        brain=brain, repo=tmp_path, max_plan_chars=60_000, max_total_plan_chars=200_000
+    )
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # At least one plan must have landed, and at least one must have been skipped.
+    # Skipped plans surface under a '[... N plans omitted ...]'-style marker.
+    assert "plans omitted" in prompt or "plans elided" in prompt
+
+
+@pytest.mark.asyncio
+async def test_caps_have_sensible_defaults() -> None:
+    """Defaults: max_plan_chars=50_000, max_total_plan_chars=200_000.
+
+    Pins the defaults so a future change is deliberate.
+    """
+    reviewer = PlanReviewer(brain=MockBrain(), repo=Path("/tmp"))
+    assert reviewer._max_plan_chars == 50_000  # noqa: SLF001
+    assert reviewer._max_total_plan_chars == 200_000  # noqa: SLF001
+```
+
+**Step 2: Run tests — expect failure**
+
+`PlanReviewer.__init__` doesn't accept the kwargs; `_collect_plans` and `_assemble_prompt` don't truncate.
+
+**Step 3: Implement**
+
+Constructor kwargs:
+
+```python
+class PlanReviewer:
+    def __init__(
+        self,
+        brain: BrainInterface,
+        repo: Path,
+        *,
+        max_plan_chars: int = 50_000,
+        max_total_plan_chars: int = 200_000,
+    ) -> None:
+        """..."""  # (extend docstring)
+        self._brain = brain
+        self._repo = repo
+        self._max_plan_chars = max_plan_chars
+        self._max_total_plan_chars = max_total_plan_chars
+```
+
+Per-file truncation inside `_collect_plans` (apply AFTER the `read_text` succeeds, BEFORE appending to the readable list):
+
+```python
+def _truncate_plan_body(body: str, max_chars: int) -> str:
+    """Truncate ``body`` to ``max_chars`` with an inline marker if cut."""
+    if len(body) <= max_chars:
+        return body
+    elided = len(body) - max_chars
+    return body[:max_chars] + f"\n[... truncated: {elided} chars elided ...]\n"
+```
+
+Hook into `_collect_plans`: pass `max_chars` through from `review()` call site (since the function is a module-level helper, not a method — keep the signature explicit):
+
+```python
+def _collect_plans(
+    repo: Path,
+    max_chars_per_plan: int,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    # ... same as M3 structure, with:
+    readable.append((rel, _truncate_plan_body(content, max_chars_per_plan)))
+```
+
+Update `review()` to pass the cap: `plans, unreadable = _collect_plans(self._repo, max_chars_per_plan=self._max_plan_chars)`.
+
+Total-budget truncation inside `_assemble_prompt`: after assembling the individual `--- rel ---` + body blocks for each plan, track running char count; when the budget is exhausted, append a marker and stop adding plans.
+
+```python
+def _assemble_plans_block(
+    plans: list[tuple[str, str]],
+    max_total_chars: int,
+) -> list[str]:
+    """Build the plans section under a total char budget."""
+    parts: list[str] = ["=== PLANS ==="]
+    if not plans:
+        parts.append("(no plan or spec files discovered under conventional locations...)")
+        return parts
+
+    used = 0
+    included = 0
+    for rel, body in plans:
+        block = f"--- {rel} ---\n{body.rstrip(chr(10))}\n"
+        if used + len(block) > max_total_chars and included > 0:
+            remaining = len(plans) - included
+            parts.append(
+                f"[... {remaining} plan(s) omitted: total body "
+                f"budget of {max_total_chars} chars exhausted ...]"
+            )
+            break
+        parts.append(block.rstrip(chr(10)))
+        parts.append("")
+        used += len(block)
+        included += 1
+    return parts
+```
+
+Call from `_assemble_prompt` in place of the old inline plan-rendering loop. The existing `(no plans)` branch stays.
+
+**Step 4: Run tests — expect pass**
+
+```bash
+uv run pytest daemon/tests/test_specialist_plan_reviewer.py -q
+uv run mypy --strict daemon/src daemon/tests
+```
+
+Existing tests may need a small update where they construct `PlanReviewer` in the integration test at the bottom — add the new kwargs as default (they're keyword-only).
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(specialists/plan-reviewer): size caps on assembled prompt (#2)
+
+Constructor kwargs max_plan_chars (default 50_000) and
+max_total_plan_chars (default 200_000). Per-file truncation inside
+_collect_plans appends a visible marker ('[... truncated: N chars
+elided ...]'). Total-budget truncation inside _assemble_prompt stops
+adding plans once the cumulative budget is exceeded, replacing the
+rest with a single '[... N plan(s) omitted ...]' marker.
+
+Rationale: Claude's 200k-token context needs room for the diff + the
+brain's response + other sections; concatenating every plan's full
+body (this repo's own Phase-A plan is 3000+ lines) risks silent
+truncation at the SDK layer. Visible in-prompt truncation is better
+than silent mid-sentence cut-off.
+
+Defaults calibrated to real plan sizes in this repo; override via
+kwargs if sharp edges appear. YAGNI: no per-project config hook;
+change in one place if needed."
+```
+
+---
+
+## Milestone 5 — Fallback banner + missing test (#3)
+
+One-line banner on the diff text when `_capture_diff` falls back; add the missing test for the feature-branch-with-no-main-ref case.
+
+### Task 5.1: Banner + test coverage
+
+**Files:**
+- Modify: `daemon/src/reachy_ducky_daemon/specialists/plan_reviewer.py` (`_capture_diff`).
+- Modify: `daemon/tests/test_specialist_plan_reviewer.py` (new test).
+
+**Step 1: Failing test**
+
+The existing test suite has three `_capture_diff` scenarios covered (feature branch success, main with uncommitted, no plans). Missing: feature branch WHERE `main` ref doesn't exist.
+
+```python
+@pytest.mark.asyncio
+async def test_capture_diff_falls_back_when_main_ref_absent(tmp_path: Path) -> None:
+    """Feature branch but no 'main' ref → fall back to working-tree-vs-HEAD.
+
+    Banner: the fallback diff text starts with a one-line marker telling
+    the brain it came from the fallback path, not the merge-base diff.
+    """
+    # Init with default branch 'feat-alone' instead of 'main'.
+    _run("git", "init", "-b", "feat-alone", cwd=tmp_path)
+    _run("git", "config", "user.email", "test@example.com", cwd=tmp_path)
+    _run("git", "config", "user.name", "Test User", cwd=tmp_path)
+    _run("git", "config", "commit.gpgsign", "false", cwd=tmp_path)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    (tmp_path / "docs" / "plans" / "foo.md").write_text("# Plan Foo\n")
+    _commit(tmp_path, "initial")
+    # Make an uncommitted edit so `git diff` has output.
+    (tmp_path / "docs" / "plans" / "foo.md").write_text(
+        "# Plan Foo\nUNCOMMITTED_EDIT\n"
+    )
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(brain=brain, repo=tmp_path)
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+    # Fallback engaged — uncommitted edit surfaces.
+    assert "UNCOMMITTED_EDIT" in prompt
+    # Banner line sits at the top of the diff section.
+    diff_section = prompt.split("=== DIFF ===", 1)[1]
+    assert "(fallback:" in diff_section or "fallback:" in diff_section
+    assert "working-tree" in diff_section.lower() or "working tree" in diff_section.lower()
+```
+
+**Step 2: Run — expect failure**
+
+`(fallback: ...)` banner doesn't exist yet; the test fails at the banner assertion.
+
+**Step 3: Implement banner in `_capture_diff`**
+
+Inside the existing fallback branch (when `git diff main...HEAD` fails and we fall back to `git diff`), prefix the fallback output with a banner. Change the tail of `_capture_diff` from:
+
+```python
+    try:
+        fallback = _run_git(["diff"], cwd=repo)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "", f"git diff failed: {exc}"
+    if fallback.returncode != 0:
+        combined = fallback.stderr.strip() or "non-zero exit"
+        if fallback_err is not None:
+            return "", f"{fallback_err}; git diff (fallback) failed: {combined}"
+        return "", f"git diff failed: {combined}"
+    return fallback.stdout, fallback_err
+```
+
+To:
+
+```python
+    try:
+        fallback = _run_git(["diff"], cwd=repo)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "", f"git diff failed: {exc}"
+    if fallback.returncode != 0:
+        combined = fallback.stderr.strip() or "non-zero exit"
+        if fallback_err is not None:
+            return "", f"{fallback_err}; git diff (fallback) failed: {combined}"
+        return "", f"git diff failed: {combined}"
+    # Prepend a banner when we actually fell back from a merge-base diff
+    # (i.e., not the on-main path where fallback_err is None because there
+    # was no merge-base attempt in the first place). Lets the brain tell
+    # 'working-tree diff because on main' from 'working-tree diff because
+    # main ref is absent / merge-base failed'.
+    if fallback_err is not None and fallback.stdout:
+        banner = (
+            "(fallback: using working-tree-vs-HEAD diff; "
+            "merge-base against main was unavailable)\n"
+        )
+        return banner + fallback.stdout, fallback_err
+    return fallback.stdout, fallback_err
+```
+
+**Step 4: Run tests — expect pass**
+
+```bash
+uv run pytest daemon/tests/test_specialist_plan_reviewer.py -q
+uv run mypy --strict daemon/src daemon/tests
+```
+
+Existing `test_main_branch_fallback_includes_uncommitted_diff` test should continue to pass — on the main-branch path, `fallback_err` is `None` and the banner isn't prepended. Verify.
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(specialists/plan-reviewer): banner + test for merge-base fallback (#3)
+
+When `git diff main...HEAD` fails (main ref absent / shallow clone /
+whatever), PlanReviewer falls back to `git diff` (working-tree vs
+HEAD). Previously the brain couldn't tell that fallback had engaged —
+it just saw a diff without context. Now the diff text starts with a
+one-line banner:
+
+    (fallback: using working-tree-vs-HEAD diff; merge-base against
+    main was unavailable)
+
+Disambiguates 'working-tree diff because on main' from 'working-tree
+diff because main ref is absent'. No banner when falling back wasn't
+actually a fallback (on-main path), so the common case stays clean.
+
+Also adds the previously-missing test for the feature-branch-
+without-main-ref case (the fallback-when-failed-but-had-tried-merge-
+base branch, not the on-main branch).
+
+Closes #3."
+```
+
+---
+
+## Done / exit criteria
+
+When all 5 milestone commits are on `plan-reviewer-polish-sweep`:
+
+1. Run the full-branch gate:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy --strict daemon/src app/src menubar/src protocol/src daemon/tests protocol/tests menubar/tests app/tests
+uv run pyright
+uv run bandit -ll -r daemon/src app/src menubar/src protocol/src
+uv run pytest -q --cov
+```
+
+All clean. Coverage ≥ 90%.
+
+2. `grep -rn "TODO(#[2345])" daemon/` — should return 0 hits (all four in-code TODOs are resolved). `TODO(#8)` should also be gone — #8's TODO was never added as a code comment; it's resolved by the `_discover` filter.
+
+3. Push + open PR:
+
+```bash
+git push -u origin plan-reviewer-polish-sweep
+gh pr create --base main --title "refactor(specialists): PlanReviewer polish sweep (closes #2, #3, #4, #5, #8)" --body "<summary of each milestone's fix>"
+```
+
+4. Augment + Codex review; address + merge; all 5 issues auto-close via the `Closes` lines.
+
+5. Follow-ups NOT in scope: #19 (BrainRequest.include_tools prune), #6 (AppConfig errors), and the hardware-dependent #20 / #23 — still blocked on physical Reachy.


### PR DESCRIPTION
## Summary

PlanReviewer polish sweep — five open follow-ups closed as one coherent branch. All fixes share a theme: **surface what was silent** (API visibility, security enforcement, read errors, prompt bounds, mode switches).

- **M1 (#4)** — Promote `_list_plans` → `list_plans`. Drops the cross-subpackage underscore import from `specialists/plan_reviewer.py`. `_read_plan` and `_discover` stay private (security-validated read path).
- **M2 (#8)** — `_discover` filters symlinks resolving outside `base`. Security property lives at the resolution seam; `list_plans` + `_read_plan`'s membership check inherit it.
- **M3 (#5)** — `_collect_plans` returns `(readable, unreadable)`; `_assemble_prompt` surfaces unreadable entries under `=== UNREADABLE PLANS ===`. Parity with the `(diagnostic: ...)` pattern used by `_current_branch` and `_capture_diff`.
- **M4 (#2)** — Constructor kwargs `max_plan_chars=50_000`, `max_total_plan_chars=200_000`. Per-file truncation + total-budget truncation with visible in-prompt markers.
- **M5 (#3)** — `_capture_diff` prepends `(fallback: ...)` banner when falling back from a failed merge-base diff. On-main path (no merge-base attempt) stays banner-free.

Implementation matches the plan at `docs/plans/2026-04-23-plan-reviewer-polish-sweep.md` with four reviewer-driven improvements applied during code-review loops:

- `OSError` diagnostic uses `exc.strerror` (not `str(exc)`) to avoid leaking absolute filesystem paths into prompts sent to Claude (M3 follow-up, commit `b679e70`).
- Grammatical singular/plural `plan` vs `plans` in the omission marker (M4 follow-up, `40f30b1`).
- `max_plan_chars <= max_total_plan_chars` invariant documented in `__init__`; inline comment on the `included > 0` guard; drift-eliminated block construction in `_assemble_plans_block`; strengthened test covering insertion-order / exact-count / position (M4 follow-up, `40f30b1`).
- Position-anchored banner assertion on the first `diff --git` hunk header; negative assertion on the on-main regression test; banner documented in `_capture_diff` docstring; `(fallback:)` vs `(diagnostic:)` clarifying comment (M5 follow-up, `b5f1f94`).
- **Final-review fix:** `_assemble_plans_block` no longer emits the contradictory \"no plan or spec files discovered\" message when every discovered plan is unreadable (M3 + M4 interaction caught in the sweep-level review, commit `1009495`).

## Deferrals filed

- #55 — Ship ONNX-backed wake detector (out of scope; unrelated to this sweep but flagged during the parallel hardware-testing planning effort).
- #56 — Three minor plan-reviewer polish follow-ups from the final review (stale module docstring, invariant test, symlink-to-non-plan test).

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy --strict` full workspace (75 files) — 0 issues
- [x] `uv run pyright` CLI — 0 errors, 0 warnings, 0 informations
- [x] `uv run bandit -ll` — 0 issues
- [x] `uv run pytest -q --cov` — 597 passed, 5 skipped, 4 deselected; coverage 91.49% (floor 90%)
- [x] Targeted security repro: symlink under `docs/plans/` resolving to outside-root — zero leak to prompt, `list_plans` does not advertise
- [x] Targeted security repro: transitively-chained symlink escape (`a.md -> b.md -> /etc/hosts`) — zero leak
- [x] Targeted regression: all-unreadable-plan case emits non-contradictory prompt (see `test_prompt_has_no_contradiction_when_all_plans_unreadable`)

Closes #2, #3, #4, #5, #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)