### PR TITLE
fix(embodiment): ReachyMotionDriver.play_move resolves str to Move (closes #64)

### DIFF
--- a/app/src/reachy_ducky_app/embodiment/motion_driver.py
+++ b/app/src/reachy_ducky_app/embodiment/motion_driver.py
@@ -74,6 +74,10 @@ class ReachyMotionDriver(MotionDriver):
     default HuggingFace datasets (emotions + dances libraries). Libraries
     are lazy-loaded on the first ``play_move`` call so tests that only
     exercise ``go_to_sleep`` / ``wake_up`` don't trigger HF downloads.
+    Emotions library is searched first; same-name collisions resolve to
+    the emotions version (important because the state-machine's move
+    names — ``neutral``, ``listening``, ``thinking`` — come from the
+    emotions library).
     """
 
     def __init__(self, mini: object) -> None:
@@ -91,6 +95,18 @@ class ReachyMotionDriver(MotionDriver):
         Searches emotions library first, falls through to dances library.
         Raises ``ValueError`` with a clear message if the name is in
         neither — the SDK's own ``play_move`` would fail less helpfully.
+
+        The ``except ValueError`` narrows on miss by-contract with the
+        current SDK — ``RecordedMoves.get()`` raises ``ValueError`` only
+        when the name isn't in the dataset. Revisit this catch when
+        bumping ``reachy-mini`` (tracked in #60) if a future version
+        adds input validation that also raises ``ValueError``.
+
+        Dataset loading failures (HF cache corruption, network errors
+        in ``snapshot_download``) propagate from the FIRST
+        ``RecordedMoves(...)`` call and are NOT caught — those are
+        single-root-cause environment problems, not per-dataset
+        conditions. Silently falling through would hide the real issue.
         """
         if self._move_libraries is None:
             from reachy_mini.motion.recorded_move import (  # type: ignore[import-untyped]
@@ -106,7 +122,11 @@ class ReachyMotionDriver(MotionDriver):
                 return lib.get(name)  # type: ignore[attr-defined]
             except ValueError:
                 continue
-        raise ValueError(f"Move '{name}' not found in emotions or dances library")
+        raise ValueError(
+            f"Move '{name}' not found in emotions library "
+            f"(pollen-robotics/reachy-mini-emotions-library) or dances "
+            f"library (pollen-robotics/reachy-mini-dances-library)"
+        )
 
     def play_move(self, name: str) -> None:
         move = self._get_move(name)

--- a/app/src/reachy_ducky_app/embodiment/motion_driver.py
+++ b/app/src/reachy_ducky_app/embodiment/motion_driver.py
@@ -72,56 +72,68 @@ class ReachyMotionDriver(MotionDriver):
     Named moves (``"neutral"``, ``"listening"``, etc.) are resolved to
     SDK ``Move`` objects via ``RecordedMoves`` — the SDK ships two
     default HuggingFace datasets (emotions + dances libraries). Libraries
-    are lazy-loaded on the first ``play_move`` call so tests that only
-    exercise ``go_to_sleep`` / ``wake_up`` don't trigger HF downloads.
-    Emotions library is searched first; same-name collisions resolve to
-    the emotions version (important because the state-machine's move
-    names — ``neutral``, ``listening``, ``thinking`` — come from the
-    emotions library).
+    are lazy-loaded **per-library**: emotions on the first ``play_move``
+    call, dances only if that call misses emotions. Partial-cache
+    scenarios (emotions cached, dances unavailable) don't break
+    emotion-library moves. Emotions library is searched first; same-name
+    collisions resolve to the emotions version (important because the
+    state-machine's move names — ``neutral``, ``listening``,
+    ``thinking`` — come from the emotions library).
     """
 
     def __init__(self, mini: object) -> None:
         # Typed as object — the concrete type comes from reachy_mini which
         # may not be installed on a dev machine. Callers pass a ReachyMini.
         self._mini = mini
-        # Lazy: resolved on first play_move() call via _get_move. Tests
-        # inject a fake list here; production code triggers HF download
-        # on first access (cached to disk for subsequent sessions).
-        self._move_libraries: list[object] | None = None
+        # Per-library lazy: each dataset constructed on its own first
+        # access. Tests inject directly into these attrs; production code
+        # triggers HF download on first access (cached for later sessions).
+        self._emotions_library: object | None = None
+        self._dances_library: object | None = None
+
+    def _load_emotions_library(self) -> object:
+        if self._emotions_library is None:
+            from reachy_mini.motion.recorded_move import (  # type: ignore[import-untyped]
+                RecordedMoves,
+            )
+
+            self._emotions_library = RecordedMoves("pollen-robotics/reachy-mini-emotions-library")
+        return self._emotions_library
+
+    def _load_dances_library(self) -> object:
+        if self._dances_library is None:
+            from reachy_mini.motion.recorded_move import RecordedMoves
+
+            self._dances_library = RecordedMoves("pollen-robotics/reachy-mini-dances-library")
+        return self._dances_library
 
     def _get_move(self, name: str) -> object:
         """Resolve ``name`` to an SDK ``Move`` via RecordedMoves libraries.
 
-        Searches emotions library first, falls through to dances library.
-        Raises ``ValueError`` with a clear message if the name is in
-        neither — the SDK's own ``play_move`` would fail less helpfully.
+        Emotions library is tried first (it's the critical path — the
+        state-machine's move names ``neutral`` / ``listening`` /
+        ``thinking`` all live here). Dances library is only constructed
+        on an emotions miss, so users with a partial cache (emotions
+        cached but dances unavailable / offline) can still play emotions
+        moves. If emotions itself fails to construct (import error, HF
+        cache corrupt, network error), that error propagates — it is a
+        real environment problem and silent fall-through to dances would
+        hide it.
 
         The ``except ValueError`` narrows on miss by-contract with the
         current SDK — ``RecordedMoves.get()`` raises ``ValueError`` only
         when the name isn't in the dataset. Revisit this catch when
         bumping ``reachy-mini`` (tracked in #60) if a future version
         adds input validation that also raises ``ValueError``.
-
-        Dataset loading failures (HF cache corruption, network errors
-        in ``snapshot_download``) propagate from the FIRST
-        ``RecordedMoves(...)`` call and are NOT caught — those are
-        single-root-cause environment problems, not per-dataset
-        conditions. Silently falling through would hide the real issue.
         """
-        if self._move_libraries is None:
-            from reachy_mini.motion.recorded_move import (  # type: ignore[import-untyped]
-                RecordedMoves,
-            )
-
-            self._move_libraries = [
-                RecordedMoves("pollen-robotics/reachy-mini-emotions-library"),
-                RecordedMoves("pollen-robotics/reachy-mini-dances-library"),
-            ]
-        for lib in self._move_libraries:
-            try:
-                return lib.get(name)  # type: ignore[attr-defined]
-            except ValueError:
-                continue
+        try:
+            return self._load_emotions_library().get(name)  # type: ignore[attr-defined]
+        except ValueError:
+            pass  # emotions miss; fall through to dances
+        try:
+            return self._load_dances_library().get(name)  # type: ignore[attr-defined]
+        except ValueError:
+            pass
         raise ValueError(
             f"Move '{name}' not found in emotions library "
             f"(pollen-robotics/reachy-mini-emotions-library) or dances "

--- a/app/src/reachy_ducky_app/embodiment/motion_driver.py
+++ b/app/src/reachy_ducky_app/embodiment/motion_driver.py
@@ -68,15 +68,49 @@ class ReachyMotionDriver(MotionDriver):
     ``gstreamer-msvc-runtime`` platform-marker bug is patched at the
     workspace root via ``[tool.uv] dependency-metadata``). The caller
     constructs a ``ReachyMini`` and passes it in.
+
+    Named moves (``"neutral"``, ``"listening"``, etc.) are resolved to
+    SDK ``Move`` objects via ``RecordedMoves`` — the SDK ships two
+    default HuggingFace datasets (emotions + dances libraries). Libraries
+    are lazy-loaded on the first ``play_move`` call so tests that only
+    exercise ``go_to_sleep`` / ``wake_up`` don't trigger HF downloads.
     """
 
     def __init__(self, mini: object) -> None:
         # Typed as object — the concrete type comes from reachy_mini which
         # may not be installed on a dev machine. Callers pass a ReachyMini.
         self._mini = mini
+        # Lazy: resolved on first play_move() call via _get_move. Tests
+        # inject a fake list here; production code triggers HF download
+        # on first access (cached to disk for subsequent sessions).
+        self._move_libraries: list[object] | None = None
+
+    def _get_move(self, name: str) -> object:
+        """Resolve ``name`` to an SDK ``Move`` via RecordedMoves libraries.
+
+        Searches emotions library first, falls through to dances library.
+        Raises ``ValueError`` with a clear message if the name is in
+        neither — the SDK's own ``play_move`` would fail less helpfully.
+        """
+        if self._move_libraries is None:
+            from reachy_mini.motion.recorded_move import (  # type: ignore[import-untyped]
+                RecordedMoves,
+            )
+
+            self._move_libraries = [
+                RecordedMoves("pollen-robotics/reachy-mini-emotions-library"),
+                RecordedMoves("pollen-robotics/reachy-mini-dances-library"),
+            ]
+        for lib in self._move_libraries:
+            try:
+                return lib.get(name)  # type: ignore[attr-defined]
+            except ValueError:
+                continue
+        raise ValueError(f"Move '{name}' not found in emotions or dances library")
 
     def play_move(self, name: str) -> None:
-        self._mini.play_move(name)  # type: ignore[attr-defined]
+        move = self._get_move(name)
+        self._mini.play_move(move)  # type: ignore[attr-defined]
 
     def go_to_sleep(self) -> None:
         self._mini.goto_sleep()  # type: ignore[attr-defined]

--- a/app/tests/test_reachy_motion_driver.py
+++ b/app/tests/test_reachy_motion_driver.py
@@ -1,0 +1,113 @@
+"""Unit tests for ``ReachyMotionDriver`` — the concrete SDK-backed driver.
+
+Tests inject a fake ``_move_libraries`` to exercise the resolver logic
+without downloading HuggingFace datasets. Hardware-tier verification
+that the real libraries return the real move names (``neutral``,
+``listening``, ``thinking``) is tracked in the hardware-testing plan
+(#23 / #20); out of scope here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from reachy_ducky_app.embodiment.motion_driver import ReachyMotionDriver
+
+
+class _FakeMove:
+    """Opaque Move-compatible stand-in (doesn't need to quack as ``Move`` —
+    we only verify it is what gets forwarded to the SDK's ``play_move``)."""
+
+
+class _FakeMoveLibrary:
+    """In-memory library stand-in: maps name→Move; raises ``ValueError`` like
+    the real ``RecordedMoves.get`` when the name is missing."""
+
+    def __init__(self, moves: dict[str, _FakeMove]) -> None:
+        self._moves = moves
+
+    def get(self, name: str) -> _FakeMove:
+        if name not in self._moves:
+            raise ValueError(f"not found: {name}")
+        return self._moves[name]
+
+
+def test_play_move_forwards_resolved_move_to_sdk() -> None:
+    """play_move("listening") resolves from libraries and forwards the Move
+    (not the string) to the SDK's play_move."""
+    mini = MagicMock()
+    driver = ReachyMotionDriver(mini)
+    listening_move = _FakeMove()
+    driver._move_libraries = [  # noqa: SLF001 — test injection seam
+        _FakeMoveLibrary({"listening": listening_move}),
+    ]
+
+    driver.play_move("listening")
+
+    mini.play_move.assert_called_once_with(listening_move)
+
+
+def test_play_move_searches_libraries_in_order() -> None:
+    """Missing from library 1 → falls through to library 2; earlier wins on
+    name collision."""
+    mini = MagicMock()
+    driver = ReachyMotionDriver(mini)
+    emotions_move = _FakeMove()
+    dances_move = _FakeMove()
+    pirouette_move = _FakeMove()
+    driver._move_libraries = [  # noqa: SLF001
+        _FakeMoveLibrary({"neutral": emotions_move}),
+        _FakeMoveLibrary({"neutral": dances_move, "pirouette": pirouette_move}),
+    ]
+
+    # Found in the first library — earlier wins on collision.
+    driver.play_move("neutral")
+    mini.play_move.assert_called_once_with(emotions_move)
+
+    mini.reset_mock()
+    # Missing from first, found in second.
+    driver.play_move("pirouette")
+    mini.play_move.assert_called_once_with(pirouette_move)
+
+
+def test_play_move_raises_when_name_missing_from_all_libraries() -> None:
+    """Unknown name → ValueError with a clear message naming the missing
+    move. SDK's ``play_move`` is NOT called."""
+    mini = MagicMock()
+    driver = ReachyMotionDriver(mini)
+    driver._move_libraries = [  # noqa: SLF001
+        _FakeMoveLibrary({"neutral": _FakeMove()}),
+        _FakeMoveLibrary({"wave": _FakeMove()}),
+    ]
+
+    with pytest.raises(ValueError, match="Move 'sprint' not found"):
+        driver.play_move("sprint")
+
+    mini.play_move.assert_not_called()
+
+
+def test_move_libraries_are_lazy_loaded_on_first_play_move() -> None:
+    """``__init__`` does NOT load HuggingFace datasets — that happens on the
+    first ``play_move`` call. Unit tests that never play a move pay zero
+    SDK / HF cost."""
+    mini = MagicMock()
+    driver = ReachyMotionDriver(mini)
+    # Fresh driver: move_libraries is None (not yet loaded).
+    assert driver._move_libraries is None  # noqa: SLF001
+
+
+def test_go_to_sleep_and_wake_up_bypass_move_resolution() -> None:
+    """``goto_sleep`` and ``wake_up`` forward directly to the SDK — they are
+    NOT move-library lookups. Touching _move_libraries stays lazy."""
+    mini = MagicMock()
+    driver = ReachyMotionDriver(mini)
+
+    driver.go_to_sleep()
+    mini.goto_sleep.assert_called_once()
+
+    driver.wake_up()
+    mini.wake_up.assert_called_once()
+
+    # Move libraries untouched — no HF download triggered.
+    assert driver._move_libraries is None  # noqa: SLF001

--- a/app/tests/test_reachy_motion_driver.py
+++ b/app/tests/test_reachy_motion_driver.py
@@ -97,6 +97,22 @@ def test_move_libraries_are_lazy_loaded_on_first_play_move() -> None:
     assert driver._move_libraries is None  # noqa: SLF001
 
 
+def test_play_move_reuses_loaded_libraries_across_calls() -> None:
+    """Second ``play_move`` call reuses the libraries loaded on the first
+    — no re-import, no re-construction. Catches regressions where a
+    refactor accidentally resets ``_move_libraries`` per call."""
+    mini = MagicMock()
+    driver = ReachyMotionDriver(mini)
+    lib = _FakeMoveLibrary({"a": _FakeMove(), "b": _FakeMove()})
+    driver._move_libraries = [lib]  # noqa: SLF001 — test injection seam
+
+    driver.play_move("a")
+    libs_after_first = driver._move_libraries  # noqa: SLF001
+
+    driver.play_move("b")
+    assert driver._move_libraries is libs_after_first  # noqa: SLF001
+
+
 def test_go_to_sleep_and_wake_up_bypass_move_resolution() -> None:
     """``goto_sleep`` and ``wake_up`` forward directly to the SDK — they are
     NOT move-library lookups. Touching _move_libraries stays lazy."""

--- a/app/tests/test_reachy_motion_driver.py
+++ b/app/tests/test_reachy_motion_driver.py
@@ -1,10 +1,10 @@
 """Unit tests for ``ReachyMotionDriver`` — the concrete SDK-backed driver.
 
-Tests inject a fake ``_move_libraries`` to exercise the resolver logic
-without downloading HuggingFace datasets. Hardware-tier verification
-that the real libraries return the real move names (``neutral``,
-``listening``, ``thinking``) is tracked in the hardware-testing plan
-(#23 / #20); out of scope here.
+Tests inject fakes into ``_emotions_library`` / ``_dances_library`` to
+exercise the resolver logic without downloading HuggingFace datasets.
+Hardware-tier verification that the real libraries return the real move
+names (``neutral``, ``listening``, ``thinking``) is tracked in the
+hardware-testing plan (#23 / #20); out of scope here.
 """
 
 from __future__ import annotations
@@ -39,9 +39,8 @@ def test_play_move_forwards_resolved_move_to_sdk() -> None:
     mini = MagicMock()
     driver = ReachyMotionDriver(mini)
     listening_move = _FakeMove()
-    driver._move_libraries = [  # noqa: SLF001 — test injection seam
-        _FakeMoveLibrary({"listening": listening_move}),
-    ]
+    # Inject emotions; dances stays lazy (None).
+    driver._emotions_library = _FakeMoveLibrary({"listening": listening_move})  # noqa: SLF001
 
     driver.play_move("listening")
 
@@ -49,24 +48,24 @@ def test_play_move_forwards_resolved_move_to_sdk() -> None:
 
 
 def test_play_move_searches_libraries_in_order() -> None:
-    """Missing from library 1 → falls through to library 2; earlier wins on
+    """Emotions tried first; dances only on emotions miss. Earlier wins on
     name collision."""
     mini = MagicMock()
     driver = ReachyMotionDriver(mini)
     emotions_move = _FakeMove()
     dances_move = _FakeMove()
     pirouette_move = _FakeMove()
-    driver._move_libraries = [  # noqa: SLF001
-        _FakeMoveLibrary({"neutral": emotions_move}),
-        _FakeMoveLibrary({"neutral": dances_move, "pirouette": pirouette_move}),
-    ]
+    driver._emotions_library = _FakeMoveLibrary({"neutral": emotions_move})  # noqa: SLF001
+    driver._dances_library = _FakeMoveLibrary(  # noqa: SLF001
+        {"neutral": dances_move, "pirouette": pirouette_move}
+    )
 
-    # Found in the first library — earlier wins on collision.
+    # Found in emotions — earlier wins on collision.
     driver.play_move("neutral")
     mini.play_move.assert_called_once_with(emotions_move)
 
     mini.reset_mock()
-    # Missing from first, found in second.
+    # Missing from emotions, found in dances.
     driver.play_move("pirouette")
     mini.play_move.assert_called_once_with(pirouette_move)
 
@@ -76,10 +75,8 @@ def test_play_move_raises_when_name_missing_from_all_libraries() -> None:
     move. SDK's ``play_move`` is NOT called."""
     mini = MagicMock()
     driver = ReachyMotionDriver(mini)
-    driver._move_libraries = [  # noqa: SLF001
-        _FakeMoveLibrary({"neutral": _FakeMove()}),
-        _FakeMoveLibrary({"wave": _FakeMove()}),
-    ]
+    driver._emotions_library = _FakeMoveLibrary({"neutral": _FakeMove()})  # noqa: SLF001
+    driver._dances_library = _FakeMoveLibrary({"wave": _FakeMove()})  # noqa: SLF001
 
     with pytest.raises(ValueError, match="Move 'sprint' not found"):
         driver.play_move("sprint")
@@ -87,35 +84,36 @@ def test_play_move_raises_when_name_missing_from_all_libraries() -> None:
     mini.play_move.assert_not_called()
 
 
-def test_move_libraries_are_lazy_loaded_on_first_play_move() -> None:
-    """``__init__`` does NOT load HuggingFace datasets — that happens on the
-    first ``play_move`` call. Unit tests that never play a move pay zero
-    SDK / HF cost."""
+def test_libraries_are_lazy_init() -> None:
+    """``__init__`` does NOT load HuggingFace datasets — each library is
+    constructed on its own first access. Unit tests that never play a
+    move pay zero SDK / HF cost."""
     mini = MagicMock()
     driver = ReachyMotionDriver(mini)
-    # Fresh driver: move_libraries is None (not yet loaded).
-    assert driver._move_libraries is None  # noqa: SLF001
+    # Fresh driver: both libraries are None (not yet loaded).
+    assert driver._emotions_library is None  # noqa: SLF001
+    assert driver._dances_library is None  # noqa: SLF001
 
 
 def test_play_move_reuses_loaded_libraries_across_calls() -> None:
-    """Second ``play_move`` call reuses the libraries loaded on the first
+    """Second ``play_move`` call reuses the library loaded on the first
     — no re-import, no re-construction. Catches regressions where a
-    refactor accidentally resets ``_move_libraries`` per call."""
+    refactor accidentally resets the library attr per call."""
     mini = MagicMock()
     driver = ReachyMotionDriver(mini)
     lib = _FakeMoveLibrary({"a": _FakeMove(), "b": _FakeMove()})
-    driver._move_libraries = [lib]  # noqa: SLF001 — test injection seam
+    driver._emotions_library = lib  # noqa: SLF001 — test injection seam
 
     driver.play_move("a")
-    libs_after_first = driver._move_libraries  # noqa: SLF001
+    lib_after_first = driver._emotions_library  # noqa: SLF001
 
     driver.play_move("b")
-    assert driver._move_libraries is libs_after_first  # noqa: SLF001
+    assert driver._emotions_library is lib_after_first  # noqa: SLF001
 
 
 def test_go_to_sleep_and_wake_up_bypass_move_resolution() -> None:
     """``goto_sleep`` and ``wake_up`` forward directly to the SDK — they are
-    NOT move-library lookups. Touching _move_libraries stays lazy."""
+    NOT move-library lookups. Library attrs stay lazy (both None)."""
     mini = MagicMock()
     driver = ReachyMotionDriver(mini)
 
@@ -126,4 +124,26 @@ def test_go_to_sleep_and_wake_up_bypass_move_resolution() -> None:
     mini.wake_up.assert_called_once()
 
     # Move libraries untouched — no HF download triggered.
-    assert driver._move_libraries is None  # noqa: SLF001
+    assert driver._emotions_library is None  # noqa: SLF001
+    assert driver._dances_library is None  # noqa: SLF001
+
+
+def test_emotions_hit_does_not_load_dances() -> None:
+    """A successful emotions lookup must not touch the dances library.
+
+    This is the partial-cache resilience property (Codex PR #67): users
+    with emotions cached but dances unavailable (no network + cache
+    miss) must still be able to play emotions moves. Verifies dances
+    library construction is NOT triggered when emotions has the move.
+    """
+    mini = MagicMock()
+    driver = ReachyMotionDriver(mini)
+    emotions_move = _FakeMove()
+    driver._emotions_library = _FakeMoveLibrary({"neutral": emotions_move})  # noqa: SLF001
+    # _dances_library intentionally left None — mimicking dances unavailable.
+
+    driver.play_move("neutral")
+
+    mini.play_move.assert_called_once_with(emotions_move)
+    # Dances library was never touched.
+    assert driver._dances_library is None  # noqa: SLF001


### PR DESCRIPTION
## Summary

Fixes #64 — pre-existing latent bug surfaced during #65's attribute audit. The state-machine passes move names as strings (\`"neutral"\`, \`"listening"\`, \`"thinking"\`) to \`driver.play_move(name)\`, but the SDK's \`ReachyMini.play_move\` expects a \`Move\` object. Unit tests mock the driver so it's invisible today; hardware tests (M1/M2 of the refreshed hardware-testing plan #66) will surface it.

## Fix

Adapter in \`ReachyMotionDriver\` using the SDK's native \`RecordedMoves\` class. Lazy-loads two default HuggingFace datasets on the first \`play_move\` call:

- \`pollen-robotics/reachy-mini-emotions-library\` (searched first — state-machine names come from here)
- \`pollen-robotics/reachy-mini-dances-library\`

Libraries are reused across subsequent calls (proven by new idempotence test). No new deps — uses \`reachy_mini.motion.recorded_move.RecordedMoves\` which is already in the base install. If a name isn't in either library, raises \`ValueError\` naming both dataset slugs so a debugging user can open the HF datasets and see what's available.

## What's NOT changing

- \`MotionDriver\` ABC — keeps string contract; this is an internal adapter.
- \`MockMotionDriver\` — still records strings; unit tests don't need real Moves.
- \`EmbodimentStateMachine\`'s \`dict[State, str]\` mapping — unchanged.
- No new Python deps or pyproject.toml changes.

## Commits

- \`f4214d1\` — core adapter + 5 tests (spec + code-quality review approved).
- \`fb569ed\` — doc + error-message polish + idempotence regression test:
  - Expanded \`ValueError\` message to name both HF dataset slugs.
  - Documented the \`except ValueError\` narrow-by-contract with current SDK (revisit on #60 upgrades).
  - Documented that dataset-loading failures propagate eagerly (HF cache / network errors are NOT caught).
  - Documented emotions-first ordering on same-name collisions.
  - Added \`test_play_move_reuses_loaded_libraries_across_calls\` regression guard.

## Gates

- \`ruff check .\` clean
- \`ruff format --check .\` clean (76 files)
- \`mypy --strict\` — 0 issues
- \`pyright\` CLI — 0/0/0
- \`bandit -ll\` — 0 issues
- \`pytest -q --cov\` — **607 passed**, 5 deselected; coverage **91.56%** (up from 91.49%, driven by the 6 new tests).

## Unblocks

- **#23 / #20** (hardware audio I/O + mute coordination — M1/M2 of the hardware-testing plan at PR #59 / refresh at #66). Their hardware smokes exercise motion transitions and would fail confusingly against a broken \`play_move\`.

## Test plan

- [x] Unit tests injecting fake move libraries cover forward-the-Move, earlier-library-wins, not-found-raises, lazy-init, bypass-paths, and second-call idempotence.
- [x] Local gates green; coverage above floor.
- [ ] Hardware smoke validation deferred to #23's M1 execution (confirms the move names \`"neutral"\`, \`"listening"\`, \`"thinking"\` actually exist in the emotions library on a connected robot).

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)