### PR TITLE
feat(app/voice): hardware audio I/O aligned with conversation-app reference (M1 Tasks 1.1-1.4)

### DIFF
--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -78,8 +78,8 @@ class ReachyDuckyApp:
         driver = ReachyMotionDriver(reachy_mini)
         sm = EmbodimentStateMachine(driver=driver)
         voice = OpenAIRealtimeVoice(
-            mic=load_default_mic_source(),
-            speaker=load_default_speaker_sink(),
+            mic=load_default_mic_source(reachy_mini=reachy_mini),
+            speaker=load_default_speaker_sink(reachy_mini=reachy_mini),
         )
         daemon = DaemonClient.from_env()
         wake = load_default_wake_detector()

--- a/app/src/reachy_ducky_app/voice/audio_io.py
+++ b/app/src/reachy_ducky_app/voice/audio_io.py
@@ -139,22 +139,27 @@ class ReachySpeakerSink(SpeakerSink):
         await loop.run_in_executor(None, push, float32)
 
 
-def load_default_mic_source() -> MicSource:
-    """Factory for the production mic source.
+def load_default_mic_source(reachy_mini: object | None = None) -> MicSource:
+    """Return :class:`ReachyMicSource` when ``reachy_mini`` is given, else mock.
 
-    Phase A returns a silent :class:`MockMicSource`. A follow-up issue
-    swaps in a ``ReachyMicSource`` once the Reachy audio API is bound;
-    callers should never instantiate the mock directly outside tests.
+    The on-robot Pollen daemon hands :meth:`ReachyDuckyApp.run` a live
+    ``ReachyMini`` instance; :meth:`ReachyDuckyApp._run_async` threads it
+    through this factory so production is hardware by default. Dev
+    machines and unit tests pass ``None`` (the default) and get the
+    silent :class:`MockMicSource`.
     """
-    return MockMicSource()
+    if reachy_mini is None:
+        return MockMicSource()
+    return ReachyMicSource(reachy_mini)
 
 
-def load_default_speaker_sink() -> SpeakerSink:
-    """Factory for the production speaker sink.
+def load_default_speaker_sink(reachy_mini: object | None = None) -> SpeakerSink:
+    """Return :class:`ReachySpeakerSink` when ``reachy_mini`` is given, else mock.
 
-    Phase A returns a dropping :class:`MockSpeakerSink`. A follow-up
-    issue swaps in a ``ReachySpeakerSink`` once the Reachy audio API is
-    bound; callers should never instantiate the mock directly outside
-    tests.
+    Symmetric with :func:`load_default_mic_source` — production path
+    selects the hardware-backed adapter when the on-robot daemon hands
+    us a live ``ReachyMini``; dev/unit path keeps the silent mock.
     """
-    return MockSpeakerSink()
+    if reachy_mini is None:
+        return MockSpeakerSink()
+    return ReachySpeakerSink(reachy_mini)

--- a/app/src/reachy_ducky_app/voice/audio_io.py
+++ b/app/src/reachy_ducky_app/voice/audio_io.py
@@ -17,8 +17,11 @@ handles base64 framing at the connection boundary.
 
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Sequence
+
+import numpy as np
 
 
 class MicSource(ABC):
@@ -62,6 +65,44 @@ class MockSpeakerSink(SpeakerSink):
 
     async def play(self, pcm: bytes) -> None:
         self.played.append(pcm)
+
+
+class ReachyMicSource(MicSource):
+    """Hardware-backed mic source: pulls PCM frames from the ReachyMini SDK.
+
+    Wraps ``ReachyMini.media.get_audio_sample()`` in an async generator.
+    The SDK call is synchronous and runs on an executor so the voice
+    event loop isn't blocked.
+
+    **Format conversion at the adapter boundary.** The SDK returns
+    ``npt.NDArray[np.float32]`` (values in ``[-1.0, 1.0]`` per the
+    ``MediaManager`` contract); the :class:`MicSource` ABC yields PCM16
+    mono 24 kHz bytes (matches the OpenAI Realtime API downstream).
+    This class converts float32 → PCM16-bytes per frame: clip to
+    ``[-1, 1]``, scale by 32767, cast to int16, ``.tobytes()``. If a
+    future SDK version returns a different dtype, the
+    :mod:`test_sdk_audio_contract` drift guard fails first.
+
+    **Hardware-only.** Constructors take a duck-typed ``reachy_mini``
+    whose ``.media`` exposes ``get_audio_sample()``; the factory
+    :func:`load_default_mic_source` selects this impl over
+    :class:`MockMicSource` when a non-None ``reachy_mini`` is passed
+    (Task 1.4).
+    """
+
+    def __init__(self, reachy_mini: object) -> None:
+        self._mini = reachy_mini
+
+    async def frames(self) -> AsyncIterator[bytes]:
+        """Yield PCM16 bytes until the SDK returns None or an empty buffer."""
+        loop = asyncio.get_running_loop()
+        get_sample = self._mini.media.get_audio_sample  # type: ignore[attr-defined]
+        while True:
+            frame = await loop.run_in_executor(None, get_sample)
+            if frame is None or frame.size == 0:
+                return
+            pcm16 = (np.clip(frame, -1.0, 1.0) * 32767).astype(np.int16)
+            yield pcm16.tobytes()
 
 
 def load_default_mic_source() -> MicSource:

--- a/app/src/reachy_ducky_app/voice/audio_io.py
+++ b/app/src/reachy_ducky_app/voice/audio_io.py
@@ -119,13 +119,25 @@ class ReachyMicSource(MicSource):
         self._mini = reachy_mini
 
     async def frames(self) -> AsyncIterator[AudioFrame]:
-        """Yield ``(24000, int16 mono)`` tuples until the SDK returns ``None``."""
+        """Yield (24 kHz, int16 mono) tuples in a long-running loop.
+
+        The SDK's ``get_audio_sample()`` returns ``None`` transiently while
+        GStreamer buffers warm up (documented in
+        :mod:`test_sdk_audio_contract`). We poll with a brief sleep on
+        ``None`` rather than treating it as end-of-stream — the mic is
+        always recording; only task cancellation should terminate this
+        generator.
+        """
         loop = asyncio.get_running_loop()
         get_sample = self._mini.media.get_audio_sample  # type: ignore[attr-defined]
         while True:
             sample = await loop.run_in_executor(None, get_sample)
             if sample is None:
-                return
+                # Buffer empty — wait briefly so we don't busy-loop the
+                # executor. 10 ms is shorter than a typical audio frame
+                # (~40 ms @ 24 kHz).
+                await asyncio.sleep(0.01)
+                continue
             # Collapse stereo (N, 2) → mono. Pick channel 0 per the
             # conversation-app reference (openai_realtime.py:760).
             mono = sample[:, 0] if sample.ndim == 2 else sample

--- a/app/src/reachy_ducky_app/voice/audio_io.py
+++ b/app/src/reachy_ducky_app/voice/audio_io.py
@@ -3,16 +3,17 @@
 Mirrors the :class:`~reachy_ducky_app.wake.WakeDetector` +
 :class:`~reachy_ducky_app.embodiment.motion_driver.MotionDriver` pattern:
 define a narrow ABC, ship a ``MockImpl`` unit-testable without hardware,
-ship a ``load_default_*`` factory that returns the mock today and will
-return a hardware-backed impl once the Reachy audio API is bound
-(tracked as a follow-up).
+ship a ``load_default_*`` factory that returns the mock today and the
+hardware-backed impl when a ``ReachyMini`` is wired through.
 
-Audio format: PCM16 little-endian at 24 kHz mono — the format the
-OpenAI Realtime API expects on both input and output. The SDK's
-``input_audio_buffer.append`` and ``response.output_audio.delta`` events
-carry audio as base64-encoded strings; callers of :class:`MicSource`
-and :class:`SpeakerSink` work in raw PCM bytes, and the voice layer
-handles base64 framing at the connection boundary.
+Audio shape: :data:`AudioFrame` = ``(sample_rate, int16 mono ndarray)``.
+The reference conversation app
+(``pollen-robotics/reachy_mini_conversation_app``) carries audio between
+its mic-pump, LLM session, and head-wobble driver as raw
+``(sample_rate, ndarray)`` tuples. We mirror that here so parallel
+consumers (head wobble, transcript-synced lighting, VU meter) can read
+the same frame at different rates without resampling twice — see
+``console.py:625-628`` in the reference for the canonical example.
 """
 
 from __future__ import annotations
@@ -20,145 +21,194 @@ from __future__ import annotations
 import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Sequence
+from typing import cast
 
 import numpy as np
+import numpy.typing as npt
+import scipy.signal
+
+# ``AudioFrame = (sample_rate, int16 mono ndarray)``. Matches the raw-tuple
+# shape used by pollen-robotics/reachy_mini_conversation_app's
+# AsyncStreamHandler pattern (console.py:569-630) so our adapters are
+# composable with parallel consumers like an audio-driven head-wobble
+# driver without resampling twice. The mono constraint is deliberate —
+# OpenAI Realtime expects mono PCM16 and the reference pipeline collapses
+# stereo → left channel at the adapter boundary. PEP 695 ``type`` syntax
+# (Python 3.12+) is canonical here per ruff UP040.
+type AudioFrame = tuple[int, npt.NDArray[np.int16]]
+
+# Module-level constants for clarity at the call sites.
+_SDK_AUDIO_RATE = 16000  # ``AudioBase.SAMPLE_RATE`` from the reachy_mini SDK.
+_LLM_AUDIO_RATE = 24000  # OpenAI Realtime default PCM16 mono.
 
 
 class MicSource(ABC):
-    """Async source of PCM16 mono 24 kHz mic frames."""
+    """Async source of :data:`AudioFrame` tuples from a mic.
+
+    Each frame is ``(sample_rate, int16 mono samples)``. The sample rate
+    is carried explicitly (not implicit to the ABC) so upstream consumers
+    can resample or route to rate-specific sinks without peeking into a
+    subclass. The reference conversation app threads the same int16
+    ndarray into BOTH a resampling LLM handler AND a head-wobble driver
+    at different rates — tuples make that trivial.
+    """
 
     @abstractmethod
-    def frames(self) -> AsyncIterator[bytes]:
-        """Yield PCM audio frames until the turn ends or the source closes."""
+    def frames(self) -> AsyncIterator[AudioFrame]:
+        """Yield audio frames until the turn ends or the source closes."""
 
 
 class SpeakerSink(ABC):
-    """Async sink that plays PCM16 mono 24 kHz frames through a speaker."""
+    """Async sink that plays :data:`AudioFrame` tuples through a speaker."""
 
     @abstractmethod
-    async def play(self, pcm: bytes) -> None:
-        """Play one PCM frame. Implementations may buffer internally."""
+    async def play(self, frame: AudioFrame) -> None:
+        """Play one ``(sample_rate, int16 mono samples)`` frame."""
 
 
 class MockMicSource(MicSource):
-    """Replays a scripted sequence of PCM frames then terminates.
+    """Replays a scripted sequence of :data:`AudioFrame` tuples then terminates.
 
     Default behaviour yields nothing — a bare ``MockMicSource()`` simulates
-    a silent mic (stream ends immediately). Pass ``frames=[b"...", ...]``
-    to replay a scripted payload sequence — useful for driving the full
-    turn orchestration in tests.
+    a silent mic (stream ends immediately). Pass
+    ``frames=[(sample_rate, ndarray), ...]`` to replay a scripted payload
+    sequence — useful for driving the full turn orchestration in tests.
     """
 
-    def __init__(self, frames: Sequence[bytes] | None = None) -> None:
+    def __init__(self, frames: Sequence[AudioFrame] | None = None) -> None:
         self._frames = tuple(frames) if frames is not None else ()
 
-    async def frames(self) -> AsyncIterator[bytes]:
+    async def frames(self) -> AsyncIterator[AudioFrame]:
         for frame in self._frames:
             yield frame
 
 
 class MockSpeakerSink(SpeakerSink):
-    """Captures played PCM frames in order for test assertions."""
+    """Captures played :data:`AudioFrame` tuples in order for test assertions."""
 
     def __init__(self) -> None:
-        self.played: list[bytes] = []
+        self.played: list[AudioFrame] = []
 
-    async def play(self, pcm: bytes) -> None:
-        self.played.append(pcm)
+    async def play(self, frame: AudioFrame) -> None:
+        self.played.append(frame)
 
 
 class ReachyMicSource(MicSource):
-    """Hardware-backed mic source: pulls PCM frames from the ReachyMini SDK.
+    """Hardware-backed mic source: pulls frames from the ReachyMini SDK.
 
     Wraps ``ReachyMini.media.get_audio_sample()`` in an async generator.
     The SDK call is synchronous and runs on an executor so the voice
     event loop isn't blocked.
 
     **Format conversion at the adapter boundary.** The SDK returns
-    ``npt.NDArray[np.float32]`` (values in ``[-1.0, 1.0]`` per the
-    ``MediaManager`` contract); the :class:`MicSource` ABC yields PCM16
-    mono 24 kHz bytes (matches the OpenAI Realtime API downstream).
-    This class converts float32 → PCM16-bytes per frame: clip to
-    ``[-1, 1]``, scale by 32767, cast to int16, ``.tobytes()``. If a
-    future SDK version returns a different dtype, the
-    :mod:`test_sdk_audio_contract` drift guard fails first.
+    ``float32 stereo (N, 2)`` at 16 kHz (``AudioBase.SAMPLE_RATE`` /
+    ``CHANNELS``); OpenAI Realtime expects ``int16 mono`` at 24 kHz. This
+    adapter collapses stereo → mono by picking the left channel
+    (matching ``openai_realtime.py:760`` in the reference), resamples
+    16 kHz → 24 kHz via :func:`scipy.signal.resample`, and casts to
+    int16 by ``np.clip(x, -1, 1) * 32767`` (matches
+    ``fastrtc.audio_to_int16`` which the reference uses).
 
-    **Hardware-only.** Constructors take a duck-typed ``reachy_mini``
+    **Hardware-only.** Constructor takes a duck-typed ``reachy_mini``
     whose ``.media`` exposes ``get_audio_sample()``; the factory
     :func:`load_default_mic_source` selects this impl over
-    :class:`MockMicSource` when a non-None ``reachy_mini`` is passed
-    (Task 1.4).
+    :class:`MockMicSource` when a non-None ``reachy_mini`` is passed.
     """
 
     def __init__(self, reachy_mini: object) -> None:
         self._mini = reachy_mini
 
-    async def frames(self) -> AsyncIterator[bytes]:
-        """Yield PCM16 bytes until the SDK returns None or an empty buffer."""
+    async def frames(self) -> AsyncIterator[AudioFrame]:
+        """Yield ``(24000, int16 mono)`` tuples until the SDK returns ``None``."""
         loop = asyncio.get_running_loop()
         get_sample = self._mini.media.get_audio_sample  # type: ignore[attr-defined]
         while True:
-            frame = await loop.run_in_executor(None, get_sample)
-            if frame is None or frame.size == 0:
+            sample = await loop.run_in_executor(None, get_sample)
+            if sample is None:
                 return
-            pcm16 = (np.clip(frame, -1.0, 1.0) * 32767).astype(np.int16)
-            yield pcm16.tobytes()
+            # Collapse stereo (N, 2) → mono. Pick channel 0 per the
+            # conversation-app reference (openai_realtime.py:760).
+            mono = sample[:, 0] if sample.ndim == 2 else sample
+            # Resample 16 kHz → 24 kHz. scipy.signal.resample is FFT-
+            # based; matches the reference pipeline. ``scipy.signal``
+            # ships no py.typed marker so pyright infers a union return
+            # type; the implementation always returns an ndarray when
+            # passed a 1-D array (the with-time variant returns a tuple,
+            # which we don't request) — cast to keep downstream typing
+            # strict.
+            resampled = cast(
+                npt.NDArray[np.float32],
+                scipy.signal.resample(mono, int(len(mono) * _LLM_AUDIO_RATE / _SDK_AUDIO_RATE)),
+            )
+            # Float32 [-1, 1] → int16 via * 32767 (matches
+            # fastrtc.audio_to_int16 which the reference uses).
+            int16 = (np.clip(resampled, -1.0, 1.0) * 32767).astype(np.int16)
+            yield (_LLM_AUDIO_RATE, int16)
 
 
 class ReachySpeakerSink(SpeakerSink):
-    """Hardware-backed speaker sink: pushes PCM frames to the ReachyMini SDK.
+    """Hardware-backed speaker sink: pushes frames to the ReachyMini SDK.
 
-    Wraps ``ReachyMini.media.push_audio_sample()``. Symmetric with
-    :class:`ReachyMicSource`: synchronous SDK call is dispatched to an
-    executor so the voice loop stays unblocked.
+    Symmetric with :class:`ReachyMicSource`: unpacks an
+    :data:`AudioFrame` tuple, converts int16 → float32 via
+    ``/ 32768`` (matches ``fastrtc.audio_to_float32`` and the
+    conversation-app reference — asymmetric with the mic's ``* 32767``
+    is a deliberate PCM16 round-trip pattern), resamples to the SDK's
+    16 kHz output rate via :func:`scipy.signal.resample`, and pushes
+    **mono** float32 to ``push_audio_sample``. The SDK auto-fans
+    mono → stereo internally (``media_manager.py:357-358``), so we do
+    NOT duplicate channels here.
 
-    **Format conversion at the adapter boundary.** The SpeakerSink ABC
-    takes PCM16 mono 24 kHz bytes (matches the OpenAI Realtime API
-    upstream); the SDK takes ``npt.NDArray[np.float32]`` (values in
-    ``[-1.0, 1.0]``). This class converts PCM16-bytes → float32 per
-    frame: ``np.frombuffer(pcm, dtype=np.int16).astype(np.float32)``
-    divided by 32767. If a future SDK version takes a different dtype,
-    the :mod:`test_sdk_audio_contract` drift guard fails first.
-
-    **Hardware-only.** Constructors take a duck-typed ``reachy_mini``
-    whose ``.media`` exposes ``push_audio_sample()``; the factory
-    :func:`load_default_speaker_sink` selects this impl over
-    :class:`MockSpeakerSink` when a non-None ``reachy_mini`` is passed
-    (Task 1.4).
+    **Hardware-only.** Same selection semantics as
+    :class:`ReachyMicSource` via :func:`load_default_speaker_sink`.
     """
 
     def __init__(self, reachy_mini: object) -> None:
         self._mini = reachy_mini
 
-    async def play(self, pcm: bytes) -> None:
-        """Play one PCM16 frame through the SDK speaker (async via executor)."""
+    async def play(self, frame: AudioFrame) -> None:
+        """Play one ``(sample_rate, int16 mono)`` frame through the SDK."""
+        sample_rate, samples = frame
         loop = asyncio.get_running_loop()
         push = self._mini.media.push_audio_sample  # type: ignore[attr-defined]
-        int16 = np.frombuffer(pcm, dtype=np.int16)
-        float32 = int16.astype(np.float32) / 32767
+        # int16 → float32 via / 32768 (fastrtc convention — asymmetric
+        # with mic's * 32767 is a deliberate PCM16 round-trip pattern).
+        float32: npt.NDArray[np.float32] = samples.astype(np.float32) / 32768.0
+        # Resample to SDK's 16 kHz if the incoming rate differs.
+        if sample_rate != _SDK_AUDIO_RATE:
+            # See note in ReachyMicSource on the scipy.signal.resample
+            # narrow-cast — same return-type-union issue here.
+            resampled = cast(
+                npt.NDArray[np.float32],
+                scipy.signal.resample(float32, int(len(float32) * _SDK_AUDIO_RATE / sample_rate)),
+            )
+            float32 = resampled.astype(np.float32)
         await loop.run_in_executor(None, push, float32)
 
 
-def load_default_mic_source(reachy_mini: object | None = None) -> MicSource:
+def load_default_mic_source(*, reachy_mini: object | None = None) -> MicSource:
     """Return :class:`ReachyMicSource` when ``reachy_mini`` is given, else mock.
 
     The on-robot Pollen daemon hands :meth:`ReachyDuckyApp.run` a live
     ``ReachyMini`` instance; :meth:`ReachyDuckyApp._run_async` threads it
     through this factory so production is hardware by default. Dev
     machines and unit tests pass ``None`` (the default) and get the
-    silent :class:`MockMicSource`.
+    silent :class:`MockMicSource`. ``reachy_mini`` is keyword-only so
+    future kwargs (e.g. M2's ``mute_gate``) can be added without
+    positional churn.
     """
     if reachy_mini is None:
         return MockMicSource()
     return ReachyMicSource(reachy_mini)
 
 
-def load_default_speaker_sink(reachy_mini: object | None = None) -> SpeakerSink:
+def load_default_speaker_sink(*, reachy_mini: object | None = None) -> SpeakerSink:
     """Return :class:`ReachySpeakerSink` when ``reachy_mini`` is given, else mock.
 
     Symmetric with :func:`load_default_mic_source` — production path
     selects the hardware-backed adapter when the on-robot daemon hands
     us a live ``ReachyMini``; dev/unit path keeps the silent mock.
+    Keyword-only ``reachy_mini`` for forward-compat (M2 mute gate).
     """
     if reachy_mini is None:
         return MockSpeakerSink()

--- a/app/src/reachy_ducky_app/voice/audio_io.py
+++ b/app/src/reachy_ducky_app/voice/audio_io.py
@@ -105,6 +105,40 @@ class ReachyMicSource(MicSource):
             yield pcm16.tobytes()
 
 
+class ReachySpeakerSink(SpeakerSink):
+    """Hardware-backed speaker sink: pushes PCM frames to the ReachyMini SDK.
+
+    Wraps ``ReachyMini.media.push_audio_sample()``. Symmetric with
+    :class:`ReachyMicSource`: synchronous SDK call is dispatched to an
+    executor so the voice loop stays unblocked.
+
+    **Format conversion at the adapter boundary.** The SpeakerSink ABC
+    takes PCM16 mono 24 kHz bytes (matches the OpenAI Realtime API
+    upstream); the SDK takes ``npt.NDArray[np.float32]`` (values in
+    ``[-1.0, 1.0]``). This class converts PCM16-bytes → float32 per
+    frame: ``np.frombuffer(pcm, dtype=np.int16).astype(np.float32)``
+    divided by 32767. If a future SDK version takes a different dtype,
+    the :mod:`test_sdk_audio_contract` drift guard fails first.
+
+    **Hardware-only.** Constructors take a duck-typed ``reachy_mini``
+    whose ``.media`` exposes ``push_audio_sample()``; the factory
+    :func:`load_default_speaker_sink` selects this impl over
+    :class:`MockSpeakerSink` when a non-None ``reachy_mini`` is passed
+    (Task 1.4).
+    """
+
+    def __init__(self, reachy_mini: object) -> None:
+        self._mini = reachy_mini
+
+    async def play(self, pcm: bytes) -> None:
+        """Play one PCM16 frame through the SDK speaker (async via executor)."""
+        loop = asyncio.get_running_loop()
+        push = self._mini.media.push_audio_sample  # type: ignore[attr-defined]
+        int16 = np.frombuffer(pcm, dtype=np.int16)
+        float32 = int16.astype(np.float32) / 32767
+        await loop.run_in_executor(None, push, float32)
+
+
 def load_default_mic_source() -> MicSource:
     """Factory for the production mic source.
 

--- a/app/src/reachy_ducky_app/voice/openai_realtime.py
+++ b/app/src/reachy_ducky_app/voice/openai_realtime.py
@@ -4,8 +4,9 @@ Wraps the OpenAI Python SDK's realtime WebSocket session behind our
 :class:`~reachy_ducky_app.voice.interface.VoiceInterface`. The SDK handles
 STT + TTS + turn-taking + barge-in at the protocol level; our job is to
 plumb the events through our narrow :class:`VoiceTurn` contract and to
-shuttle raw PCM between the :class:`MicSource` / :class:`SpeakerSink`
-abstractions and the SDK's base64-framed audio events.
+shuttle :data:`AudioFrame` tuples between the :class:`MicSource` /
+:class:`SpeakerSink` abstractions and the SDK's base64-framed audio
+events.
 
 **Not run in unit tests.** The stateful session methods require a live
 connection to OpenAI. Unit coverage is construction-shape only (API-key
@@ -41,8 +42,9 @@ so this module adapts:
    ``type`` literal is ``"conversation.item.input_audio_transcription.completed"``
    and whose ``.transcript`` attribute carries the text.
 
-4. **Mic in.** Raw PCM frames from the :class:`MicSource` are
-   base64-encoded and sent via
+4. **Mic in.** :data:`AudioFrame` tuples from the :class:`MicSource` are
+   unpacked at the network boundary: int16 samples are ``.tobytes()``'d,
+   base64-encoded, and sent via
    ``conn.input_audio_buffer.append(audio=<base64>)``. With the default
    server-VAD ``turn_detection``, the server commits the buffer and
    triggers transcription on its own — no explicit ``.commit()`` call is
@@ -53,9 +55,10 @@ so this module adapts:
 
 5. **Speaker out.** Assistant TTS audio arrives as a stream of
    ``ResponseAudioDeltaEvent`` (``response.output_audio.delta``) whose
-   ``.delta`` attribute is a base64-encoded PCM payload. We decode each
-   delta and forward the raw bytes to :meth:`SpeakerSink.play` — the
-   transport-tier implementation decides how to buffer and render.
+   ``.delta`` attribute is a base64-encoded PCM16 mono 24 kHz payload.
+   We decode each delta, wrap the int16 samples as an :data:`AudioFrame`
+   tuple, and forward to :meth:`SpeakerSink.play` — the transport-tier
+   implementation decides how to buffer, resample, and render.
 
 6. **Response create/cancel.** ``conn.response.create(response=params)`` —
    param field is ``output_modalities`` (not ``modalities`` as in the plan
@@ -100,6 +103,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+import numpy as np
 from openai.types.realtime import (
     RealtimeErrorEvent,
     ResponseAudioDeltaEvent,
@@ -108,14 +112,30 @@ from openai.types.realtime import (
 from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
     ConversationItemInputAudioTranscriptionCompletedEvent,
 )
+from openai.types.realtime.realtime_audio_config_input_param import (
+    RealtimeAudioConfigInputParam,
+)
+from openai.types.realtime.realtime_audio_config_output_param import (
+    RealtimeAudioConfigOutputParam,
+)
+from openai.types.realtime.realtime_audio_config_param import RealtimeAudioConfigParam
+from openai.types.realtime.realtime_audio_formats_param import AudioPCM
+from openai.types.realtime.realtime_session_create_request_param import (
+    RealtimeSessionCreateRequestParam,
+)
 
-from .audio_io import MicSource, SpeakerSink
+from .audio_io import AudioFrame, MicSource, SpeakerSink
 from .interface import VoiceInterface, VoiceTurn
 
 if TYPE_CHECKING:
     from openai.resources.realtime.realtime import AsyncRealtimeConnection
 
 logger = logging.getLogger(__name__)
+
+# OpenAI Realtime expects PCM16 mono at 24 kHz on both directions; ``AudioPCM``
+# in the SDK pins ``rate: Literal[24000]`` so this is the canonical sample
+# rate for both ``input_audio_buffer.append`` and ``response.output_audio.delta``.
+_LLM_AUDIO_RATE = 24000
 
 
 class OpenAIRealtimeVoiceTurn(VoiceTurn):
@@ -152,8 +172,9 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
         Two concurrent tasks run:
 
         * A **mic pump** that iterates :meth:`MicSource.frames`,
-          base64-encodes each raw PCM frame, and calls
-          ``connection.input_audio_buffer.append(audio=<base64>)``.
+          unpacks each :data:`AudioFrame` tuple at the network
+          boundary, ``.tobytes()`` + base64-encodes the int16 samples,
+          and calls ``connection.input_audio_buffer.append(audio=<base64>)``.
           With server-VAD turn_detection (the SDK default) the server
           decides when speech has ended and commits the buffer itself.
         * The **event drain** on ``self._connection``, which returns the
@@ -171,7 +192,13 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
 
         async def _pump_mic() -> None:
             async for frame in self._mic.frames():
-                b64 = base64.b64encode(frame).decode("ascii")
+                _sample_rate, int16 = frame
+                # OpenAI Realtime expects raw PCM16 little-endian bytes
+                # in base64. The mic adapter has already resampled to
+                # ``_LLM_AUDIO_RATE`` and cast to int16 — the network
+                # boundary just serializes.
+                pcm_bytes = int16.tobytes()
+                b64 = base64.b64encode(pcm_bytes).decode("ascii")
                 await self._connection.input_audio_buffer.append(audio=b64)
 
         pump_task = asyncio.create_task(_pump_mic())
@@ -218,8 +245,9 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
         text output modalities. The SDK streams audio chunks over the
         WebSocket as ``response.output_audio.delta`` events
         (:class:`ResponseAudioDeltaEvent`); each ``.delta`` field is a
-        base64-encoded PCM payload that we decode and forward to
-        :meth:`SpeakerSink.play`.
+        base64-encoded PCM16 mono 24 kHz payload that we decode, wrap as
+        an :data:`AudioFrame` tuple ``(24000, int16_array)``, and forward
+        to :meth:`SpeakerSink.play`.
 
         Drains the connection's event iterator until the terminal
         ``response.done`` (completed / cancelled / failed / incomplete)
@@ -240,8 +268,14 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
         )
         async for event in self._connection:
             if isinstance(event, ResponseAudioDeltaEvent):
-                pcm = base64.b64decode(event.delta)
-                await self._speaker.play(pcm)
+                pcm_bytes = base64.b64decode(event.delta)
+                int16 = np.frombuffer(pcm_bytes, dtype=np.int16)
+                # NOTE: ``np.frombuffer`` produces a read-only view over
+                # the decoded bytes. The downstream sink may need to
+                # reshape or apply post-processing; ``.copy()`` makes
+                # that safe and is cheap relative to the WebSocket I/O.
+                frame: AudioFrame = (_LLM_AUDIO_RATE, int16.copy())
+                await self._speaker.play(frame)
                 continue
             if isinstance(event, ResponseDoneEvent):
                 status = event.response.status
@@ -278,9 +312,9 @@ class OpenAIRealtimeVoice(VoiceInterface):
     ``mic`` and ``speaker`` are required. Production code wires them via
     :func:`~reachy_ducky_app.voice.audio_io.load_default_mic_source` and
     :func:`~reachy_ducky_app.voice.audio_io.load_default_speaker_sink`
-    (today a silent mock, eventually the Reachy hardware bindings).
-    Tests can pass :class:`MockMicSource` /
-    :class:`MockSpeakerSink` directly.
+    (today the silent mock or the hardware-backed adapter, depending on
+    whether a ``ReachyMini`` is supplied). Tests can pass
+    :class:`MockMicSource` / :class:`MockSpeakerSink` directly.
     """
 
     def __init__(
@@ -309,6 +343,14 @@ class OpenAIRealtimeVoice(VoiceInterface):
         our ``finally``-equivalent drives the SDK manager's ``__aexit__``
         and the websocket is released.
 
+        After the connection opens we issue a ``session.update`` to pin
+        PCM16 at 24 kHz on both directions explicitly — matching the
+        reference conversation app's
+        ``openai_realtime.py:504-521`` pattern. The Realtime API would
+        default to PCM16/24 kHz here too (it's the only ``AudioPCM`` rate
+        the SDK type allows), but the explicit pin documents intent and
+        protects against future SDK default drift.
+
         Lazy-imports :class:`openai.AsyncOpenAI` so unit tests that only
         exercise construction-shape don't pay the SDK's import cost.
         """
@@ -316,6 +358,23 @@ class OpenAIRealtimeVoice(VoiceInterface):
 
         client = AsyncOpenAI(api_key=self._api_key)
         async with client.realtime.connect(model=self._model) as connection:
+            # The SDK's ``AudioPCM`` pins ``rate: Literal[24000]`` — the
+            # only PCM rate the Realtime API accepts. Passing the literal
+            # ``24000`` directly satisfies the TypedDict; the
+            # ``_LLM_AUDIO_RATE`` constant elsewhere in the module
+            # documents the same value at the audio-conversion sites.
+            session_config = RealtimeSessionCreateRequestParam(
+                type="realtime",
+                audio=RealtimeAudioConfigParam(
+                    input=RealtimeAudioConfigInputParam(
+                        format=AudioPCM(type="audio/pcm", rate=24000),
+                    ),
+                    output=RealtimeAudioConfigOutputParam(
+                        format=AudioPCM(type="audio/pcm", rate=24000),
+                    ),
+                ),
+            )
+            await connection.session.update(session=session_config)
             yield OpenAIRealtimeVoiceTurn(
                 connection,
                 mic=self._mic,

--- a/app/src/reachy_ducky_app/voice/openai_realtime.py
+++ b/app/src/reachy_ducky_app/voice/openai_realtime.py
@@ -101,9 +101,11 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
+import numpy.typing as npt
+import scipy.signal
 from openai.types.realtime import (
     RealtimeErrorEvent,
     ResponseAudioDeltaEvent,
@@ -192,11 +194,26 @@ class OpenAIRealtimeVoiceTurn(VoiceTurn):
 
         async def _pump_mic() -> None:
             async for frame in self._mic.frames():
-                _sample_rate, int16 = frame
+                sample_rate, int16 = frame
+                # Resample to OpenAI's 24 kHz if the MicSource yields a
+                # different rate. Mirrors the reference's per-frame
+                # resample pattern (openai_realtime.py:763-764 in
+                # pollen-robotics/reachy_mini_conversation_app).
+                # ``ReachyMicSource`` always yields 24 kHz, but this
+                # guards future sources (sim, other hardware) against
+                # chipmunk/slow playback if they yield at a different
+                # rate.
+                if sample_rate != _LLM_AUDIO_RATE:
+                    resampled = cast(
+                        npt.NDArray[np.float32],
+                        scipy.signal.resample(
+                            int16.astype(np.float32),
+                            int(len(int16) * _LLM_AUDIO_RATE / sample_rate),
+                        ),
+                    )
+                    int16 = np.clip(resampled, -32768, 32767).astype(np.int16)
                 # OpenAI Realtime expects raw PCM16 little-endian bytes
-                # in base64. The mic adapter has already resampled to
-                # ``_LLM_AUDIO_RATE`` and cast to int16 — the network
-                # boundary just serializes.
+                # in base64. The network boundary just serializes.
                 pcm_bytes = int16.tobytes()
                 b64 = base64.b64encode(pcm_bytes).decode("ascii")
                 await self._connection.input_audio_buffer.append(audio=b64)

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -249,12 +249,12 @@ async def test_run_async_constructs_voice_with_default_mic_and_speaker(
     mic_factory_calls = 0
     speaker_factory_calls = 0
 
-    def _spy_mic_factory() -> MicSource:
+    def _spy_mic_factory(reachy_mini: object | None = None) -> MicSource:
         nonlocal mic_factory_calls
         mic_factory_calls += 1
         return MockMicSource()
 
-    def _spy_speaker_factory() -> SpeakerSink:
+    def _spy_speaker_factory(reachy_mini: object | None = None) -> SpeakerSink:
         nonlocal speaker_factory_calls
         speaker_factory_calls += 1
         return MockSpeakerSink()

--- a/app/tests/test_audio_io.py
+++ b/app/tests/test_audio_io.py
@@ -15,6 +15,7 @@ from reachy_ducky_app.voice.audio_io import (
     MockMicSource,
     MockSpeakerSink,
     ReachyMicSource,
+    ReachySpeakerSink,
     SpeakerSink,
     load_default_mic_source,
     load_default_speaker_sink,
@@ -149,3 +150,74 @@ async def test_reachy_mic_source_is_a_mic_source() -> None:
 
     src = ReachyMicSource(FakeMini())
     assert isinstance(src, MicSource)
+
+
+async def test_reachy_speaker_sink_converts_pcm16_to_float32() -> None:
+    """SpeakerSink ABC takes PCM16 bytes; SDK takes float32 ndarray in [-1, 1].
+
+    Adapter converts at the boundary: ``np.frombuffer(pcm, int16).astype(float32) / 32767``.
+    """
+    received: list[np.ndarray] = []
+
+    class FakeMedia:
+        def push_audio_sample(self, data: np.ndarray) -> None:
+            received.append(data)
+
+    class FakeMini:
+        media = FakeMedia()
+
+    # Construct a known PCM16 frame: int16 value 16384 = 0.5 float32 (approx).
+    int16_frame = np.full(480, 16384, dtype=np.int16)
+    pcm_bytes = int16_frame.tobytes()
+
+    sink = ReachySpeakerSink(FakeMini())
+    await sink.play(pcm_bytes)
+
+    assert len(received) == 1
+    forwarded = received[0]
+    assert forwarded.dtype == np.float32
+    assert forwarded.shape == (480,)
+    # 16384 / 32767 ≈ 0.5000153
+    np.testing.assert_allclose(forwarded, 16384 / 32767, rtol=1e-6)
+
+
+async def test_reachy_speaker_sink_forwards_multiple_frames() -> None:
+    """Multiple ``play()`` calls forward to the SDK in order."""
+    received: list[np.ndarray] = []
+
+    class FakeMedia:
+        def push_audio_sample(self, data: np.ndarray) -> None:
+            received.append(data)
+
+    class FakeMini:
+        media = FakeMedia()
+
+    sink = ReachySpeakerSink(FakeMini())
+
+    frame_a = np.full(480, 1000, dtype=np.int16).tobytes()
+    frame_b = np.full(480, -1000, dtype=np.int16).tobytes()
+    frame_c = np.zeros(480, dtype=np.int16).tobytes()
+
+    await sink.play(frame_a)
+    await sink.play(frame_b)
+    await sink.play(frame_c)
+
+    assert len(received) == 3
+    # Verify per-frame conversion correctness: positive, negative, zero.
+    np.testing.assert_allclose(received[0], 1000 / 32767, rtol=1e-6)
+    np.testing.assert_allclose(received[1], -1000 / 32767, rtol=1e-6)
+    np.testing.assert_allclose(received[2], 0.0, atol=1e-9)
+
+
+async def test_reachy_speaker_sink_is_a_speaker_sink() -> None:
+    """Structural: ReachySpeakerSink satisfies the SpeakerSink contract."""
+
+    class FakeMedia:
+        def push_audio_sample(self, data: np.ndarray) -> None:
+            pass
+
+    class FakeMini:
+        media = FakeMedia()
+
+    sink = ReachySpeakerSink(FakeMini())
+    assert isinstance(sink, SpeakerSink)

--- a/app/tests/test_audio_io.py
+++ b/app/tests/test_audio_io.py
@@ -221,3 +221,43 @@ async def test_reachy_speaker_sink_is_a_speaker_sink() -> None:
 
     sink = ReachySpeakerSink(FakeMini())
     assert isinstance(sink, SpeakerSink)
+
+
+def test_load_default_mic_source_returns_mock_when_reachy_mini_is_none() -> None:
+    """No reachy_mini -> MockMicSource (dev-machine / unit-test path)."""
+    src = load_default_mic_source(reachy_mini=None)
+    assert isinstance(src, MockMicSource)
+
+
+def test_load_default_mic_source_returns_hardware_impl_when_reachy_mini_given() -> None:
+    """A ReachyMini-like object -> ReachyMicSource.
+
+    Factory only checks truthiness; the returned adapter stores the
+    object for later ``frames()`` calls (which would then touch
+    ``.media.get_audio_sample``). A bare stand-in suffices here.
+    """
+
+    class FakeMini:
+        pass
+
+    src = load_default_mic_source(reachy_mini=FakeMini())
+    assert isinstance(src, ReachyMicSource)
+
+
+def test_load_default_speaker_sink_returns_mock_when_reachy_mini_is_none() -> None:
+    sink = load_default_speaker_sink(reachy_mini=None)
+    assert isinstance(sink, MockSpeakerSink)
+
+
+def test_load_default_speaker_sink_returns_hardware_impl_when_reachy_mini_given() -> None:
+    class FakeMini:
+        pass
+
+    sink = load_default_speaker_sink(reachy_mini=FakeMini())
+    assert isinstance(sink, ReachySpeakerSink)
+
+
+def test_load_default_factories_default_reachy_mini_to_none() -> None:
+    """Back-compat: factories callable with no args (returns mocks)."""
+    assert isinstance(load_default_mic_source(), MockMicSource)
+    assert isinstance(load_default_speaker_sink(), MockSpeakerSink)

--- a/app/tests/test_audio_io.py
+++ b/app/tests/test_audio_io.py
@@ -8,11 +8,13 @@ hardware-marked module and these stay unit-tier.
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 from reachy_ducky_app.voice.audio_io import (
     MicSource,
     MockMicSource,
     MockSpeakerSink,
+    ReachyMicSource,
     SpeakerSink,
     load_default_mic_source,
     load_default_speaker_sink,
@@ -76,3 +78,74 @@ def test_speaker_sink_is_abstract() -> None:
     """``SpeakerSink`` cannot be instantiated directly — it's an ABC."""
     with pytest.raises(TypeError):
         SpeakerSink()  # type: ignore[abstract]
+
+
+async def test_reachy_mic_source_yields_pcm16_frames_from_float32_source() -> None:
+    """``ReachyMicSource`` pulls float32 frames from the SDK and yields PCM16 bytes.
+
+    Pins the adapter-boundary conversion: the SDK returns
+    ``npt.NDArray[np.float32]`` in ``[-1, 1]``; the :class:`MicSource`
+    ABC yields PCM16 mono 24 kHz bytes (matches the OpenAI Realtime
+    API downstream). A scripted ``FakeMedia`` keeps this hardware-free.
+    """
+    scripted = [
+        np.full(480, 0.1, dtype=np.float32),
+        np.full(480, 0.2, dtype=np.float32),
+        np.full(480, 0.3, dtype=np.float32),
+    ]
+    expected_bytes = [(np.clip(f, -1.0, 1.0) * 32767).astype(np.int16).tobytes() for f in scripted]
+
+    class FakeMedia:
+        _i = 0
+        _scripted = scripted
+
+        def get_audio_sample(self) -> np.ndarray | None:
+            if FakeMedia._i >= len(FakeMedia._scripted):
+                return None
+            frame = FakeMedia._scripted[FakeMedia._i]
+            FakeMedia._i += 1
+            return frame
+
+    class FakeMini:
+        media = FakeMedia()
+
+    src = ReachyMicSource(FakeMini())
+    collected = [frame async for frame in src.frames()]
+
+    assert collected == expected_bytes
+
+
+async def test_reachy_mic_source_terminates_on_none_sentinel() -> None:
+    """Adapter stops when the SDK returns ``None`` (no more data available)."""
+    call_count = 0
+
+    class FakeMedia:
+        def get_audio_sample(self) -> np.ndarray | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count > 2:
+                return None
+            return np.full(480, 0.5, dtype=np.float32)
+
+    class FakeMini:
+        media = FakeMedia()
+
+    src = ReachyMicSource(FakeMini())
+    frames = [frame async for frame in src.frames()]
+
+    assert len(frames) == 2
+    assert call_count == 3  # two data frames + one None terminator
+
+
+async def test_reachy_mic_source_is_a_mic_source() -> None:
+    """``ReachyMicSource`` satisfies the :class:`MicSource` structural contract."""
+
+    class FakeMedia:
+        def get_audio_sample(self) -> np.ndarray | None:
+            return None
+
+    class FakeMini:
+        media = FakeMedia()
+
+    src = ReachyMicSource(FakeMini())
+    assert isinstance(src, MicSource)

--- a/app/tests/test_audio_io.py
+++ b/app/tests/test_audio_io.py
@@ -1,9 +1,11 @@
 """Tests for :mod:`reachy_ducky_app.voice.audio_io` — the pluggable audio I/O layer.
 
-Mirrors the :mod:`test_wake` shape: unit-test the mock impls and the
-load-default factory. The real Reachy-backed mic + speaker land later
-as a hardware-tier follow-up; when they do, those tests live in a
-hardware-marked module and these stay unit-tier.
+Mirrors the :mod:`test_wake` shape: unit-test the mock impls, the
+hardware-backed ``Reachy*`` adapters via ``FakeMedia`` /  ``FakeMini``
+fixtures, and the load-default factory selection. The ``FakeMedia`` mic
+fixture mimics the real SDK's ``(N, 2)`` stereo float32 output shape so
+the adapter's stereo→mono collapse path is exercised end-to-end without
+hardware.
 """
 
 from __future__ import annotations
@@ -11,6 +13,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from reachy_ducky_app.voice.audio_io import (
+    AudioFrame,
     MicSource,
     MockMicSource,
     MockSpeakerSink,
@@ -21,6 +24,54 @@ from reachy_ducky_app.voice.audio_io import (
     load_default_speaker_sink,
 )
 
+# Constants mirroring the adapter's internal SDK / LLM rates so test
+# fixtures and assertions don't accidentally drift from the source of
+# truth in audio_io.py.
+_SDK_RATE = 16000
+_LLM_RATE = 24000
+
+
+class _FakeMedia:
+    """Stand-in for ``reachy_mini.media.MediaManager`` covering the audio surface.
+
+    Mic side: pops scripted stereo (N, 2) float32 samples until exhausted,
+    then returns ``None`` to signal end-of-stream. Speaker side: appends
+    every ``push_audio_sample`` payload into ``pushed`` for assertions.
+    Also exposes the samplerate getters so the FakeMedia stays
+    forward-compatible if the adapter ever consults them (today it
+    hardcodes 16 kHz to match the real SDK's ``AudioBase.SAMPLE_RATE``).
+    """
+
+    def __init__(self, scripted: list[np.ndarray] | None = None) -> None:
+        self._scripted = list(scripted) if scripted is not None else []
+        self.pushed: list[np.ndarray] = []
+
+    def get_audio_sample(self) -> np.ndarray | None:
+        if not self._scripted:
+            return None
+        return self._scripted.pop(0)
+
+    def push_audio_sample(self, data: np.ndarray) -> None:
+        self.pushed.append(data)
+
+    def get_input_audio_samplerate(self) -> int:
+        return _SDK_RATE
+
+    def get_output_audio_samplerate(self) -> int:
+        return _SDK_RATE
+
+
+class _FakeMini:
+    """Stand-in for ``ReachyMini`` exposing only ``.media``."""
+
+    def __init__(self, media: _FakeMedia) -> None:
+        self.media = media
+
+
+# ---------------------------------------------------------------------------
+# Mock impl tests
+# ---------------------------------------------------------------------------
+
 
 async def test_mock_mic_source_default_yields_no_frames() -> None:
     """``MockMicSource()`` with no scripted frames terminates immediately.
@@ -30,41 +81,55 @@ async def test_mock_mic_source_default_yields_no_frames() -> None:
     through cleanly when no audio arrives.
     """
     mic = MockMicSource()
-    collected: list[bytes] = []
+    collected: list[AudioFrame] = []
     async for frame in mic.frames():
         collected.append(frame)
     assert collected == []
 
 
 async def test_mock_mic_source_replays_scripted_frames_in_order() -> None:
-    """Scripted frames are yielded in the order passed to ``__init__``."""
-    mic = MockMicSource(frames=[b"f1", b"f2", b"f3"])
-    collected: list[bytes] = []
+    """Scripted frames are yielded verbatim in the order passed to ``__init__``."""
+    f1: AudioFrame = (_LLM_RATE, np.array([1, 2, 3], dtype=np.int16))
+    f2: AudioFrame = (_LLM_RATE, np.array([4, 5, 6], dtype=np.int16))
+    mic = MockMicSource(frames=[f1, f2])
+
+    collected: list[AudioFrame] = []
     async for frame in mic.frames():
         collected.append(frame)
-    assert collected == [b"f1", b"f2", b"f3"]
+
+    assert len(collected) == 2
+    assert collected[0][0] == _LLM_RATE
+    np.testing.assert_array_equal(collected[0][1], f1[1])
+    assert collected[1][0] == _LLM_RATE
+    np.testing.assert_array_equal(collected[1][1], f2[1])
 
 
 async def test_mock_speaker_sink_accumulates_plays() -> None:
-    """``MockSpeakerSink.play`` records each PCM frame in call order."""
+    """``MockSpeakerSink.play`` records each :data:`AudioFrame` in call order."""
     sink = MockSpeakerSink()
-    await sink.play(b"x")
-    await sink.play(b"y")
-    assert sink.played == [b"x", b"y"]
+    frame_a: AudioFrame = (_LLM_RATE, np.array([1, 2], dtype=np.int16))
+    frame_b: AudioFrame = (_LLM_RATE, np.array([3, 4], dtype=np.int16))
+    await sink.play(frame_a)
+    await sink.play(frame_b)
+    assert len(sink.played) == 2
+    assert sink.played[0][0] == _LLM_RATE
+    np.testing.assert_array_equal(sink.played[0][1], frame_a[1])
+    np.testing.assert_array_equal(sink.played[1][1], frame_b[1])
+
+
+# ---------------------------------------------------------------------------
+# Factory tests
+# ---------------------------------------------------------------------------
 
 
 def test_load_default_mic_source_returns_mic_source() -> None:
-    """Phase A: the factory returns a :class:`MicSource` (today a mock).
-
-    Isinstance check guards the contract: callers depending on the ABC
-    don't break when the factory is swapped to a hardware impl later.
-    """
+    """Factory returns a :class:`MicSource` (today the mock with no kwargs)."""
     mic = load_default_mic_source()
     assert isinstance(mic, MicSource)
 
 
 def test_load_default_speaker_sink_returns_speaker_sink() -> None:
-    """Phase A: the factory returns a :class:`SpeakerSink` (today a mock)."""
+    """Factory returns a :class:`SpeakerSink` (today the mock with no kwargs)."""
     sink = load_default_speaker_sink()
     assert isinstance(sink, SpeakerSink)
 
@@ -81,166 +146,194 @@ def test_speaker_sink_is_abstract() -> None:
         SpeakerSink()  # type: ignore[abstract]
 
 
-async def test_reachy_mic_source_yields_pcm16_frames_from_float32_source() -> None:
-    """``ReachyMicSource`` pulls float32 frames from the SDK and yields PCM16 bytes.
+# ---------------------------------------------------------------------------
+# ReachyMicSource — hardware adapter mic path
+# ---------------------------------------------------------------------------
 
-    Pins the adapter-boundary conversion: the SDK returns
-    ``npt.NDArray[np.float32]`` in ``[-1, 1]``; the :class:`MicSource`
-    ABC yields PCM16 mono 24 kHz bytes (matches the OpenAI Realtime
-    API downstream). A scripted ``FakeMedia`` keeps this hardware-free.
+
+async def test_reachy_mic_source_collapses_resamples_and_casts_to_int16() -> None:
+    """The full mic conversion chain: stereo float32 → mono → 24 kHz int16 tuple.
+
+    Pins the canonical reference flow (``console.py:569-578``,
+    ``openai_realtime.py:760``):
+
+    1. SDK returns ``(N, 2)`` float32 at 16 kHz.
+    2. Adapter picks left channel → mono (N,).
+    3. Resamples 16 → 24 kHz via FFT-based ``scipy.signal.resample``
+       (target length ``N * 24000 / 16000 == 1.5 * N``).
+    4. Clips to ``[-1, 1]`` and casts ``* 32767`` → int16.
+    5. Yields ``(24000, int16_samples)`` tuple.
+
+    A constant 0.5 input lets us assert on a tight expected magnitude
+    band that survives FFT-resample numerical jitter at the edges.
     """
-    scripted = [
-        np.full(480, 0.1, dtype=np.float32),
-        np.full(480, 0.2, dtype=np.float32),
-        np.full(480, 0.3, dtype=np.float32),
-    ]
-    expected_bytes = [(np.clip(f, -1.0, 1.0) * 32767).astype(np.int16).tobytes() for f in scripted]
+    # 480 samples @ 16 kHz = 30 ms — a typical mic chunk.
+    stereo_frame = np.full((480, 2), 0.5, dtype=np.float32)
+    media = _FakeMedia(scripted=[stereo_frame])
+    src = ReachyMicSource(_FakeMini(media))
 
-    class FakeMedia:
-        _i = 0
-        _scripted = scripted
+    collected: list[AudioFrame] = []
+    async for frame in src.frames():
+        collected.append(frame)
 
-        def get_audio_sample(self) -> np.ndarray | None:
-            if FakeMedia._i >= len(FakeMedia._scripted):
-                return None
-            frame = FakeMedia._scripted[FakeMedia._i]
-            FakeMedia._i += 1
-            return frame
-
-    class FakeMini:
-        media = FakeMedia()
-
-    src = ReachyMicSource(FakeMini())
-    collected = [frame async for frame in src.frames()]
-
-    assert collected == expected_bytes
+    # Exactly one frame yielded then end-of-stream.
+    assert len(collected) == 1
+    sample_rate, int16 = collected[0]
+    assert sample_rate == _LLM_RATE
+    assert int16.dtype == np.int16
+    # Resample 16→24 kHz scales length by 1.5 — exact for this clean ratio.
+    assert int16.shape == (720,)
+    # Constant 0.5 in → ~16383 int16. FFT resample introduces small ringing
+    # at the boundaries, so check the steady-state interior with a tight
+    # tolerance and the full array with a slightly looser tolerance.
+    np.testing.assert_allclose(int16[100:-100], 16383, atol=20)
 
 
 async def test_reachy_mic_source_terminates_on_none_sentinel() -> None:
     """Adapter stops when the SDK returns ``None`` (no more data available)."""
-    call_count = 0
+    media = _FakeMedia(
+        scripted=[
+            np.full((480, 2), 0.1, dtype=np.float32),
+            np.full((480, 2), 0.2, dtype=np.float32),
+        ]
+    )
+    src = ReachyMicSource(_FakeMini(media))
 
-    class FakeMedia:
-        def get_audio_sample(self) -> np.ndarray | None:
-            nonlocal call_count
-            call_count += 1
-            if call_count > 2:
-                return None
-            return np.full(480, 0.5, dtype=np.float32)
-
-    class FakeMini:
-        media = FakeMedia()
-
-    src = ReachyMicSource(FakeMini())
     frames = [frame async for frame in src.frames()]
 
     assert len(frames) == 2
-    assert call_count == 3  # two data frames + one None terminator
+    # Second call after exhaustion would have returned None and ended the loop.
+
+
+async def test_reachy_mic_source_handles_mono_input_without_collapsing() -> None:
+    """Defensive: if the SDK ever returns mono ``(N,)``, adapter passes it through.
+
+    The real SDK only returns stereo ``(N, 2)`` per ``audio_base.py:61``,
+    but covering the mono branch keeps the conditional honest under
+    coverage and protects against an upstream simplification.
+    """
+    mono_frame = np.full(480, 0.25, dtype=np.float32)
+    media = _FakeMedia(scripted=[mono_frame])
+    src = ReachyMicSource(_FakeMini(media))
+
+    collected = [frame async for frame in src.frames()]
+
+    assert len(collected) == 1
+    sample_rate, int16 = collected[0]
+    assert sample_rate == _LLM_RATE
+    assert int16.dtype == np.int16
+    assert int16.shape == (720,)
 
 
 async def test_reachy_mic_source_is_a_mic_source() -> None:
     """``ReachyMicSource`` satisfies the :class:`MicSource` structural contract."""
-
-    class FakeMedia:
-        def get_audio_sample(self) -> np.ndarray | None:
-            return None
-
-    class FakeMini:
-        media = FakeMedia()
-
-    src = ReachyMicSource(FakeMini())
+    src = ReachyMicSource(_FakeMini(_FakeMedia(scripted=[])))
     assert isinstance(src, MicSource)
 
 
-async def test_reachy_speaker_sink_converts_pcm16_to_float32() -> None:
-    """SpeakerSink ABC takes PCM16 bytes; SDK takes float32 ndarray in [-1, 1].
+# ---------------------------------------------------------------------------
+# ReachySpeakerSink — hardware adapter speaker path
+# ---------------------------------------------------------------------------
 
-    Adapter converts at the boundary: ``np.frombuffer(pcm, int16).astype(float32) / 32767``.
+
+async def test_reachy_speaker_sink_resamples_and_pushes_mono_float32() -> None:
+    """Full speaker conversion chain: int16 24 kHz tuple → float32 16 kHz mono.
+
+    Pins the canonical reference flow:
+
+    1. ABC accepts ``(24000, int16 mono samples)`` tuple.
+    2. Adapter casts ``int16 / 32768`` → float32 in [-1, 1].
+    3. Resamples 24 → 16 kHz (target length ``N * 2/3``).
+    4. Pushes **mono** float32 to the SDK; the SDK auto-fans to stereo
+       internally per ``media_manager.py:357-358`` — we do NOT
+       duplicate channels at this layer.
     """
-    received: list[np.ndarray] = []
+    media = _FakeMedia()
+    sink = ReachySpeakerSink(_FakeMini(media))
 
-    class FakeMedia:
-        def push_audio_sample(self, data: np.ndarray) -> None:
-            received.append(data)
+    # 720 samples @ 24 kHz = 30 ms. Constant 16384 ≈ 0.5 float32.
+    int16_samples = np.full(720, 16384, dtype=np.int16)
+    frame: AudioFrame = (_LLM_RATE, int16_samples)
+    await sink.play(frame)
 
-    class FakeMini:
-        media = FakeMedia()
-
-    # Construct a known PCM16 frame: int16 value 16384 = 0.5 float32 (approx).
-    int16_frame = np.full(480, 16384, dtype=np.int16)
-    pcm_bytes = int16_frame.tobytes()
-
-    sink = ReachySpeakerSink(FakeMini())
-    await sink.play(pcm_bytes)
-
-    assert len(received) == 1
-    forwarded = received[0]
-    assert forwarded.dtype == np.float32
-    assert forwarded.shape == (480,)
-    # 16384 / 32767 ≈ 0.5000153
-    np.testing.assert_allclose(forwarded, 16384 / 32767, rtol=1e-6)
+    assert len(media.pushed) == 1
+    pushed = media.pushed[0]
+    assert pushed.dtype == np.float32
+    # 24 → 16 kHz drops length by 2/3 (exact for this clean ratio).
+    assert pushed.shape == (480,)
+    # Constant 16384 / 32768 = 0.5 expected; FFT ringing at edges, tight in middle.
+    np.testing.assert_allclose(pushed[60:-60], 16384 / 32768.0, atol=1e-3)
 
 
-async def test_reachy_speaker_sink_forwards_multiple_frames() -> None:
-    """Multiple ``play()`` calls forward to the SDK in order."""
-    received: list[np.ndarray] = []
+async def test_reachy_speaker_sink_skips_resample_when_rate_matches_sdk() -> None:
+    """If the incoming rate already equals the SDK rate, no resample happens.
 
-    class FakeMedia:
-        def push_audio_sample(self, data: np.ndarray) -> None:
-            received.append(data)
+    Length is preserved verbatim and values are the int16 / 32768 cast.
+    Pins the fast-path branch in ``ReachySpeakerSink.play``.
+    """
+    media = _FakeMedia()
+    sink = ReachySpeakerSink(_FakeMini(media))
 
-    class FakeMini:
-        media = FakeMedia()
+    int16_samples = np.full(480, 8192, dtype=np.int16)
+    frame: AudioFrame = (_SDK_RATE, int16_samples)
+    await sink.play(frame)
 
-    sink = ReachySpeakerSink(FakeMini())
+    assert len(media.pushed) == 1
+    pushed = media.pushed[0]
+    assert pushed.dtype == np.float32
+    assert pushed.shape == (480,)
+    # No resample → exact 8192 / 32768 = 0.25 everywhere.
+    np.testing.assert_allclose(pushed, 0.25, atol=1e-7)
 
-    frame_a = np.full(480, 1000, dtype=np.int16).tobytes()
-    frame_b = np.full(480, -1000, dtype=np.int16).tobytes()
-    frame_c = np.zeros(480, dtype=np.int16).tobytes()
+
+async def test_reachy_speaker_sink_forwards_multiple_frames_in_order() -> None:
+    """Multiple ``play()`` calls forward to the SDK in call order."""
+    media = _FakeMedia()
+    sink = ReachySpeakerSink(_FakeMini(media))
+
+    frame_a: AudioFrame = (_SDK_RATE, np.full(480, 1000, dtype=np.int16))
+    frame_b: AudioFrame = (_SDK_RATE, np.full(480, -1000, dtype=np.int16))
+    frame_c: AudioFrame = (_SDK_RATE, np.zeros(480, dtype=np.int16))
 
     await sink.play(frame_a)
     await sink.play(frame_b)
     await sink.play(frame_c)
 
-    assert len(received) == 3
-    # Verify per-frame conversion correctness: positive, negative, zero.
-    np.testing.assert_allclose(received[0], 1000 / 32767, rtol=1e-6)
-    np.testing.assert_allclose(received[1], -1000 / 32767, rtol=1e-6)
-    np.testing.assert_allclose(received[2], 0.0, atol=1e-9)
+    assert len(media.pushed) == 3
+    np.testing.assert_allclose(media.pushed[0], 1000 / 32768.0, rtol=1e-6)
+    np.testing.assert_allclose(media.pushed[1], -1000 / 32768.0, rtol=1e-6)
+    np.testing.assert_allclose(media.pushed[2], 0.0, atol=1e-9)
 
 
 async def test_reachy_speaker_sink_is_a_speaker_sink() -> None:
     """Structural: ReachySpeakerSink satisfies the SpeakerSink contract."""
-
-    class FakeMedia:
-        def push_audio_sample(self, data: np.ndarray) -> None:
-            pass
-
-    class FakeMini:
-        media = FakeMedia()
-
-    sink = ReachySpeakerSink(FakeMini())
+    sink = ReachySpeakerSink(_FakeMini(_FakeMedia()))
     assert isinstance(sink, SpeakerSink)
 
 
+# ---------------------------------------------------------------------------
+# Factory selection
+# ---------------------------------------------------------------------------
+
+
 def test_load_default_mic_source_returns_mock_when_reachy_mini_is_none() -> None:
-    """No reachy_mini -> MockMicSource (dev-machine / unit-test path)."""
+    """No ``reachy_mini=`` -> :class:`MockMicSource` (dev-machine / unit-test path)."""
     src = load_default_mic_source(reachy_mini=None)
     assert isinstance(src, MockMicSource)
 
 
 def test_load_default_mic_source_returns_hardware_impl_when_reachy_mini_given() -> None:
-    """A ReachyMini-like object -> ReachyMicSource.
+    """A ReachyMini-like object -> :class:`ReachyMicSource`.
 
     Factory only checks truthiness; the returned adapter stores the
     object for later ``frames()`` calls (which would then touch
     ``.media.get_audio_sample``). A bare stand-in suffices here.
     """
 
-    class FakeMini:
+    class _BareFakeMini:
         pass
 
-    src = load_default_mic_source(reachy_mini=FakeMini())
+    src = load_default_mic_source(reachy_mini=_BareFakeMini())
     assert isinstance(src, ReachyMicSource)
 
 
@@ -250,10 +343,10 @@ def test_load_default_speaker_sink_returns_mock_when_reachy_mini_is_none() -> No
 
 
 def test_load_default_speaker_sink_returns_hardware_impl_when_reachy_mini_given() -> None:
-    class FakeMini:
+    class _BareFakeMini:
         pass
 
-    sink = load_default_speaker_sink(reachy_mini=FakeMini())
+    sink = load_default_speaker_sink(reachy_mini=_BareFakeMini())
     assert isinstance(sink, ReachySpeakerSink)
 
 
@@ -261,3 +354,20 @@ def test_load_default_factories_default_reachy_mini_to_none() -> None:
     """Back-compat: factories callable with no args (returns mocks)."""
     assert isinstance(load_default_mic_source(), MockMicSource)
     assert isinstance(load_default_speaker_sink(), MockSpeakerSink)
+
+
+def test_load_default_factories_require_keyword_for_reachy_mini() -> None:
+    """``reachy_mini`` is keyword-only — positional args raise ``TypeError``.
+
+    Pins I-4 from the M1 review: future kwargs (e.g. M2's ``mute_gate``)
+    can be added without positional churn. A positional call here would
+    bypass that protection silently.
+    """
+
+    class _BareFakeMini:
+        pass
+
+    with pytest.raises(TypeError):
+        load_default_mic_source(_BareFakeMini())  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        load_default_speaker_sink(_BareFakeMini())  # type: ignore[misc]

--- a/app/tests/test_audio_io.py
+++ b/app/tests/test_audio_io.py
@@ -10,6 +10,9 @@ hardware.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+
 import numpy as np
 import pytest
 from reachy_ducky_app.voice.audio_io import (
@@ -35,9 +38,12 @@ class _FakeMedia:
     """Stand-in for ``reachy_mini.media.MediaManager`` covering the audio surface.
 
     Mic side: pops scripted stereo (N, 2) float32 samples until exhausted,
-    then returns ``None`` to signal end-of-stream. Speaker side: appends
-    every ``push_audio_sample`` payload into ``pushed`` for assertions.
-    Also exposes the samplerate getters so the FakeMedia stays
+    then raises :class:`asyncio.CancelledError` to simulate task-level
+    cancellation (the only correct way to terminate the adapter's
+    now-infinite polling loop — ``None`` is transient per
+    :mod:`test_sdk_audio_contract`). Speaker side: appends every
+    ``push_audio_sample`` payload into ``pushed`` for assertions. Also
+    exposes the samplerate getters so the FakeMedia stays
     forward-compatible if the adapter ever consults them (today it
     hardcodes 16 kHz to match the real SDK's ``AudioBase.SAMPLE_RATE``).
     """
@@ -48,7 +54,7 @@ class _FakeMedia:
 
     def get_audio_sample(self) -> np.ndarray | None:
         if not self._scripted:
-            return None
+            raise asyncio.CancelledError
         return self._scripted.pop(0)
 
     def push_audio_sample(self, data: np.ndarray) -> None:
@@ -173,8 +179,9 @@ async def test_reachy_mic_source_collapses_resamples_and_casts_to_int16() -> Non
     src = ReachyMicSource(_FakeMini(media))
 
     collected: list[AudioFrame] = []
-    async for frame in src.frames():
-        collected.append(frame)
+    with contextlib.suppress(asyncio.CancelledError):
+        async for frame in src.frames():
+            collected.append(frame)
 
     # Exactly one frame yielded then end-of-stream.
     assert len(collected) == 1
@@ -189,20 +196,47 @@ async def test_reachy_mic_source_collapses_resamples_and_casts_to_int16() -> Non
     np.testing.assert_allclose(int16[100:-100], 16383, atol=20)
 
 
-async def test_reachy_mic_source_terminates_on_none_sentinel() -> None:
-    """Adapter stops when the SDK returns ``None`` (no more data available)."""
-    media = _FakeMedia(
-        scripted=[
-            np.full((480, 2), 0.1, dtype=np.float32),
-            np.full((480, 2), 0.2, dtype=np.float32),
-        ]
-    )
-    src = ReachyMicSource(_FakeMini(media))
+async def test_reachy_mic_source_keeps_polling_on_transient_none() -> None:
+    """SDK returns None transiently while GStreamer warms up.
 
-    frames = [frame async for frame in src.frames()]
+    The adapter must keep polling — mic is always recording, only task
+    cancellation terminates. Pinning this so a future refactor that
+    accidentally converts None → end-of-stream gets caught before
+    reaching hardware (where startup would see 0 frames).
+    """
+    sequence: list[np.ndarray | None] = [
+        None,
+        None,
+        np.full((480, 2), 0.1, dtype=np.float32),
+        None,
+        np.full((480, 2), 0.2, dtype=np.float32),
+    ]
 
-    assert len(frames) == 2
-    # Second call after exhaustion would have returned None and ended the loop.
+    class _FakeMediaTransient:
+        _i = 0
+
+        def get_audio_sample(self) -> np.ndarray | None:
+            if _FakeMediaTransient._i >= len(sequence):
+                raise asyncio.CancelledError  # simulate task cancel
+            frame = sequence[_FakeMediaTransient._i]
+            _FakeMediaTransient._i += 1
+            return frame
+
+    class _FakeMiniTransient:
+        media = _FakeMediaTransient()
+
+    src = ReachyMicSource(_FakeMiniTransient())
+
+    collected: list[AudioFrame] = []
+    with contextlib.suppress(asyncio.CancelledError):
+        async for frame in src.frames():
+            collected.append(frame)
+
+    # Two non-None frames yielded despite Nones interleaved.
+    assert len(collected) == 2, f"expected 2 frames, got {len(collected)}"
+    # Both at the LLM rate.
+    for sr, _ in collected:
+        assert sr == _LLM_RATE
 
 
 async def test_reachy_mic_source_handles_mono_input_without_collapsing() -> None:
@@ -216,7 +250,10 @@ async def test_reachy_mic_source_handles_mono_input_without_collapsing() -> None
     media = _FakeMedia(scripted=[mono_frame])
     src = ReachyMicSource(_FakeMini(media))
 
-    collected = [frame async for frame in src.frames()]
+    collected: list[AudioFrame] = []
+    with contextlib.suppress(asyncio.CancelledError):
+        async for frame in src.frames():
+            collected.append(frame)
 
     assert len(collected) == 1
     sample_rate, int16 = collected[0]

--- a/app/tests/test_sdk_audio_contract.py
+++ b/app/tests/test_sdk_audio_contract.py
@@ -74,9 +74,31 @@ def test_media_manager_exposes_audio_sample_methods() -> None:
     )
 
 
+def test_media_manager_exposes_samplerate_methods() -> None:
+    """``MediaManager`` exposes the samplerate queries our adapter design relies on.
+
+    ``ReachyMicSource`` / ``ReachySpeakerSink`` hardcode ``_SDK_AUDIO_RATE
+    = 16000`` (matches ``AudioBase.SAMPLE_RATE``) for the resample math,
+    but the canonical reference (``console.py:571``) reads
+    ``get_input_audio_samplerate()`` / ``get_output_audio_samplerate()``
+    at runtime. Pinning the class-surface presence here means an upstream
+    rename surfaces in CI before our hardcoded value silently goes stale
+    — the kind of drift the M1 review flagged as invisible without an
+    explicit guard.
+    """
+    assert hasattr(MediaManager, "get_input_audio_samplerate"), (
+        "MediaManager.get_input_audio_samplerate missing — drift guard for "
+        "ReachyMicSource resample rate"
+    )
+    assert hasattr(MediaManager, "get_output_audio_samplerate"), (
+        "MediaManager.get_output_audio_samplerate missing — drift guard for "
+        "ReachySpeakerSink resample rate"
+    )
+
+
 @pytest.mark.hardware
-def test_get_audio_sample_returns_non_empty_buffer() -> None:
-    """``get_audio_sample`` eventually yields a non-empty float32 buffer.
+def test_get_audio_sample_returns_non_empty_stereo_buffer() -> None:
+    """``get_audio_sample`` eventually yields a non-empty stereo float32 array.
 
     The SDK documents ``Optional[NDArray[np.float32]]`` — ``None`` is a
     legitimate "GStreamer ring buffer has no data yet" response,
@@ -84,6 +106,11 @@ def test_get_audio_sample_returns_non_empty_buffer() -> None:
     flowing. Polls up to 2s so this pins "the method eventually yields"
     rather than "the method returns non-None on the first call"
     (which would race).
+
+    The ``(N, 2)`` shape is the real SDK contract (``audio_base.py:61`` —
+    ``np.frombuffer(..., dtype=np.float32).reshape(-1, 2)``). Pin it
+    explicitly so a shape change surfaces here before the adapter
+    silently produces corrupted audio at the channel-pick step.
     """
     mini = ReachyMini()
     deadline = time.monotonic() + 2.0
@@ -95,6 +122,9 @@ def test_get_audio_sample_returns_non_empty_buffer() -> None:
     assert sample is not None, "get_audio_sample kept returning None for 2s — mic not primed?"
     assert sample.size > 0, f"get_audio_sample yielded empty array ({sample!r})"
     assert sample.dtype == np.float32, f"expected float32 per SDK contract, got {sample.dtype}"
+    assert sample.ndim == 2 and sample.shape[1] == 2, (
+        f"expected stereo (N, 2) per audio_base.py:61, got {sample.shape}"
+    )
 
 
 @pytest.mark.hardware

--- a/app/tests/test_sdk_audio_contract.py
+++ b/app/tests/test_sdk_audio_contract.py
@@ -11,6 +11,8 @@ hit real hardware.
 from __future__ import annotations
 
 import inspect
+import logging
+import time
 
 import numpy as np
 import pytest
@@ -39,6 +41,11 @@ def test_media_manager_exposes_audio_sample_methods() -> None:
     ``ReachySpeakerSink`` implementations. Introspecting the class directly
     (not an instance) keeps this in the default tier with no live-robot
     requirement — catches the rename in CI before it hits hardware.
+
+    For ``get_audio_sample`` we pin "callable with no args" rather than
+    "exactly one parameter" — the real drift concern is the SDK growing
+    a required argument we don't supply, not adding a keyword arg with
+    a default (which keeps our call site working).
     """
     assert hasattr(MediaManager, "get_audio_sample"), (
         "MediaManager.get_audio_sample missing — ReachyMicSource can't source frames"
@@ -46,56 +53,74 @@ def test_media_manager_exposes_audio_sample_methods() -> None:
     assert hasattr(MediaManager, "push_audio_sample"), (
         "MediaManager.push_audio_sample missing — ReachySpeakerSink can't sink frames"
     )
-    # Also pin the parameterless call shape of get_audio_sample — we
-    # rely on calling it with no arguments. Signature check is class-
-    # level safe (``inspect.signature`` doesn't need an instance).
     sig = inspect.signature(MediaManager.get_audio_sample)
-    # self is the only parameter; no caller-supplied args.
-    assert len(sig.parameters) == 1, (
-        f"MediaManager.get_audio_sample unexpectedly accepts "
-        f"{list(sig.parameters)}; ReachyMicSource calls it with no args"
+    params = list(sig.parameters.values())
+    assert params and params[0].name == "self", (
+        f"MediaManager.get_audio_sample signature unexpected: {sig}"
+    )
+    non_self_required = [
+        p
+        for p in params[1:]
+        if p.default is inspect.Parameter.empty
+        and p.kind
+        not in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        )
+    ]
+    assert not non_self_required, (
+        f"get_audio_sample grew a required parameter we don't supply: "
+        f"{[p.name for p in non_self_required]}"
     )
 
 
 @pytest.mark.hardware
 def test_get_audio_sample_returns_non_empty_buffer() -> None:
-    """get_audio_sample returns a non-empty PCM buffer.
+    """``get_audio_sample`` eventually yields a non-empty float32 buffer.
 
-    Exact dtype/shape asserted in the refinement pass after Step 1
-    introspection. Today we pin only ``truthy``/``non-empty``.
+    The SDK documents ``Optional[NDArray[np.float32]]`` — ``None`` is a
+    legitimate "GStreamer ring buffer has no data yet" response,
+    especially on a fresh ``ReachyMini()`` where audio hasn't started
+    flowing. Polls up to 2s so this pins "the method eventually yields"
+    rather than "the method returns non-None on the first call"
+    (which would race).
     """
     mini = ReachyMini()
-    sample = mini.media.get_audio_sample()
-    assert sample is not None, "get_audio_sample returned None"
-    # bytes → len > 0; np.ndarray → size > 0
-    length = len(sample) if hasattr(sample, "__len__") else sample.size
-    assert length > 0, f"get_audio_sample returned empty buffer ({sample!r})"
+    deadline = time.monotonic() + 2.0
+    sample: np.ndarray | None = None
+    while time.monotonic() < deadline:
+        sample = mini.media.get_audio_sample()
+        if sample is not None and sample.size > 0:
+            break
+    assert sample is not None, "get_audio_sample kept returning None for 2s — mic not primed?"
+    assert sample.size > 0, f"get_audio_sample yielded empty array ({sample!r})"
+    assert sample.dtype == np.float32, f"expected float32 per SDK contract, got {sample.dtype}"
 
 
 @pytest.mark.hardware
-def test_push_audio_sample_accepts_silent_frame() -> None:
-    """push_audio_sample accepts a well-formed silent PCM frame.
+def test_push_audio_sample_accepts_silent_frame(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``push_audio_sample`` accepts a well-formed silent float32 frame.
 
     The SDK's MediaManager.push_audio_sample takes ``npt.NDArray[np.float32]``
-    per the installed ``reachy_mini.media.media_manager`` source. A PCM16
-    bytes payload would fail here — the ReachyMicSource/ReachySpeakerSink
-    impls in Tasks 1.2/1.3 handle format conversion at the boundary so
-    the MicSource/SpeakerSink ABC's PCM16-bytes contract (set by the
-    OpenAI Realtime API downstream) stays intact.
+    per the installed ``reachy_mini.media.media_manager`` source. The
+    ``MicSource`` / ``SpeakerSink`` ABC contract stays PCM16-bytes (matches
+    OpenAI Realtime API downstream); Tasks 1.2 / 1.3 handle
+    float32↔PCM16 conversion at the Reachy adapter boundary.
+
+    We assert not only that the call doesn't raise but also that it
+    emits no warning — the SDK silently logs a warning and returns on
+    wrong-shape input (media_manager.py:343-347), so a no-op silently
+    passing "must not raise" would be the accomplishment-simulator
+    anti-pattern ``testing-standards.md`` warns against.
     """
     mini = ReachyMini()
-    # 40ms @ 24 kHz mono float32 = 960 samples. If sample rate or dtype
-    # is different on real hardware, this test fails with a clear error
-    # and Task 1.5's refinement pass will tighten the shape.
+    # 40ms @ 24 kHz mono float32 = 960 samples.
     silent = np.zeros(960, dtype=np.float32)
-    mini.media.push_audio_sample(silent)  # must not raise
-
-
-@pytest.mark.hardware
-def test_get_audio_sample_signature_is_parameterless() -> None:
-    """Signature is () → buffer; we rely on calling without arguments."""
-    sig = inspect.signature(ReachyMini().media.get_audio_sample)
-    assert len(sig.parameters) == 0, (
-        f"get_audio_sample unexpectedly accepts {list(sig.parameters)}; "
-        "ReachyMicSource calls it with no arguments"
+    with caplog.at_level(logging.WARNING, logger="reachy_mini.media.media_manager"):
+        mini.media.push_audio_sample(silent)
+    assert not caplog.records, (
+        f"push_audio_sample logged warnings (data dropped silently): "
+        f"{[r.getMessage() for r in caplog.records]}"
     )

--- a/app/tests/test_sdk_audio_contract.py
+++ b/app/tests/test_sdk_audio_contract.py
@@ -1,0 +1,101 @@
+"""SDK contract — pin the ReachyMini audio surface used by #23 impls.
+
+Class-level introspection runs in the default unit tier (``reachy-mini``
+installs on every machine since PR #65). Instance-level live-robot
+checks are gated on ``@pytest.mark.hardware`` and run locally via
+``uv run pytest -m hardware`` against a LAN-reachable Reachy Mini —
+they catch upstream audio-API renames / signature changes before they
+hit real hardware.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+import pytest
+from reachy_mini import ReachyMini  # type: ignore[import-untyped]
+from reachy_mini.media.media_manager import MediaManager  # type: ignore[import-untyped]
+
+
+def test_reachy_mini_media_property_exists() -> None:
+    """``ReachyMini.media`` property is declared at class scope.
+
+    Class-level only — ``media`` is a ``@property`` so the descriptor lives
+    on the class even without instantiation. Proves the access path
+    ``mini.media.<method>`` is still valid without needing a live robot.
+    """
+    assert hasattr(ReachyMini, "media"), (
+        "ReachyMini.media property missing — can't source or sink frames"
+    )
+
+
+def test_media_manager_exposes_audio_sample_methods() -> None:
+    """``MediaManager`` class declares the two audio methods our impls call.
+
+    This is the critical default-tier drift guard: ``mini.media`` returns
+    a ``MediaManager`` instance, so renames on ``MediaManager.get_audio_sample`` /
+    ``push_audio_sample`` would silently break our ``ReachyMicSource`` /
+    ``ReachySpeakerSink`` implementations. Introspecting the class directly
+    (not an instance) keeps this in the default tier with no live-robot
+    requirement — catches the rename in CI before it hits hardware.
+    """
+    assert hasattr(MediaManager, "get_audio_sample"), (
+        "MediaManager.get_audio_sample missing — ReachyMicSource can't source frames"
+    )
+    assert hasattr(MediaManager, "push_audio_sample"), (
+        "MediaManager.push_audio_sample missing — ReachySpeakerSink can't sink frames"
+    )
+    # Also pin the parameterless call shape of get_audio_sample — we
+    # rely on calling it with no arguments. Signature check is class-
+    # level safe (``inspect.signature`` doesn't need an instance).
+    sig = inspect.signature(MediaManager.get_audio_sample)
+    # self is the only parameter; no caller-supplied args.
+    assert len(sig.parameters) == 1, (
+        f"MediaManager.get_audio_sample unexpectedly accepts "
+        f"{list(sig.parameters)}; ReachyMicSource calls it with no args"
+    )
+
+
+@pytest.mark.hardware
+def test_get_audio_sample_returns_non_empty_buffer() -> None:
+    """get_audio_sample returns a non-empty PCM buffer.
+
+    Exact dtype/shape asserted in the refinement pass after Step 1
+    introspection. Today we pin only ``truthy``/``non-empty``.
+    """
+    mini = ReachyMini()
+    sample = mini.media.get_audio_sample()
+    assert sample is not None, "get_audio_sample returned None"
+    # bytes → len > 0; np.ndarray → size > 0
+    length = len(sample) if hasattr(sample, "__len__") else sample.size
+    assert length > 0, f"get_audio_sample returned empty buffer ({sample!r})"
+
+
+@pytest.mark.hardware
+def test_push_audio_sample_accepts_silent_frame() -> None:
+    """push_audio_sample accepts a well-formed silent PCM frame.
+
+    The SDK's MediaManager.push_audio_sample takes ``npt.NDArray[np.float32]``
+    per the installed ``reachy_mini.media.media_manager`` source. A PCM16
+    bytes payload would fail here — the ReachyMicSource/ReachySpeakerSink
+    impls in Tasks 1.2/1.3 handle format conversion at the boundary so
+    the MicSource/SpeakerSink ABC's PCM16-bytes contract (set by the
+    OpenAI Realtime API downstream) stays intact.
+    """
+    mini = ReachyMini()
+    # 40ms @ 24 kHz mono float32 = 960 samples. If sample rate or dtype
+    # is different on real hardware, this test fails with a clear error
+    # and Task 1.5's refinement pass will tighten the shape.
+    silent = np.zeros(960, dtype=np.float32)
+    mini.media.push_audio_sample(silent)  # must not raise
+
+
+@pytest.mark.hardware
+def test_get_audio_sample_signature_is_parameterless() -> None:
+    """Signature is () → buffer; we rely on calling without arguments."""
+    sig = inspect.signature(ReachyMini().media.get_audio_sample)
+    assert len(sig.parameters) == 0, (
+        f"get_audio_sample unexpectedly accepts {list(sig.parameters)}; "
+        "ReachyMicSource calls it with no arguments"
+    )

--- a/app/tests/test_voice_openai_realtime.py
+++ b/app/tests/test_voice_openai_realtime.py
@@ -416,6 +416,55 @@ async def test_get_user_text_pumps_mic_frames_as_base64_append_events() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mic_send_path_resamples_non_24khz_frames() -> None:
+    """OpenAI Realtime expects 24 kHz PCM16; AudioFrame rate != 24 kHz
+    must be resampled before transmission.
+
+    Protects against a future MicSource (sim, different hardware)
+    yielding at a non-24 kHz rate — without this, bytes would be
+    interpreted at OpenAI's default 24 kHz and produce chipmunk /
+    slow audio. Mirrors the reference's per-frame resample
+    (openai_realtime.py:763-764 in
+    pollen-robotics/reachy_mini_conversation_app).
+    """
+    # Build a 16 kHz AudioFrame — two-thirds the OpenAI rate, so
+    # resample should scale the sample count by 24/16 = 1.5x before send.
+    source_rate = 16000
+    source_samples = np.full(480, 8000, dtype=np.int16)  # known value
+    mic = MockMicSource(frames=[(source_rate, source_samples)])
+    speaker = MockSpeakerSink()
+    connection = _FakeConnection(events=[_make_transcription_completed("hi")])
+
+    turn = OpenAIRealtimeVoiceTurn(connection, mic=mic, speaker=speaker)  # type: ignore[arg-type]
+
+    result = await asyncio.wait_for(turn.get_user_text(), timeout=1.0)
+
+    assert result == "hi"
+    # Frame was appended exactly once.
+    assert connection.input_audio_buffer.append.await_count == 1
+
+    # Extract the base64 payload and decode back to int16.
+    append_call = connection.input_audio_buffer.append.await_args
+    assert append_call is not None
+    b64_audio = append_call.kwargs["audio"]
+    pcm_bytes = base64.b64decode(b64_audio)
+    sent_int16 = np.frombuffer(pcm_bytes, dtype=np.int16)
+
+    # Resampled from 480 @ 16 kHz → 720 @ 24 kHz (1.5x). This
+    # specifically pins that the rate was honored — 480 bytes would
+    # indicate the rate was ignored (the bug) and 720 means the
+    # resample happened before send.
+    assert sent_int16.shape == (720,), (
+        f"expected 720 samples (480 × 24/16), got {sent_int16.shape} — "
+        "rate likely not honored before send"
+    )
+    # Constant-in → approximately-constant-out; FFT-resample introduces
+    # edge ringing, so check the steady-state interior with a tight
+    # tolerance.
+    np.testing.assert_allclose(sent_int16[100:-100], 8000, atol=20)
+
+
+@pytest.mark.asyncio
 async def test_get_user_text_cancels_mic_pump_on_transcription() -> None:
     """When transcription arrives, the mic pump task must be cancelled.
 

--- a/app/tests/test_voice_openai_realtime.py
+++ b/app/tests/test_voice_openai_realtime.py
@@ -19,6 +19,7 @@ from collections.abc import AsyncIterator
 from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock
 
+import numpy as np
 import pytest
 from openai.types.realtime import (
     RealtimeErrorEvent,
@@ -28,6 +29,7 @@ from openai.types.realtime import (
 from openai.types.realtime.realtime_error import RealtimeError
 from openai.types.realtime.realtime_response import RealtimeResponse
 from reachy_ducky_app.voice.audio_io import (
+    AudioFrame,
     MicSource,
     MockMicSource,
     MockSpeakerSink,
@@ -37,6 +39,16 @@ from reachy_ducky_app.voice.openai_realtime import (
     OpenAIRealtimeVoiceTurn,
 )
 
+# OpenAI Realtime fixed sample rate for PCM16 mono — matches the
+# ``AudioPCM`` literal in the SDK and the ``_LLM_AUDIO_RATE`` constant
+# in ``openai_realtime.py``.
+_LLM_RATE = 24000
+
+
+def _frame(samples: np.ndarray, *, rate: int = _LLM_RATE) -> AudioFrame:
+    """Tuple-builder helper to keep test fixtures readable."""
+    return (rate, samples.astype(np.int16))
+
 
 class _FakeConnection:
     """Scripted stand-in for ``openai`` ``AsyncRealtimeConnection``.
@@ -45,8 +57,8 @@ class _FakeConnection:
     event sequence. The iterator records which events were consumed
     (``observed``) so tests can assert the drain went all the way to
     the terminal event and no further. ``response.create`` /
-    ``response.cancel`` and ``input_audio_buffer.append`` are
-    ``AsyncMock`` s so tests can assert the outbound side-effects.
+    ``response.cancel`` / ``session.update`` and ``input_audio_buffer.append``
+    are ``AsyncMock`` s so tests can assert the outbound side-effects.
     """
 
     def __init__(self, events: list[Any]) -> None:
@@ -55,6 +67,8 @@ class _FakeConnection:
         self.response = MagicMock()
         self.response.create = AsyncMock()
         self.response.cancel = AsyncMock()
+        self.session = MagicMock()
+        self.session.update = AsyncMock()
         self.input_audio_buffer = MagicMock()
         self.input_audio_buffer.append = AsyncMock()
 
@@ -84,19 +98,20 @@ class _InfiniteMicSource(MicSource):
 
     def __init__(self) -> None:
         self.yielded: int = 0
+        self._silence: AudioFrame = (_LLM_RATE, np.zeros(480, dtype=np.int16))
 
-    async def frames(self) -> AsyncIterator[bytes]:
+    async def frames(self) -> AsyncIterator[AudioFrame]:
         while True:
             self.yielded += 1
-            yield b"silence"
+            yield self._silence
             await asyncio.sleep(0)
 
 
 class _RaisingMicSource(MicSource):
     """Mic stub that yields one frame then raises — exercises error propagation."""
 
-    async def frames(self) -> AsyncIterator[bytes]:
-        yield b"first"
+    async def frames(self) -> AsyncIterator[AudioFrame]:
+        yield (_LLM_RATE, np.array([1, 2, 3], dtype=np.int16))
         raise RuntimeError("mic lost")
 
 
@@ -110,9 +125,9 @@ class _ImmediateRaisingMicSource(MicSource):
     stored by the time ``get_user_text`` returns an early transcript.
     """
 
-    async def frames(self) -> AsyncIterator[bytes]:
+    async def frames(self) -> AsyncIterator[AudioFrame]:
         raise RuntimeError("mic dead")
-        yield b""  # pragma: no cover — unreachable; keeps the function an async generator
+        yield (_LLM_RATE, np.zeros(0, dtype=np.int16))  # pragma: no cover — unreachable
 
 
 def _make_response_done(
@@ -271,10 +286,12 @@ async def test_start_turn_enters_and_exits_sdk_connect_manager(
     """
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
-    # Fake AsyncRealtimeConnection: start_turn does not touch any of its
-    # attrs — it just yields it as the turn's .connection. A plain
-    # MagicMock is enough.
+    # Fake AsyncRealtimeConnection: start_turn calls
+    # ``connection.session.update(session=...)`` after entering the
+    # connect manager, so ``.session.update`` must be an AsyncMock.
     fake_connection = MagicMock(name="AsyncRealtimeConnection")
+    fake_connection.session = MagicMock()
+    fake_connection.session.update = AsyncMock()
 
     # Fake AsyncRealtimeConnectionManager: an async context manager.
     connect_manager = MagicMock(name="AsyncRealtimeConnectionManager")
@@ -306,6 +323,22 @@ async def test_start_turn_enters_and_exits_sdk_connect_manager(
         # Turn forwards mic + speaker from the voice factory.
         assert turn._mic is mic
         assert turn._speaker is speaker
+        # session.update was issued before the turn body runs — pinning
+        # PCM16 24 kHz on both directions per the conversation-app
+        # reference (openai_realtime.py:504-521).
+        fake_connection.session.update.assert_awaited_once()
+        await_args = fake_connection.session.update.await_args
+        assert await_args is not None
+        session_kwarg = await_args.kwargs["session"]
+        assert session_kwarg["type"] == "realtime"
+        assert session_kwarg["audio"]["input"]["format"] == {
+            "type": "audio/pcm",
+            "rate": 24000,
+        }
+        assert session_kwarg["audio"]["output"]["format"] == {
+            "type": "audio/pcm",
+            "rate": 24000,
+        }
 
     # After the async-with in this test exits: manager must have been exited.
     connect_manager.__aexit__.assert_awaited_once()
@@ -320,6 +353,8 @@ async def test_start_turn_exits_sdk_connect_manager_on_exception(
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     fake_connection = MagicMock(name="AsyncRealtimeConnection")
+    fake_connection.session = MagicMock()
+    fake_connection.session.update = AsyncMock()
 
     connect_manager = MagicMock(name="AsyncRealtimeConnectionManager")
     connect_manager.__aenter__ = AsyncMock(return_value=fake_connection)
@@ -350,14 +385,17 @@ async def test_start_turn_exits_sdk_connect_manager_on_exception(
 
 @pytest.mark.asyncio
 async def test_get_user_text_pumps_mic_frames_as_base64_append_events() -> None:
-    """Mic frames are base64-encoded and sent via ``input_audio_buffer.append``.
+    """Mic frames are unpacked, ``.tobytes()``-serialized, and base64-appended.
 
     The original P1 bug: ``get_user_text`` iterated server events without
     ever pushing audio in, so the transcription event could never arrive.
     Now the method spawns a concurrent pump task that drains the mic
-    source and calls ``append(audio=<base64>)`` for each frame.
+    source, unpacks each :data:`AudioFrame` tuple at the network
+    boundary, and calls ``append(audio=<base64>)`` for each frame.
     """
-    mic = MockMicSource(frames=[b"f1", b"f2"])
+    samples_a = np.array([1, 2, 3, 4], dtype=np.int16)
+    samples_b = np.array([5, 6, 7, 8], dtype=np.int16)
+    mic = MockMicSource(frames=[_frame(samples_a), _frame(samples_b)])
     speaker = MockSpeakerSink()
     connection = _FakeConnection(events=[_make_transcription_completed("hi")])
 
@@ -366,13 +404,14 @@ async def test_get_user_text_pumps_mic_frames_as_base64_append_events() -> None:
     result = await asyncio.wait_for(turn.get_user_text(), timeout=1.0)
 
     assert result == "hi"
-    # Both scripted frames were appended, in order, base64-encoded.
+    # Both scripted frames were appended, in order, base64-encoded from
+    # the underlying int16 ``.tobytes()``.
     assert connection.input_audio_buffer.append.await_count == 2
     connection.input_audio_buffer.append.assert_any_await(
-        audio=base64.b64encode(b"f1").decode("ascii")
+        audio=base64.b64encode(samples_a.tobytes()).decode("ascii")
     )
     connection.input_audio_buffer.append.assert_any_await(
-        audio=base64.b64encode(b"f2").decode("ascii")
+        audio=base64.b64encode(samples_b.tobytes()).decode("ascii")
     )
 
 
@@ -420,7 +459,7 @@ async def test_get_user_text_propagates_mic_errors() -> None:
 
     # The one pre-raise frame was pumped, proving the pump ran before failing.
     connection.input_audio_buffer.append.assert_awaited_once_with(
-        audio=base64.b64encode(b"first").decode("ascii")
+        audio=base64.b64encode(np.array([1, 2, 3], dtype=np.int16).tobytes()).decode("ascii")
     )
 
 
@@ -482,11 +521,14 @@ async def test_speak_text_pipes_audio_deltas_to_speaker() -> None:
 
     The original P1 bug: ``speak_text`` drained to ``response.done`` but
     ignored ``response.output_audio.delta`` events, so the robot's
-    speaker never heard the TTS audio. Now each delta is base64-decoded
-    and forwarded to ``speaker.play(pcm)``.
+    speaker never heard the TTS audio. Now each delta is base64-decoded,
+    wrapped as an :data:`AudioFrame` ``(24000, int16 ndarray)`` tuple,
+    and forwarded to ``speaker.play(frame)``.
     """
-    delta1 = _make_audio_delta(b"pcm1", event_id="a1")
-    delta2 = _make_audio_delta(b"pcm2", event_id="a2")
+    pcm_a = np.array([100, 200, 300], dtype=np.int16)
+    pcm_b = np.array([400, 500, 600], dtype=np.int16)
+    delta1 = _make_audio_delta(pcm_a.tobytes(), event_id="a1")
+    delta2 = _make_audio_delta(pcm_b.tobytes(), event_id="a2")
     done = _make_response_done("completed")
     connection = _FakeConnection(events=[delta1, delta2, done])
 
@@ -500,7 +542,11 @@ async def test_speak_text_pipes_audio_deltas_to_speaker() -> None:
     await turn.speak_text("hi")
 
     connection.response.create.assert_awaited_once()
-    assert speaker.played == [b"pcm1", b"pcm2"]
+    assert len(speaker.played) == 2
+    assert speaker.played[0][0] == _LLM_RATE
+    np.testing.assert_array_equal(speaker.played[0][1], pcm_a)
+    assert speaker.played[1][0] == _LLM_RATE
+    np.testing.assert_array_equal(speaker.played[1][1], pcm_b)
     # Drain consumed all three events and stopped at the terminal one.
     assert connection.observed == [delta1, delta2, done]
 
@@ -508,9 +554,11 @@ async def test_speak_text_pipes_audio_deltas_to_speaker() -> None:
 @pytest.mark.asyncio
 async def test_speak_text_ignores_non_delta_events_while_piping_audio() -> None:
     """Deltas interleaved with non-audio events: only deltas reach the speaker."""
-    delta1 = _make_audio_delta(b"A")
+    pcm_a = np.array([10, 20], dtype=np.int16)
+    pcm_b = np.array([30, 40], dtype=np.int16)
+    delta1 = _make_audio_delta(pcm_a.tobytes())
     interstitial = MagicMock(name="unrelated_event")
-    delta2 = _make_audio_delta(b"B")
+    delta2 = _make_audio_delta(pcm_b.tobytes())
     done = _make_response_done("completed")
     connection = _FakeConnection(events=[delta1, interstitial, delta2, done])
 
@@ -524,7 +572,9 @@ async def test_speak_text_ignores_non_delta_events_while_piping_audio() -> None:
     await turn.speak_text("hi")
 
     connection.response.create.assert_awaited_once()
-    assert speaker.played == [b"A", b"B"]
+    assert len(speaker.played) == 2
+    np.testing.assert_array_equal(speaker.played[0][1], pcm_a)
+    np.testing.assert_array_equal(speaker.played[1][1], pcm_b)
     assert connection.observed == [delta1, interstitial, delta2, done]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,17 @@ ignore_missing_imports = true
 module = "mediapipe"
 ignore_missing_imports = true
 
+# scipy is a transitive dep via reachy-mini (used by ReachyMicSource /
+# ReachySpeakerSink for FFT-based resampling matching the conversation-app
+# reference). The wheel ships no py.typed marker; ``scipy-stubs`` exists
+# upstream but is not pulled in. The adapters use a narrow surface
+# (``scipy.signal.resample``) and validate shape via the test fixtures,
+# so suppressing the missing-stub error here keeps mypy --strict happy
+# without dragging in a stub package whose churn outweighs its value.
+[[tool.mypy.overrides]]
+module = "scipy.*"
+ignore_missing_imports = true
+
 # Pyright config lives in ./pyrightconfig.json (takes precedence over
 # [tool.pyright] here; pyrightconfig.json is more reliably live-reloaded
 # by IDE language servers). Pyright doesn't support per-module


### PR DESCRIPTION
## Summary

M1 of the hardware-testing plan (#23), delivering `ReachyMicSource` + `ReachySpeakerSink` hardware adapters, a SDK contract test, factory selection, and full voice-layer alignment with the canonical `pollen-robotics/reachy_mini_conversation_app` reference.

**Task 1.5 (hardware smoke) is explicitly deferred** — the user is off-network during this session and can't reach \`reachy-mini.local\`. The adapters + contract tests + session config land now; the hardware smoke will follow in a small PR when the user is back on LAN.

## Arc

Six commits tell the M1 story:

1. \`f08f9bd\` — Task 1.1 initial: SDK contract test (class-level + hardware-tier).
2. \`50ed04c\` — Task 1.1 review fixes: bounded-poll for None races, caplog for silent-drop detection, relaxed signature check, deleted redundant test.
3. \`b311aff\` — Task 1.2: `ReachyMicSource` draft (bytes-at-boundary).
4. \`a9e41e8\` — Task 1.3: `ReachySpeakerSink` draft (bytes-at-boundary).
5. \`e251eb4\` — Task 1.4: factory selection via `reachy_mini` kwarg.
6. \`59ad0f4\` — **A refactor**: align the voice layer with the conversation-app reference after branch-level code review surfaced 6 gaps.

## Why the A refactor

Code review of commits 1-5 surfaced a format mismatch: SDK returns float32 stereo 16 kHz; OpenAI Realtime default is PCM16 mono 24 kHz; our ABC was bytes with no resample/collapse. Research into [`pollen-robotics/reachy_mini_conversation_app`](https://github.com/pollen-robotics/reachy_mini_conversation_app) showed its canonical pattern — `(sample_rate, int16 ndarray)` tuples at the handler boundary, `scipy.signal.resample`, left-channel pick, `session.update` on OpenAI — and we aligned to it in one atomic refactor commit.

Six gaps closed:

1. **AudioFrame type alias** (`tuple[int, npt.NDArray[np.int16]]`) replaces bytes-at-boundary ABC. Composable with parallel consumers (head-wobble / VU / transcript-synced lighting — `console.py:625-628` in reference shows why this matters).
2. `ReachyMicSource` collapses stereo → mono (`frame[:, 0]` — left channel, matches `openai_realtime.py:760` in reference), resamples 16→24 kHz via `scipy.signal.resample`, casts float32 → int16 via `* 32767` (matches `fastrtc.audio_to_int16`).
3. `ReachySpeakerSink` accepts tuples, `int16 → float32 / 32768` (asymmetric with mic scaling — deliberate PCM16 round-trip pattern matching `fastrtc.audio_to_float32`), resamples to SDK's 16 kHz, pushes **mono** — SDK auto-fans mono → stereo internally (`media_manager.py:357-358`).
4. `OpenAIRealtimeVoice` pins 24 kHz PCM16 both directions via `session.update` at connection setup (mirrors reference `openai_realtime.py:504-521`). Bytes-at-network-boundary conversion moves from ABC layer to voice-session layer.
5. Contract test tightened: default tier pins `MediaManager.get_input_audio_samplerate` / `get_output_audio_samplerate` class-surface; hardware tier pins stereo `(N, 2)` float32 shape (previously only `size > 0`).
6. Factory kwarg `reachy_mini` is now **keyword-only** (`*, reachy_mini=...`) — forward-compat with M2's `mute_gate` kwarg addition. Dropped `sample.size == 0` belt-and-suspenders in `ReachyMicSource` since SDK only ever returns `None` or populated `reshape(-1, 2)`.

Research report + validation against the installed SDK source + a full spec-compliance pass are all on-branch history.

## Files touched

- \`app/src/reachy_ducky_app/voice/audio_io.py\` — ABC reshaped, `MockMicSource` / `MockSpeakerSink` / `ReachyMicSource` / `ReachySpeakerSink` / factories all reflect tuple contract.
- \`app/src/reachy_ducky_app/voice/openai_realtime.py\` — `session.update` + tuple consumption.
- \`app/tests/test_audio_io.py\` — stereo fixtures, tuple assertions, keyword-only factory test.
- \`app/tests/test_sdk_audio_contract.py\` — new default-tier samplerate-surface test + hardware-tier stereo-shape pin.
- \`app/tests/test_voice_openai_realtime.py\` — updated for session.update + tuple paths.
- \`pyproject.toml\` — narrow \`scipy.*\` mypy override (scipy ships no py.typed; transitive via reachy-mini).

\`main.py\` and \`test_app_main.py\` are untouched — call sites already used keyword syntax.

## Gates

- \`ruff check .\` clean (77 files)
- \`ruff format --check .\` clean
- \`mypy --strict\` 0 issues across all src + tests
- \`pyright\` CLI 0/0/0
- \`bandit -ll\` clean
- \`pytest -q --cov\` — **625 passed**, 7 deselected; coverage **91.69%** (audio_io.py 100%, openai_realtime.py 91%)

## Deferred

- **Task 1.5 (hardware smoke)** — waits for user to be back on LAN. Budget: ~20min on-robot, one small follow-up PR.
- **Parallel consumers** (head-wobble / VU / transcript-lighting) — AudioFrame tuples make these trivially composable when we add them. Not in this PR.

## Refs

- Design decision log: \`docs/plans/2026-04-22-hardware-testing-prerequisites.md\` refresh PR #66.
- Reference app: https://github.com/pollen-robotics/reachy_mini_conversation_app (notable files: \`src/.../console.py\` lines 569-630; \`src/.../openai_realtime.py\` lines 504-521, 737-775).
- Unblocks M2 (#20): \`MuteGate\` binding slots in cleanly via the keyword-only factory kwarg.

Closes no issues outright (M1 of 2 for #23). #23 closes after Task 1.5's hardware smoke lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)