### PR TITLE
chore: small-cleanup bundle (closes #19, #56; addresses #47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,24 @@ protocol/    Shared Pydantic messages between daemon ↔ app
 - Conventional commits (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`).
 - **No `--no-verify`. No force-push. No `git reset --hard` on shared branches.**
 
+### Auto-merge for Dependabot + safe PRs
+
+The repo allows auto-merge on PRs that pass required CI. Enable selectively:
+
+```bash
+# Safe: dev-tool-only Dependabot bumps (after required checks pass)
+gh pr merge <pr-url> --auto --squash --delete-branch
+
+# Manual review required: any PR touching runtime deps, source code,
+# or configuration with behavioural impact. Don't --auto these.
+```
+
+Required status checks on `main` (as of 2026-04-24):
+- `Lint, type-check, unit tests (ubuntu-latest)`
+- `Lint, type-check, unit tests (macos-latest)`
+
+`sdk-contract.yml` was removed in PR #65 (canonical dep migration); its introspection tests now run in the default CI tier. `windows-latest` (Phase 3) lands as informative-only and is not required.
+
 ---
 
 ## Memory (daemon)

--- a/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
+++ b/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
@@ -8,11 +8,17 @@ Exposes two read-only tools over ``create_sdk_mcp_server``:
 * ``read_plan`` — read a single plan/spec file by its project-relative path,
   with two non-negotiable security properties:
 
-    1. the resolved target path must stay inside the project root
-       (``..`` traversal, absolute paths, and symlink escapes are denied);
+    1. the resolved target path must stay inside the project root (``..``
+       traversal and absolute paths are rejected by ``_read_plan``'s own
+       ``is_relative_to`` check; symlink escapes are denied in
+       :func:`_discover`, which silently drops any hit whose ``.resolve()``
+       escapes ``project_root`` at discovery time);
     2. the target path must be one of the files that :func:`_discover` would
        advertise (``read_plan`` is not a general-purpose file reader — daemon
-       source and secrets are denied even if they exist).
+       source and secrets are denied even if they exist). Because
+       ``_discover`` has already filtered symlink escapes, this membership
+       check inherits the property: ``_read_plan`` can only return content
+       for paths ``_discover`` already cleared.
 
 The tool surface is intentionally tiny: Claude uses its built-in ``Read`` /
 ``Glob`` / ``Grep`` tools (gated by the PreToolUse security hook) for

--- a/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
+++ b/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
@@ -10,15 +10,17 @@ Exposes two read-only tools over ``create_sdk_mcp_server``:
 
     1. the resolved target path must stay inside the project root (``..``
        traversal and absolute paths are rejected by ``_read_plan``'s own
-       ``is_relative_to`` check; symlink escapes are denied in
-       :func:`_discover`, which silently drops any hit whose ``.resolve()``
-       escapes ``project_root`` at discovery time);
-    2. the target path must be one of the files that :func:`_discover` would
-       advertise (``read_plan`` is not a general-purpose file reader — daemon
-       source and secrets are denied even if they exist). Because
-       ``_discover`` has already filtered symlink escapes, this membership
-       check inherits the property: ``_read_plan`` can only return content
-       for paths ``_discover`` already cleared.
+       ``is_relative_to`` check; external-target symlinks are denied in
+       :func:`_discover`, which silently drops any symlink hit at
+       discovery time so the symlink itself is never admitted);
+    2. the resolved target must be one of the files that :func:`_discover`
+       would advertise (``read_plan`` is not a general-purpose file
+       reader — daemon source and secrets are denied even if they exist).
+       Internal-target symlinks pointing at non-plan paths are rejected
+       here (the non-plan target is not in the set). Internal-target
+       symlinks pointing at a conventional plan transparently follow to
+       the target — same content as reading the target directly; no
+       security gain for an attacker.
 
 The tool surface is intentionally tiny: Claude uses its built-in ``Read`` /
 ``Glob`` / ``Grep`` tools (gated by the PreToolUse security hook) for
@@ -117,25 +119,35 @@ def _discover(base: Path) -> set[Path]:
     not ``base/nested/AGENTS.md``. That anchoring is what makes the read
     surface exactly as wide as the discover surface.
 
-    Symlink-escape filter: a hit whose ``.resolve()`` lands outside ``base`` is
-    silently dropped. The plans MCP tool surface — :func:`list_plans`
-    (discovery) and :func:`_read_plan` (read with membership check) — both
-    read from this set, so neither can return or accept an escape-resolving
-    path. Closed via #8.
+    **Symlinks are skipped at discovery.** A symlink under a conventional
+    plan path is not added to the result set by its own glob match — so
+    a plan-shaped link pointing at a non-plan target (e.g.
+    ``docs/plans/escape.md -> daemon/src/foo.py``) cannot smuggle its
+    target into the membership set. A link pointing at another
+    conventional plan (``docs/plans/link.md -> docs/plans/real.md``) is
+    still readable via :func:`_read_plan` because the target enters the
+    set via its own pattern match and ``_read_plan``'s ``.resolve()``
+    follows the link transparently — that's fine because the attacker
+    gains nothing they couldn't get by reading the target directly.
     """
     results: set[Path] = set()
     for pattern in _CONVENTIONAL_PATTERNS:
         for hit in base.glob(pattern):
             if not hit.is_file():
                 continue
+            if hit.is_symlink():
+                # Skip the symlink hit itself so a plan-shaped link
+                # pointing at a non-plan target (``docs/plans/escape.md
+                # -> daemon/src/foo.py``) cannot smuggle its target into
+                # the membership set via its own glob match. A link to
+                # another conventional plan is still readable because
+                # the target enters the set via its own pattern match
+                # and ``_read_plan``'s ``.resolve()`` follows the link
+                # transparently — same content as reading the target
+                # directly; no security gain for an attacker. See the
+                # module docstring's security invariants.
+                continue
             resolved = hit.resolve()
-            # Reject symlinks whose resolved target escapes ``base``.
-            # ``is_relative_to`` (Python 3.9+) is the non-raising form
-            # of the same check ``_read_plan`` uses. Filtering here
-            # means both ``list_plans`` (discovery) and ``_read_plan``
-            # (membership check) inherit the property for free — no
-            # escaping path can be advertised, read, or leaked via
-            # diagnostic. (#8)
             if not resolved.is_relative_to(base):
                 continue
             results.add(resolved)
@@ -159,11 +171,17 @@ def _read_plan(project_root: Path, rel_path: str) -> str:
 
     Raises:
         PermissionError: if ``rel_path`` resolves outside ``project_root``
-            (``..`` escape, absolute path, symlink escape), or if the
-            resolved path is not one of the files that :func:`_discover`
-            would advertise. The membership check fires regardless of
-            whether the path exists on disk, so probing non-plan locations
-            cannot be used as an existence oracle for arbitrary files.
+            (``..`` escape, absolute path), or if the resolved path is not
+            one of the files that :func:`_discover` would advertise.
+            Because :func:`_discover` skips symlink hits at discovery,
+            a plan-shaped symlink pointing at a non-plan target fails
+            the membership check as "not a plan or spec file"; a
+            plan-shaped symlink pointing at another conventional plan
+            resolves to the target and reads transparently (same content
+            as reading the target directly — no security gain). The
+            membership check fires regardless of whether the path exists
+            on disk, so probing non-plan locations cannot be used as an
+            existence oracle for arbitrary files.
         OSError: subclasses (``FileNotFoundError``, ``PermissionError`` from
             the filesystem, etc.) surface from ``read_text``.
         UnicodeDecodeError: if the file exists and is advertised but isn't

--- a/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
+++ b/daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
@@ -11,8 +11,10 @@ Exposes two read-only tools over ``create_sdk_mcp_server``:
     1. the resolved target path must stay inside the project root (``..``
        traversal and absolute paths are rejected by ``_read_plan``'s own
        ``is_relative_to`` check; external-target symlinks are denied in
-       :func:`_discover`, which silently drops any symlink hit at
-       discovery time so the symlink itself is never admitted);
+       :func:`_discover`, which silently drops any hit reached through a
+       symlink — both symlink FILES and files reached through symlink
+       DIRECTORIES — so neither the symlink itself nor a non-symlink
+       leaf under a symlinked parent is ever admitted);
     2. the resolved target must be one of the files that :func:`_discover`
        would advertise (``read_plan`` is not a general-purpose file
        reader — daemon source and secrets are denied even if they exist).
@@ -108,6 +110,33 @@ _CONVENTIONAL_PATTERNS: tuple[str, ...] = (
 )
 
 
+def _chain_has_symlink(path: Path, base: Path) -> bool:
+    """Return True if ``path`` or any ancestor up to (not including)
+    ``base`` is a symlink.
+
+    Walks parent-ward from ``path`` until we hit ``base``. If any step
+    is a symlink, the chain is tainted and the caller should reject.
+    If ``path`` isn't under ``base``, returns True conservatively
+    (shouldn't happen given glob's contract, but belt-and-suspenders).
+    Python 3.12's ``Path.glob`` follows symlinked directories by
+    default (``recurse_symlinks=False`` is 3.13+ only); this walk is
+    the portable equivalent.
+    """
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return True  # Not under base — treat as tainted.
+    current = path
+    while current != base:
+        if current.is_symlink():
+            return True
+        parent = current.parent
+        if parent == current:  # Root — shouldn't happen, but bail out.
+            return True
+        current = parent
+    return False
+
+
 def _discover(base: Path) -> set[Path]:
     """Return the absolute paths of every file under ``base`` matched by any
     conventional pattern.
@@ -119,33 +148,23 @@ def _discover(base: Path) -> set[Path]:
     not ``base/nested/AGENTS.md``. That anchoring is what makes the read
     surface exactly as wide as the discover surface.
 
-    **Symlinks are skipped at discovery.** A symlink under a conventional
-    plan path is not added to the result set by its own glob match — so
-    a plan-shaped link pointing at a non-plan target (e.g.
-    ``docs/plans/escape.md -> daemon/src/foo.py``) cannot smuggle its
-    target into the membership set. A link pointing at another
-    conventional plan (``docs/plans/link.md -> docs/plans/real.md``) is
-    still readable via :func:`_read_plan` because the target enters the
-    set via its own pattern match and ``_read_plan``'s ``.resolve()``
-    follows the link transparently — that's fine because the attacker
-    gains nothing they couldn't get by reading the target directly.
+    **Symlinks are skipped at discovery — both symlink FILES and files
+    reached through symlink DIRECTORIES.** Python 3.12's ``Path.glob``
+    follows symlinked directories by default, so a check on the leaf
+    hit alone isn't enough. :func:`_chain_has_symlink` walks from the
+    hit up to ``base`` and rejects if any step is a symlink — covers
+    both ``docs/plans/link.md -> X`` (file symlink) and
+    ``docs/plans/evil_dir/leaked.md`` where ``evil_dir -> daemon/src``
+    (parent-dir symlink). Transparent-follow symlinks to conventional
+    plan paths are still readable: the target enters the set via its
+    own pattern match and ``_read_plan.resolve()`` follows the link.
     """
     results: set[Path] = set()
     for pattern in _CONVENTIONAL_PATTERNS:
         for hit in base.glob(pattern):
             if not hit.is_file():
                 continue
-            if hit.is_symlink():
-                # Skip the symlink hit itself so a plan-shaped link
-                # pointing at a non-plan target (``docs/plans/escape.md
-                # -> daemon/src/foo.py``) cannot smuggle its target into
-                # the membership set via its own glob match. A link to
-                # another conventional plan is still readable because
-                # the target enters the set via its own pattern match
-                # and ``_read_plan``'s ``.resolve()`` follows the link
-                # transparently — same content as reading the target
-                # directly; no security gain for an attacker. See the
-                # module docstring's security invariants.
+            if _chain_has_symlink(hit, base):
                 continue
             resolved = hit.resolve()
             if not resolved.is_relative_to(base):

--- a/daemon/tests/test_brain_plans_mcp.py
+++ b/daemon/tests/test_brain_plans_mcp.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 from reachy_ducky_daemon.brain.plans_mcp import (
     _CONVENTIONAL_PATTERNS,
+    _discover,
     _make_plans_tools,
     _read_plan,
     list_plans,
@@ -784,3 +785,46 @@ def test_read_plan_rejects_escaped_symlink(tmp_path: Path) -> None:
 
     with pytest.raises(PermissionError, match="escapes project root|not a plan"):
         _read_plan(project, "docs/plans/escape.md")
+
+
+def test_read_plan_rejects_symlinked_parent_directory(tmp_path: Path) -> None:
+    """Symlinked parent directories can't smuggle non-plan files into the set.
+
+    Python 3.12's Path.glob follows symlinked directories by default.
+    Without the parent-symlink check, a plan-shaped path like
+    ``docs/plans/evil_dir/leaked.md`` where ``evil_dir -> daemon/src``
+    would have been readable. Second attack vector of the same class
+    as C.3a (file-symlink); same security property.
+    """
+    project = tmp_path / "project"
+    (project / "docs" / "plans").mkdir(parents=True)
+    src_dir = project / "daemon" / "src"
+    src_dir.mkdir(parents=True)
+
+    leaked = src_dir / "leaked.md"
+    leaked.write_text("# maybe-a-secret\n")
+
+    evil_dir = project / "docs" / "plans" / "evil_dir"
+    evil_dir.symlink_to(src_dir)
+
+    with pytest.raises(PermissionError, match="not a plan"):
+        _read_plan(project, "docs/plans/evil_dir/leaked.md")
+
+
+def test_discover_rejects_hits_under_symlinked_parent(tmp_path: Path) -> None:
+    """Direct ``_discover`` check: paths under a symlinked parent are
+    not in the result set. Complements the ``_read_plan``-level test."""
+    project = tmp_path / "project"
+    (project / "docs" / "plans").mkdir(parents=True)
+    src_dir = project / "daemon" / "src"
+    src_dir.mkdir(parents=True)
+
+    (src_dir / "a.md").write_text("# a\n")
+    (project / "docs" / "plans" / "legit.md").write_text("# legit\n")
+
+    (project / "docs" / "plans" / "evil_dir").symlink_to(src_dir)
+
+    paths = _discover(project)
+
+    assert (project / "docs" / "plans" / "legit.md").resolve() in paths
+    assert (src_dir / "a.md").resolve() not in paths

--- a/daemon/tests/test_brain_plans_mcp.py
+++ b/daemon/tests/test_brain_plans_mcp.py
@@ -287,17 +287,59 @@ def test_read_plan_symlink_escape_rejected(tmp_path: Path) -> None:
         outside_dir.rmdir()
 
 
-def test_read_plan_symlink_to_file_inside_project_allowed(tmp_path: Path) -> None:
-    """A symlink that resolves to a file inside project_root and matches a
-    conventional pattern is allowed (symlink rejection is about escapes, not
-    symlinks in general)."""
-    (tmp_path / "docs" / "plans").mkdir(parents=True)
-    target = tmp_path / "docs" / "plans" / "real.md"
-    target.write_text("real contents")
-    link = tmp_path / "docs" / "plans" / "link.md"
+def test_read_plan_rejects_symlink_to_nonplan_path_even_inside_project(
+    tmp_path: Path,
+) -> None:
+    """Symlinks whose target is a non-plan path inside the project are
+    rejected — closes the 'plan-shaped symlink as general in-project
+    file reader' attack vector (``docs/plans/escape.md ->
+    daemon/src/foo.py`` would have silently leaked source files).
+
+    Symlinks whose target IS a conventional plan path transparently
+    read the target (no security gain for an attacker — same content
+    either way). See ``test_read_plan_symlink_to_plan_target_reads_transparently``.
+    """
+    project = tmp_path / "project"
+    (project / "docs" / "plans").mkdir(parents=True)
+    (project / "daemon" / "src").mkdir(parents=True)
+
+    # Non-plan target inside the project (classic attack vector).
+    target = project / "daemon" / "src" / "foo.py"
+    target.write_text("# definitely not a plan — maybe a secret\n")
+
+    # Plan-shaped symlink pointing at the non-plan target.
+    link = project / "docs" / "plans" / "escape.md"
     link.symlink_to(target)
 
-    assert _read_plan(tmp_path, "docs/plans/link.md") == "real contents"
+    with pytest.raises(PermissionError, match="not a plan"):
+        _read_plan(project, "docs/plans/escape.md")
+
+
+def test_read_plan_symlink_to_plan_target_reads_transparently(
+    tmp_path: Path,
+) -> None:
+    """Symlinks whose target is itself a conventional plan path
+    transparently return the target's content. No security property
+    is violated — the attacker gains nothing they couldn't get by
+    reading the target directly.
+
+    This behavior is consequence of ``_discover`` skipping the symlink
+    itself but adding the target (via its own pattern match) AND
+    ``_read_plan.resolve()`` following the link. Documented so
+    future refactors don't accidentally change it.
+    """
+    project = tmp_path / "project"
+    plans_dir = project / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+
+    (plans_dir / "real.md").write_text("# Real Plan\nbody\n")
+    (plans_dir / "link.md").symlink_to(plans_dir / "real.md")
+
+    via_real = _read_plan(project, "docs/plans/real.md")
+    via_link = _read_plan(project, "docs/plans/link.md")
+
+    assert "Real Plan" in via_real
+    assert via_real == via_link, "Symlink to plan target should return same content"
 
 
 # ---------------------------------------------------------------------------
@@ -727,10 +769,11 @@ def test_read_plan_rejects_escaped_symlink(tmp_path: Path) -> None:
 
     Two fail-closed gates cover this: ``_read_plan``'s own
     ``relative_to(base)`` check fires first (yielding "escapes project
-    root"), and even if that were ever bypassed, ``_discover``'s new
-    ``is_relative_to`` filter keeps the resolved path out of the
-    membership set. Either way, no ValueError leaks out of
-    ``_read_plan`` and the fail-closed contract is intact.
+    root"), and even if that were ever bypassed, ``_discover``'s
+    ``is_symlink()`` skip keeps the symlink's resolved target out of the
+    membership set (the symlink itself is never admitted at discovery).
+    Either way, no ValueError leaks out of ``_read_plan`` and the
+    fail-closed contract is intact.
     """
     outside = tmp_path / "outside.txt"
     outside.write_text("secret content")

--- a/daemon/tests/test_specialist_plan_reviewer.py
+++ b/daemon/tests/test_specialist_plan_reviewer.py
@@ -679,3 +679,55 @@ async def test_capture_diff_falls_back_when_main_ref_absent(tmp_path: Path) -> N
         f"fallback_idx={fallback_idx}, hunk_idx={hunk_idx}"
     )
     assert "working-tree" in diff_lines[fallback_idx].lower(), diff_lines[fallback_idx]
+
+
+@pytest.mark.asyncio
+async def test_single_oversized_plan_still_lands_despite_total_cap(
+    tmp_path: Path,
+) -> None:
+    """A single plan larger than ``max_total_plan_chars`` MUST land anyway —
+    the ``included > 0`` guard in ``_assemble_plans_block`` ensures we
+    never return zero plans when at least one exists.
+
+    Regression guard: if a future refactor changes ``included > 0``
+    to ``included > 1`` or drops the guard, this test fails clearly.
+    The per-file cap truncates the body; the total-budget check still
+    lets the single (truncated) plan through.
+    """
+    _init_repo(tmp_path)
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+
+    # Plan body is larger than BOTH caps — 250k chars, per-file cap is
+    # 60k, total-budget cap is 50k. Without the included > 0 guard,
+    # the plan would be dropped as over-budget.
+    huge = "a" * 250_000
+    (plans_dir / "huge.md").write_text(huge)
+    _commit(tmp_path, "add huge plan")
+
+    brain = MockBrain()
+    reviewer = PlanReviewer(
+        brain=brain,
+        repo=tmp_path,
+        max_plan_chars=60_000,
+        max_total_plan_chars=50_000,
+    )
+    await reviewer.review()
+
+    prompt = brain.calls[-1].user_utterance
+
+    # The plan MUST land, truncated to 60k via per-file cap.
+    assert "huge.md" in prompt, (
+        "Plan file name missing from prompt — 'at least one plan lands' invariant broken"
+    )
+    # Plan body is present up to the per-file cap. Assert 60k 'a's in a row;
+    # the truncation marker follows.
+    assert "a" * 60_000 in prompt, "Per-file truncation didn't yield 60k body"
+    assert "[... truncated:" in prompt, "Per-file truncation marker missing"
+    # Total-budget omission marker MUST NOT appear — we did NOT omit a plan.
+    assert "plans omitted" not in prompt, (
+        "Total-budget marker incorrectly fired on single-plan case"
+    )
+    assert "plan omitted" not in prompt, (
+        "Total-budget marker (singular) incorrectly fired on single-plan case"
+    )

--- a/protocol/src/reachy_ducky_protocol/messages.py
+++ b/protocol/src/reachy_ducky_protocol/messages.py
@@ -33,7 +33,6 @@ class UserUtterance(_WireMessage):
 class BrainRequest(_WireMessage):
     user_utterance: str
     project_slug: str | None = None
-    include_tools: list[str] = Field(default_factory=list)
 
 
 class BrainResponse(_WireResponse):

--- a/protocol/tests/test_messages.py
+++ b/protocol/tests/test_messages.py
@@ -17,11 +17,10 @@ def test_brain_request_serializes() -> None:
     req = BrainRequest(
         user_utterance="what's on my branch?",
         project_slug="reachy-ducky",
-        include_tools=["git", "gh", "fs", "plans"],
     )
     data = req.model_dump()
     assert data["user_utterance"] == "what's on my branch?"
-    assert "git" in data["include_tools"]
+    assert data["project_slug"] == "reachy-ducky"
 
 
 def test_brain_response_round_trip() -> None:


### PR DESCRIPTION
## Summary

Part C of the offline workstream (\`docs/plans/2026-04-24-offline-workstream.md\`). Six commits on one branch, each traces to a single issue item.

### Commits

1. **\`6a3f9c5\`** — docs(brain): point plans_mcp module docstring at \`_discover\` (#56 item 1).
2. **\`a634200\`** — test(plan-reviewer): pin 'single oversized plan lands' invariant (#56 item 2).
3. **\`01fd0bf\`** — fix(brain): \`_discover\` skips symlinks; close 'plan-shaped symlink reads non-plan' hole. **Surfaced a real security gap during the original Task C.3 pin-attempt** — plan-shaped symlinks pointing to non-plan targets inside the project root could be used as a general-purpose in-project file reader. Filter was only blocking external-target symlinks. Fix: \`_discover\` skips all symlinks at discovery. The no-security-impact transparent-follow case (symlink to another conventional plan) continues to work via the target's own pattern match. Two new tests document both properties (real rejection + transparent follow).
4. **\`1d83958\`** — chore(protocol): prune wire-dead \`BrainRequest.include_tools\` (closes #19).
5. **\`bacfa56\`** — docs(gitops): enable auto-merge + document usage policy (#47 partial — sdk-contract half obsolete since PR #65).
6. (n/a — Part C was 5 tasks in the plan; expanded to 6 after the security-regression find absorbed C.3 into C.3a. See commit 3's message for the full arc.)

### Closes

- **#19** — wire-dead \`BrainRequest.include_tools\` field pruned.
- **#56** — all three polish follow-ups (docstring fix, invariant test, symlink-to-nonplan test).

### Addresses

- **#47** — auto-merge half enabled + documented. sdk-contract half obsolete since PR #65 (workflow deleted).
- **Security regression surfaced in C.3a** — plan-shaped symlink attack vector closed. The original #56 item 3 test was upgraded from "pin existing behavior" to "pin new behavior after fixing the underlying bug."

### Gates

- \`ruff check .\` clean
- \`ruff format --check .\` clean (77 files)
- \`mypy --strict\` 0 issues
- \`pyright\` CLI 0/0/0
- \`bandit -ll\` 0 issues
- \`pytest -q --cov\` — **628 passed**, 7 deselected; coverage **91.64-91.65%**
- \`messages.py\` at 100% coverage

### Test plan

- [x] Full suite green across all 6 commits.
- [x] Security bug repro confirmed fixed (\`docs/plans/escape.md -> daemon/src/foo.py\` raises \`PermissionError(\"not a plan\")\`).
- [x] Transparent-follow documented (\`docs/plans/link.md -> docs/plans/real.md\` reads target content — no security gain for attacker).
- [x] \`include_tools\` grep clean across \`.py\` files.
- [x] Auto-merge repo setting verified via \`gh api\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)