### PR TITLE
feat(app): M2 mute coordination — bind MuteGate to state machine + mic pump (closes #20)

### DIFF
--- a/app/src/reachy_ducky_app/embodiment/state_machine.py
+++ b/app/src/reachy_ducky_app/embodiment/state_machine.py
@@ -31,9 +31,11 @@ class EmbodimentStateMachine:
 
     When a :class:`MuteGate` is supplied via the keyword-only ``mute_gate``
     kwarg, the gate is set muted on entry to ``MUTED`` and cleared on exit.
-    The gate toggle happens BEFORE motion dispatch so observers that race
-    on the transition see a consistent ``(gate, motion)`` pair. Passing
-    ``mute_gate=None`` (the default) skips the toggle entirely.
+    The transition is atomic on success: motion completes, then state +
+    gate update together. If a driver call raises, the state machine stays
+    in the prior state and the gate stays in its prior position — no
+    desync. Passing ``mute_gate=None`` (the default) skips the toggle
+    entirely.
     """
 
     def __init__(
@@ -53,11 +55,8 @@ class EmbodimentStateMachine:
     def transition(self, target: State) -> None:
         if target == self._state:
             return
-        if self._mute_gate is not None:
-            if target == State.MUTED:
-                self._mute_gate.set_muted(True)
-            elif self._state == State.MUTED:
-                self._mute_gate.set_muted(False)
+        # Motion dispatch FIRST. If any driver call raises, _state /
+        # _mute_gate stay unchanged — the transition is atomic on success.
         if target == State.MUTED:
             self._driver.go_to_sleep()
         else:
@@ -66,4 +65,11 @@ class EmbodimentStateMachine:
             move = _STATE_TO_MOVE.get(target)
             if move is not None:
                 self._driver.play_move(move)
+        # Motion succeeded — commit gate + state together. Either both
+        # update or neither does (driver exception above prevents reach).
+        if self._mute_gate is not None:
+            if target == State.MUTED:
+                self._mute_gate.set_muted(True)
+            elif self._state == State.MUTED:
+                self._mute_gate.set_muted(False)
         self._state = target

--- a/app/src/reachy_ducky_app/embodiment/state_machine.py
+++ b/app/src/reachy_ducky_app/embodiment/state_machine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from reachy_ducky_protocol.messages import State
 
+from ..mute import MuteGate
 from .motion_driver import MotionDriver
 
 # State -> emotion-library move name. Keep in sync with the design doc §11
@@ -27,11 +28,23 @@ class EmbodimentStateMachine:
       target-state ``play_move`` so the robot is upright before it moves.
     - ``IDLE``/``LISTENING``/``THINKING`` transitions call
       ``play_move(<name>)`` per :data:`_STATE_TO_MOVE`.
+
+    When a :class:`MuteGate` is supplied via the keyword-only ``mute_gate``
+    kwarg, the gate is set muted on entry to ``MUTED`` and cleared on exit.
+    The gate toggle happens BEFORE motion dispatch so observers that race
+    on the transition see a consistent ``(gate, motion)`` pair. Passing
+    ``mute_gate=None`` (the default) skips the toggle entirely.
     """
 
-    def __init__(self, driver: MotionDriver) -> None:
+    def __init__(
+        self,
+        driver: MotionDriver,
+        *,
+        mute_gate: MuteGate | None = None,
+    ) -> None:
         self._driver = driver
         self._state: State = State.IDLE
+        self._mute_gate = mute_gate
 
     @property
     def state(self) -> State:
@@ -40,6 +53,11 @@ class EmbodimentStateMachine:
     def transition(self, target: State) -> None:
         if target == self._state:
             return
+        if self._mute_gate is not None:
+            if target == State.MUTED:
+                self._mute_gate.set_muted(True)
+            elif self._state == State.MUTED:
+                self._mute_gate.set_muted(False)
         if target == State.MUTED:
             self._driver.go_to_sleep()
         else:

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -27,6 +27,7 @@ from .conversation import run_one_turn
 from .daemon_client import DaemonClient
 from .embodiment.motion_driver import ReachyMotionDriver
 from .embodiment.state_machine import EmbodimentStateMachine
+from .mute import MuteGate
 from .voice.audio_io import load_default_mic_source, load_default_speaker_sink
 from .voice.openai_realtime import OpenAIRealtimeVoice
 from .wake import load_default_wake_detector
@@ -76,9 +77,14 @@ class ReachyDuckyApp:
         ``run_one_turn``.
         """
         driver = ReachyMotionDriver(reachy_mini)
-        sm = EmbodimentStateMachine(driver=driver)
+        # Single shared gate: state machine toggles it on MUTED transitions
+        # (Task A.1); the mic pump reads it on every frame (Task A.2). Both
+        # consumers MUST see the same instance or the zero-at-source
+        # invariant breaks.
+        mute_gate = MuteGate()
+        sm = EmbodimentStateMachine(driver=driver, mute_gate=mute_gate)
         voice = OpenAIRealtimeVoice(
-            mic=load_default_mic_source(reachy_mini=reachy_mini),
+            mic=load_default_mic_source(reachy_mini=reachy_mini, mute_gate=mute_gate),
             speaker=load_default_speaker_sink(reachy_mini=reachy_mini),
         )
         daemon = DaemonClient.from_env()

--- a/app/src/reachy_ducky_app/voice/audio_io.py
+++ b/app/src/reachy_ducky_app/voice/audio_io.py
@@ -27,6 +27,8 @@ import numpy as np
 import numpy.typing as npt
 import scipy.signal
 
+from ..mute import MuteGate
+
 # ``AudioFrame = (sample_rate, int16 mono ndarray)``. Matches the raw-tuple
 # shape used by pollen-robotics/reachy_mini_conversation_app's
 # AsyncStreamHandler pattern (console.py:569-630) so our adapters are
@@ -113,10 +115,23 @@ class ReachyMicSource(MicSource):
     whose ``.media`` exposes ``get_audio_sample()``; the factory
     :func:`load_default_mic_source` selects this impl over
     :class:`MockMicSource` when a non-None ``reachy_mini`` is passed.
+
+    When a :class:`MuteGate` is passed via the keyword-only ``mute_gate``
+    kwarg, the adapter applies it post-resample / pre-yield so the int16
+    samples are zeroed when the gate is muted. Zero-at-source:
+    downstream consumers (OpenAI Realtime session, future head-wobble
+    driver, VU meter) all observe silence consistently when the gate is
+    muted, without each needing its own mute subscription.
     """
 
-    def __init__(self, reachy_mini: object) -> None:
+    def __init__(
+        self,
+        reachy_mini: object,
+        *,
+        mute_gate: MuteGate | None = None,
+    ) -> None:
         self._mini = reachy_mini
+        self._mute_gate = mute_gate
 
     async def frames(self) -> AsyncIterator[AudioFrame]:
         """Yield (24 kHz, int16 mono) tuples in a long-running loop.
@@ -155,6 +170,8 @@ class ReachyMicSource(MicSource):
             # Float32 [-1, 1] → int16 via * 32767 (matches
             # fastrtc.audio_to_int16 which the reference uses).
             int16 = (np.clip(resampled, -1.0, 1.0) * 32767).astype(np.int16)
+            if self._mute_gate is not None:
+                int16 = self._mute_gate.process(int16)
             yield (_LLM_AUDIO_RATE, int16)
 
 
@@ -198,7 +215,11 @@ class ReachySpeakerSink(SpeakerSink):
         await loop.run_in_executor(None, push, float32)
 
 
-def load_default_mic_source(*, reachy_mini: object | None = None) -> MicSource:
+def load_default_mic_source(
+    *,
+    reachy_mini: object | None = None,
+    mute_gate: MuteGate | None = None,
+) -> MicSource:
     """Return :class:`ReachyMicSource` when ``reachy_mini`` is given, else mock.
 
     The on-robot Pollen daemon hands :meth:`ReachyDuckyApp.run` a live
@@ -206,12 +227,16 @@ def load_default_mic_source(*, reachy_mini: object | None = None) -> MicSource:
     through this factory so production is hardware by default. Dev
     machines and unit tests pass ``None`` (the default) and get the
     silent :class:`MockMicSource`. ``reachy_mini`` is keyword-only so
-    future kwargs (e.g. M2's ``mute_gate``) can be added without
-    positional churn.
+    future kwargs can be added without positional churn.
+
+    ``mute_gate`` is also keyword-only. When provided alongside a
+    non-None ``reachy_mini``, it's threaded into the returned
+    :class:`ReachyMicSource`. :class:`MockMicSource` ignores the gate
+    (tests script frames directly — no gating needed).
     """
     if reachy_mini is None:
         return MockMicSource()
-    return ReachyMicSource(reachy_mini)
+    return ReachyMicSource(reachy_mini, mute_gate=mute_gate)
 
 
 def load_default_speaker_sink(*, reachy_mini: object | None = None) -> SpeakerSink:

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from reachy_ducky_app.main import ReachyDuckyApp, main
+from reachy_ducky_app.mute import MuteGate
 from reachy_ducky_app.voice.audio_io import MicSource, MockMicSource, MockSpeakerSink, SpeakerSink
 from reachy_ducky_app.wake import MockWakeDetector
 
@@ -243,21 +244,35 @@ async def test_run_async_constructs_voice_with_default_mic_and_speaker(
     :func:`load_default_mic_source` and :func:`load_default_speaker_sink`
     rather than hard-coding Mock impls directly. When the hardware-backed
     factory bodies land, ``main.py`` should require zero changes.
+
+    Also pins Task A.2: the mic factory receives the SAME ``MuteGate``
+    instance that the state machine received, so a MUTED transition
+    synchronously affects the mic pump. The speaker factory deliberately
+    does NOT receive a gate — speaker output is LLM-generated and
+    shouldn't be silenced when the user mutes.
     """
     monkeypatch.setenv("OPENAI_API_KEY", "test")
 
-    mic_factory_calls = 0
-    speaker_factory_calls = 0
+    mic_factory_kwargs: list[dict[str, object]] = []
+    speaker_factory_kwargs: list[dict[str, object]] = []
 
-    def _spy_mic_factory(reachy_mini: object | None = None) -> MicSource:
-        nonlocal mic_factory_calls
-        mic_factory_calls += 1
+    def _spy_mic_factory(
+        *,
+        reachy_mini: object | None = None,
+        mute_gate: MuteGate | None = None,
+    ) -> MicSource:
+        mic_factory_kwargs.append({"reachy_mini": reachy_mini, "mute_gate": mute_gate})
         return MockMicSource()
 
-    def _spy_speaker_factory(reachy_mini: object | None = None) -> SpeakerSink:
-        nonlocal speaker_factory_calls
-        speaker_factory_calls += 1
+    def _spy_speaker_factory(*, reachy_mini: object | None = None) -> SpeakerSink:
+        speaker_factory_kwargs.append({"reachy_mini": reachy_mini})
         return MockSpeakerSink()
+
+    sm_kwargs: list[dict[str, object]] = []
+
+    def _spy_sm(**kwargs: object) -> MagicMock:
+        sm_kwargs.append(kwargs)
+        return MagicMock()
 
     monkeypatch.setattr(
         "reachy_ducky_app.main.load_default_mic_source",
@@ -266,6 +281,10 @@ async def test_run_async_constructs_voice_with_default_mic_and_speaker(
     monkeypatch.setattr(
         "reachy_ducky_app.main.load_default_speaker_sink",
         _spy_speaker_factory,
+    )
+    monkeypatch.setattr(
+        "reachy_ducky_app.main.EmbodimentStateMachine",
+        _spy_sm,
     )
 
     app = ReachyDuckyApp()
@@ -277,8 +296,18 @@ async def test_run_async_constructs_voice_with_default_mic_and_speaker(
         timeout=0.5,
     )
 
-    assert mic_factory_calls == 1
-    assert speaker_factory_calls == 1
+    assert len(mic_factory_kwargs) == 1
+    assert len(speaker_factory_kwargs) == 1
+    assert len(sm_kwargs) == 1
+    # Mic factory MUST have received a real MuteGate, and it MUST be the
+    # SAME instance that the state machine received. If main() ever
+    # constructs two separate gates, the (gate, mic-pump) invariant
+    # silently breaks: a MUTED transition on the SM would toggle one gate
+    # while the mic pump reads the other.
+    mic_gate = mic_factory_kwargs[0]["mute_gate"]
+    sm_gate = sm_kwargs[0]["mute_gate"]
+    assert isinstance(mic_gate, MuteGate)
+    assert mic_gate is sm_gate
 
 
 async def test_run_async_closes_daemon_client_even_when_turn_raises(

--- a/app/tests/test_audio_io.py
+++ b/app/tests/test_audio_io.py
@@ -15,6 +15,7 @@ import contextlib
 
 import numpy as np
 import pytest
+from reachy_ducky_app.mute import MuteGate
 from reachy_ducky_app.voice.audio_io import (
     AudioFrame,
     MicSource,
@@ -408,3 +409,120 @@ def test_load_default_factories_require_keyword_for_reachy_mini() -> None:
         load_default_mic_source(_BareFakeMini())  # type: ignore[misc]
     with pytest.raises(TypeError):
         load_default_speaker_sink(_BareFakeMini())  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ReachyMicSource — MuteGate integration (Task A.2)
+# ---------------------------------------------------------------------------
+
+
+async def test_reachy_mic_source_applies_mute_gate_zeros_frames() -> None:
+    """When the MuteGate is muted, ReachyMicSource yields zeroed int16 frames.
+
+    Zero-at-source: all downstream consumers (OpenAI, head wobble, VU)
+    see silence consistently. Gate applied post-resample / pre-yield so
+    the int16 ndarray shape is fixed and the zeroing is a simple
+    np.zeros_like.
+    """
+    scripted = [
+        np.full((480, 2), 0.5, dtype=np.float32),
+        np.full((480, 2), -0.5, dtype=np.float32),
+    ]
+
+    class _FakeMediaMuted:
+        _i = 0
+
+        def get_audio_sample(self) -> np.ndarray | None:
+            if _FakeMediaMuted._i >= len(scripted):
+                raise asyncio.CancelledError
+            f = scripted[_FakeMediaMuted._i]
+            _FakeMediaMuted._i += 1
+            return f
+
+    class _FakeMiniMuted:
+        media = _FakeMediaMuted()
+
+    gate = MuteGate()
+    gate.set_muted(True)
+    src = ReachyMicSource(_FakeMiniMuted(), mute_gate=gate)
+
+    collected: list[AudioFrame] = []
+    with contextlib.suppress(asyncio.CancelledError):
+        async for frame in src.frames():
+            collected.append(frame)
+
+    assert len(collected) == 2
+    for sr, samples in collected:
+        assert sr == _LLM_RATE
+        assert np.all(samples == 0), f"muted frame had non-zero values: {samples!r}"
+
+
+async def test_reachy_mic_source_passes_through_when_unmuted() -> None:
+    """When the MuteGate is NOT muted, frames pass through unchanged."""
+    scripted = [np.full((480, 2), 0.5, dtype=np.float32)]
+
+    class _FakeMediaUnmuted:
+        _i = 0
+
+        def get_audio_sample(self) -> np.ndarray | None:
+            if _FakeMediaUnmuted._i >= len(scripted):
+                raise asyncio.CancelledError
+            f = scripted[_FakeMediaUnmuted._i]
+            _FakeMediaUnmuted._i += 1
+            return f
+
+    class _FakeMiniUnmuted:
+        media = _FakeMediaUnmuted()
+
+    gate = MuteGate()  # Defaults to unmuted.
+    src = ReachyMicSource(_FakeMiniUnmuted(), mute_gate=gate)
+
+    with contextlib.suppress(asyncio.CancelledError):
+        async for sr, samples in src.frames():
+            assert sr == _LLM_RATE
+            # 0.5 float32 → ~16383 int16 post-conversion — signal present.
+            assert np.any(samples != 0)
+            break
+
+
+async def test_reachy_mic_source_without_gate_passes_through() -> None:
+    """No mute_gate kwarg → frames pass through unchanged (back-compat)."""
+    scripted = [np.full((480, 2), 0.5, dtype=np.float32)]
+
+    class _FakeMediaNoGate:
+        _i = 0
+
+        def get_audio_sample(self) -> np.ndarray | None:
+            if _FakeMediaNoGate._i >= len(scripted):
+                raise asyncio.CancelledError
+            f = scripted[_FakeMediaNoGate._i]
+            _FakeMediaNoGate._i += 1
+            return f
+
+    class _FakeMiniNoGate:
+        media = _FakeMediaNoGate()
+
+    src = ReachyMicSource(_FakeMiniNoGate())  # No mute_gate kwarg.
+    with contextlib.suppress(asyncio.CancelledError):
+        async for _sr, samples in src.frames():
+            assert np.any(samples != 0)
+            break
+
+
+def test_load_default_mic_source_threads_mute_gate() -> None:
+    """Factory accepts ``mute_gate`` kwarg and passes it into ReachyMicSource."""
+    gate = MuteGate()
+
+    class _BareFakeMini:
+        pass
+
+    src = load_default_mic_source(reachy_mini=_BareFakeMini(), mute_gate=gate)
+    assert isinstance(src, ReachyMicSource)
+    # Verify the gate was threaded, not silently dropped.
+    assert src._mute_gate is gate  # noqa: SLF001 — test injection check.
+
+
+def test_load_default_mic_source_mute_gate_is_keyword_only() -> None:
+    """``mute_gate`` must be keyword-only — forward-compat with factory API growth."""
+    with pytest.raises(TypeError):
+        load_default_mic_source(object(), MuteGate())  # type: ignore[misc]

--- a/app/tests/test_embodiment_state_machine.py
+++ b/app/tests/test_embodiment_state_machine.py
@@ -198,3 +198,78 @@ def test_state_machine_without_mute_gate_still_works() -> None:
     assert sm.state == State.MUTED
     # Driver still got the visible sleep posture (existing behaviour).
     assert driver.went_to_sleep is True
+
+
+def test_failed_motion_leaves_state_and_mute_gate_unchanged() -> None:
+    """If the driver raises, _state AND _mute_gate stay at prior values.
+
+    Atomic-on-success contract: a half-failed transition (state moved,
+    gate didn't, or vice versa) is the exact bug Codex/Augment surfaced
+    on PR #71. Pinning here so a future refactor can't reintroduce it.
+    """
+
+    class _RaisingDriver(MotionDriver):
+        def play_move(self, name: str) -> None:
+            raise RuntimeError("simulated driver failure")
+
+        def go_to_sleep(self) -> None:
+            raise RuntimeError("simulated driver failure")
+
+        def wake_up(self) -> None:
+            raise RuntimeError("simulated driver failure")
+
+        def look_at_image(self, u: float, v: float, duration: float = 0.3) -> None:
+            raise RuntimeError("simulated driver failure")
+
+    gate = MuteGate()
+    driver = _RaisingDriver()
+    sm = EmbodimentStateMachine(driver, mute_gate=gate)
+
+    # MUTED entry that fails: state and gate must both stay at IDLE / unmuted.
+    with pytest.raises(RuntimeError, match="simulated driver failure"):
+        sm.transition(State.MUTED)
+    assert sm.state == State.IDLE, "state advanced despite driver failure"
+    assert gate.muted is False, "gate flipped despite driver failure"
+
+
+def test_failed_motion_from_muted_leaves_state_and_mute_gate_unchanged() -> None:
+    """Symmetric inverse: failed exit from MUTED keeps state == MUTED AND
+    gate.muted == True.
+
+    Codex specifically called out this direction (mic stays zeroed even
+    though the app reports muted — but state ALSO stays muted, so no
+    desync; the failed transition is a no-op for both).
+    """
+
+    class _ConditionalDriver(MotionDriver):
+        """Succeeds on go_to_sleep (entering MUTED), then raises on wake_up."""
+
+        def __init__(self) -> None:
+            self.went_to_sleep = False
+
+        def play_move(self, name: str) -> None:
+            pass  # not exercised in this test
+
+        def go_to_sleep(self) -> None:
+            self.went_to_sleep = True
+
+        def wake_up(self) -> None:
+            raise RuntimeError("simulated wake_up failure")
+
+        def look_at_image(self, u: float, v: float, duration: float = 0.3) -> None:
+            pass  # not exercised in this test
+
+    gate = MuteGate()
+    driver = _ConditionalDriver()
+    sm = EmbodimentStateMachine(driver, mute_gate=gate)
+
+    # Enter MUTED — succeeds.
+    sm.transition(State.MUTED)
+    assert sm.state == State.MUTED
+    assert gate.muted is True
+
+    # Exit MUTED — wake_up fails. State + gate must stay at MUTED / muted.
+    with pytest.raises(RuntimeError, match="simulated wake_up failure"):
+        sm.transition(State.IDLE)
+    assert sm.state == State.MUTED, "state advanced despite wake_up failure"
+    assert gate.muted is True, "gate cleared despite wake_up failure"

--- a/app/tests/test_embodiment_state_machine.py
+++ b/app/tests/test_embodiment_state_machine.py
@@ -8,6 +8,7 @@ from reachy_ducky_app.embodiment import (
     MockMotionDriver,
     MotionDriver,
 )
+from reachy_ducky_app.mute import MuteGate
 from reachy_ducky_protocol.messages import State
 
 
@@ -159,3 +160,41 @@ def test_every_state_has_entry_handling(target: State) -> None:
     sm = EmbodimentStateMachine(driver)
     sm.transition(target)
     assert sm.state == target
+
+
+def test_transition_to_muted_sets_mute_gate() -> None:
+    """Transitioning the state machine into MUTED toggles the MuteGate.
+
+    Earliest-boundary mute coordination: downstream consumers (mic pump,
+    VU meter, head wobble) all see the gate state change without each
+    needing its own transition subscription.
+    """
+    gate = MuteGate()
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver, mute_gate=gate)
+
+    assert gate.muted is False
+    sm.transition(State.MUTED)
+    assert gate.muted is True
+
+
+def test_transition_out_of_muted_clears_mute_gate() -> None:
+    """Leaving MUTED clears the gate symmetrically."""
+    gate = MuteGate()
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver, mute_gate=gate)
+
+    sm.transition(State.MUTED)
+    assert gate.muted is True
+    sm.transition(State.IDLE)
+    assert gate.muted is False
+
+
+def test_state_machine_without_mute_gate_still_works() -> None:
+    """``mute_gate=None`` is back-compat: no gate calls; transitions still fire."""
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver)  # No mute_gate kwarg.
+    sm.transition(State.MUTED)
+    assert sm.state == State.MUTED
+    # Driver still got the visible sleep posture (existing behaviour).
+    assert driver.went_to_sleep is True

--- a/app/tests/test_main_hardware.py
+++ b/app/tests/test_main_hardware.py
@@ -1,0 +1,68 @@
+"""Hardware smoke for #20 — mute coordination end-to-end on real hardware.
+
+Gated on ``@pytest.mark.hardware``. Runs when the user is on LAN and
+the Reachy Mini is reachable at ``reachy-mini.local``. Deferred from
+the offline workstream (which landed the integration smoke in
+``test_mute_integration.py``); runs alongside Task 1.5's audio smoke
+when the user is back on LAN.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import numpy as np
+import pytest
+from reachy_ducky_app.embodiment import EmbodimentStateMachine, MockMotionDriver
+from reachy_ducky_app.mute import MuteGate
+from reachy_ducky_app.voice.audio_io import AudioFrame, ReachyMicSource
+from reachy_ducky_protocol.messages import State
+
+reachy_mini = pytest.importorskip(
+    "reachy_mini",
+    reason="hardware tests require the reachy-mini SDK installed",
+)
+
+
+@pytest.mark.hardware
+async def test_muted_transition_zeros_live_mic() -> None:
+    """On real hardware, MUTED transition yields zeroed int16 samples.
+
+    Same contract as ``test_state_machine_transition_to_muted_zeros_mic_frames``
+    in the offline integration smoke, but against a LIVE ReachyMini
+    via the real SDK.
+    """
+    mini = reachy_mini.ReachyMini()
+    gate = MuteGate()
+    driver = MockMotionDriver()  # Don't actually care about motion side-effects here.
+    sm = EmbodimentStateMachine(driver, mute_gate=gate)
+    src = ReachyMicSource(mini, mute_gate=gate)
+
+    # Pull a few frames pre-mute; just confirm the pipeline is alive.
+    frames_before: list[AudioFrame] = []
+
+    async def drain_pre() -> None:
+        with contextlib.suppress(asyncio.CancelledError):
+            async for frame in src.frames():
+                frames_before.append(frame)
+                if len(frames_before) >= 2:
+                    return
+
+    await asyncio.wait_for(drain_pre(), timeout=5.0)
+
+    # Transition to MUTED; subsequent frames must be all zeros.
+    sm.transition(State.MUTED)
+    frames_after: list[AudioFrame] = []
+
+    async def drain_post() -> None:
+        with contextlib.suppress(asyncio.CancelledError):
+            async for frame in src.frames():
+                frames_after.append(frame)
+                if len(frames_after) >= 2:
+                    return
+
+    await asyncio.wait_for(drain_post(), timeout=5.0)
+
+    for _sr, samples in frames_after:
+        assert np.all(samples == 0), "live-hardware muted frame had signal"

--- a/app/tests/test_mute_integration.py
+++ b/app/tests/test_mute_integration.py
@@ -1,0 +1,138 @@
+"""Integration smoke — state machine -> MuteGate -> ReachyMicSource.
+
+Proves the A.1 + A.2 wiring end-to-end without hardware. Uses real
+``EmbodimentStateMachine``, ``MuteGate``, and ``ReachyMicSource``
+instances; only the underlying SDK is mocked (via a scripted
+``_ScriptedFakeMini``). A real hardware equivalent is filed in
+``test_main_hardware.py`` and runs under ``@pytest.mark.hardware``.
+
+This is NOT a unit test — it deliberately crosses module boundaries.
+Lives in its own file so it's easy to find and doesn't inflate the
+individual ``test_*.py`` files.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import numpy as np
+from reachy_ducky_app.embodiment import EmbodimentStateMachine, MockMotionDriver
+from reachy_ducky_app.mute import MuteGate
+from reachy_ducky_app.voice.audio_io import AudioFrame, ReachyMicSource
+from reachy_ducky_protocol.messages import State
+
+
+class _ScriptedFakeMini:
+    """FakeMini whose ``get_audio_sample`` is driven by a queue.
+
+    A real mic returns frames at sample-rate-bounded cadence; a list-pop
+    fake returns them as fast as the executor can call it, which lets
+    the mic pump outrun any orchestrator coroutine in the same task
+    group. Wrapping the queue lets the orchestrator deterministically
+    feed exactly one frame at a time and observe the resulting yield.
+
+    ``get_audio_sample`` returns ``None`` (the SDK's "buffer empty"
+    signal) when the queue is empty, which the mic loop handles with
+    its 10 ms sleep — natural pacing.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[np.ndarray] = []
+        self.media = self._Media(self)
+
+    def push(self, frame: np.ndarray) -> None:
+        self._pending.append(frame)
+
+    class _Media:
+        def __init__(self, outer: _ScriptedFakeMini) -> None:
+            self._outer = outer
+
+        def get_audio_sample(self) -> np.ndarray | None:
+            if not self._outer._pending:
+                return None
+            return self._outer._pending.pop(0)
+
+
+async def _await_frame_count(
+    frames: list[AudioFrame], target: int, *, timeout: float = 2.0
+) -> None:
+    """Poll until ``frames`` reaches ``target`` length or timeout."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while len(frames) < target:
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError(f"timed out waiting for frame {target}; got {len(frames)}")
+        await asyncio.sleep(0.01)
+
+
+async def test_state_machine_transition_to_muted_zeros_mic_frames() -> None:
+    """Transitioning the state machine to MUTED zeros subsequent mic frames.
+
+    Drives: sm.transition(MUTED) -> gate.set_muted(True) -> mic.frames()
+    yields zeros. Reverses: sm.transition(IDLE) -> gate clears ->
+    subsequent frames non-zero.
+    """
+    mini = _ScriptedFakeMini()
+    gate = MuteGate()
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver, mute_gate=gate)
+    src = ReachyMicSource(mini, mute_gate=gate)
+
+    frames_generated: list[AudioFrame] = []
+
+    async def drive_mic() -> None:
+        with contextlib.suppress(asyncio.CancelledError):
+            async for frame in src.frames():
+                frames_generated.append(frame)
+
+    mic_task = asyncio.create_task(drive_mic())
+    try:
+        # Frame 1: unmuted IDLE.
+        mini.push(np.full((480, 2), 0.5, dtype=np.float32))
+        await _await_frame_count(frames_generated, 1)
+
+        # Frame 2: muted.
+        sm.transition(State.MUTED)
+        mini.push(np.full((480, 2), 0.5, dtype=np.float32))
+        await _await_frame_count(frames_generated, 2)
+
+        # Frame 3: still muted.
+        mini.push(np.full((480, 2), 0.5, dtype=np.float32))
+        await _await_frame_count(frames_generated, 3)
+
+        # Frame 4: unmuted again.
+        sm.transition(State.IDLE)
+        mini.push(np.full((480, 2), 0.5, dtype=np.float32))
+        await _await_frame_count(frames_generated, 4)
+    finally:
+        mic_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await mic_task
+
+    assert len(frames_generated) == 4
+
+    # Frame 1: captured BEFORE any transition — non-zero.
+    assert np.any(frames_generated[0][1] != 0), "pre-mute frame was zeroed"
+    # Frames 2 + 3: AFTER transition to MUTED — zeroed.
+    assert np.all(frames_generated[1][1] == 0), "muted frame 2 had signal"
+    assert np.all(frames_generated[2][1] == 0), "muted frame 3 had signal"
+    # Frame 4: AFTER transition back to IDLE — non-zero again.
+    assert np.any(frames_generated[3][1] != 0), "post-unmute frame was zeroed"
+
+
+async def test_mute_gate_shared_between_state_machine_and_mic_source() -> None:
+    """Single MuteGate instance threaded to both ends — identity property."""
+    gate = MuteGate()
+    driver = MockMotionDriver()
+    sm = EmbodimentStateMachine(driver, mute_gate=gate)
+
+    mini = _ScriptedFakeMini()
+    src = ReachyMicSource(mini, mute_gate=gate)
+
+    bound_gate = src._mute_gate  # noqa: SLF001 — integration smoke.
+    assert bound_gate is not None
+    assert bound_gate is gate
+    assert bound_gate.muted is False
+
+    sm.transition(State.MUTED)
+    assert bound_gate.muted is True  # same object as ``gate``.


### PR DESCRIPTION
## Summary

Part A of the offline workstream (\`docs/plans/2026-04-24-offline-workstream.md\`). Wires \`MuteGate\` end-to-end so a state-machine MUTED transition zeros the mic pump's audio at the earliest possible boundary. Three commits, no hardware required for execution.

### Commits

1. **\`9be1bb2\`** — feat(embodiment): bind MuteGate into state machine MUTED transition (#20)
2. **\`cd13b16\`** — feat(app/voice): ReachyMicSource applies MuteGate pre-yield (#20)
3. **\`78f7572\`** — test(mute): full-stack integration smoke + deferred hardware test (#20)

### Design

**Zero-at-source.** \`MuteGate\` is applied inside \`ReachyMicSource.frames()\` immediately post-resample / pre-yield, so all downstream consumers (OpenAI Realtime, future head-wobble driver, VU meter) observe consistent silence when muted — no per-consumer mute subscription needed.

**Single shared instance.** \`main._run_async\` constructs ONE \`MuteGate\` and threads the SAME instance to both \`EmbodimentStateMachine\` (toggles on MUTED transitions) and \`load_default_mic_source\` (applies per frame). Identity property pinned by \`test_mute_gate_shared_between_state_machine_and_mic_source\`.

**Speaker stays unmuted by design.** \`load_default_speaker_sink\` deliberately does NOT get a \`MuteGate\` kwarg — speaker output is LLM-generated assistant audio; muting the user's mic shouldn't silence the assistant's replies.

**Keyword-only kwargs.** \`mute_gate\` is \`*, mute_gate=...\` everywhere it appears (state machine, ReachyMicSource, factory) — matches the convention from PR #68's \`reachy_mini\` factory kwarg.

### Testing

- **8 new unit tests** cover the state-machine toggle, the mic-source application, the factory threading, and the \`mute_gate=None\` back-compat path.
- **2 new integration smoke tests** in \`test_mute_integration.py\` drive the full stack (real EmbodimentStateMachine + real MuteGate + real ReachyMicSource + scripted FakeMini) — proves wiring without hardware.
- **1 deferred hardware smoke** in \`test_main_hardware.py\` (\`@pytest.mark.hardware\`, opt-in, runs when on LAN) — same contract against a live ReachyMini.

\`_ScriptedFakeMini\` is queue-driven (push frames between transitions) rather than list-popping — \`asyncio.gather + sleep\` doesn't reliably interleave with \`run_in_executor\`-bound coroutines. Production-code-equivalent timing semantics.

### Gates

- \`ruff check .\` clean (79 files)
- \`ruff format --check .\` clean
- \`mypy --strict\` 0 issues
- \`pyright\` CLI 0/0/0
- \`bandit -ll\` 0 issues
- \`pytest -q --cov\` — **640 passed**, 8 deselected; coverage **91.57%** (≥ 90% floor)

### Deferred

- Hardware smoke (\`test_muted_transition_zeros_live_mic\`) — runs alongside Task 1.5's M1 audio smoke when the user is back on LAN.

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)