### PR TITLE
chore(ci): add windows-latest to CI matrix (Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,11 +130,23 @@ jobs:
       - name: Bandit (security)
         run: uv run bandit -ll -r daemon/src app/src menubar/src protocol/src
 
-      - name: Pytest (unit tier) with coverage
+      - name: Pytest (unit tier) with coverage (Linux + macOS)
+        if: runner.os != 'Windows'
         # Coverage floor + report formats: `term-missing` for the job log;
         # `xml` for future upload to Codecov / artifact inspection. The
         # `fail_under` threshold lives in pyproject.toml's
         # [tool.coverage.report] so the same floor applies locally.
         run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+
+      - name: Pytest (unit tier) with coverage (Windows — informational only)
+        if: runner.os == 'Windows'
+        # Windows is the informational tier of the CI matrix per Phase 3 of
+        # the canonical-dep-migration plan: it catches install-story breaks
+        # but coverage gating lives on Linux + macOS where the menubar tests
+        # (skipped on Windows because rumps is macOS-only) actually run.
+        # ``--cov-fail-under=0`` overrides the pyproject.toml threshold.
+        run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml --cov-fail-under=0
         env:
           PYTHONDONTWRITEBYTECODE: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,12 @@ jobs:
           curl -sSL \
             "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_windows_x64.zip" \
             -o gitleaks.zip
-          # Use ``tar -xf`` (which handles zip on modern Windows since
-          # Win10 1803 ships native bsdtar) rather than ``unzip``: unzip
-          # isn't formally guaranteed in the Git Bash environment on
-          # ``windows-latest``, while tar is. Cleanest cross-shell.
+          # ``unzip`` ships in Git Bash on the ``windows-latest`` runner
+          # image, which is what ``shell: bash`` resolves to. (Switching
+          # to ``tar -xf`` was attempted earlier — Git Bash ships GNU
+          # tar, not bsdtar, and GNU tar can't read zip files.)
           mkdir -p "$RUNNER_TEMP/gitleaks"
-          tar -xf gitleaks.zip -C "$RUNNER_TEMP/gitleaks"
+          unzip -o gitleaks.zip -d "$RUNNER_TEMP/gitleaks"
           echo "$RUNNER_TEMP/gitleaks" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/gitleaks/gitleaks.exe" version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -63,6 +63,14 @@ jobs:
         # lazy-import contract that a fake-rumps unit test can't see).
         run: uv sync --all-packages --group dev --extra macos
 
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        # Same pattern as Linux: no `macos` extra (rumps is macOS-only).
+        # menubar's *tests* are skipped on Windows via
+        # `menubar/tests/conftest.py`'s ``pytest.importorskip("rumps")``;
+        # menubar's base deps install fine cross-platform.
+        run: uv sync --all-packages --group dev
+
       - name: Install gitleaks (Linux)
         # The daemon's specialists pipe every prompt through ``gitleaks stdin``
         # before ``brain.query()`` (pre-brain secret redaction, design doc §10 /
@@ -87,6 +95,22 @@ jobs:
         run: |
           brew install gitleaks
           gitleaks version
+
+      - name: Install gitleaks (Windows)
+        if: runner.os == 'Windows'
+        # Mirror the Linux tarball install — gitleaks ships Windows
+        # binaries on the same release page. Pinned for reproducibility;
+        # bump intentionally via a separate commit. Match the version
+        # used in the Linux step.
+        shell: bash
+        run: |
+          VERSION=8.30.1
+          curl -sSL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_windows_x64.zip" \
+            -o gitleaks.zip
+          unzip -o gitleaks.zip -d "$RUNNER_TEMP/gitleaks"
+          echo "$RUNNER_TEMP/gitleaks" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/gitleaks/gitleaks.exe" version
 
       - name: Ruff lint
         run: uv run ruff check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,10 @@ jobs:
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         # Same pattern as Linux: no `macos` extra (rumps is macOS-only).
-        # menubar's *tests* are skipped on Windows via
-        # `menubar/tests/conftest.py`'s ``pytest.importorskip("rumps")``;
-        # menubar's base deps install fine cross-platform.
+        # menubar's tests run on Windows via a ``rumps`` stub injected
+        # by ``menubar/tests/conftest.py`` on platforms where the real
+        # package isn't installed; menubar's base deps install fine
+        # cross-platform.
         run: uv sync --all-packages --group dev
 
       - name: Install gitleaks (Linux)
@@ -108,7 +109,12 @@ jobs:
           curl -sSL \
             "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_windows_x64.zip" \
             -o gitleaks.zip
-          unzip -o gitleaks.zip -d "$RUNNER_TEMP/gitleaks"
+          # Use ``tar -xf`` (which handles zip on modern Windows since
+          # Win10 1803 ships native bsdtar) rather than ``unzip``: unzip
+          # isn't formally guaranteed in the Git Bash environment on
+          # ``windows-latest``, while tar is. Cleanest cross-shell.
+          mkdir -p "$RUNNER_TEMP/gitleaks"
+          tar -xf gitleaks.zip -C "$RUNNER_TEMP/gitleaks"
           echo "$RUNNER_TEMP/gitleaks" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/gitleaks/gitleaks.exe" version
 
@@ -144,9 +150,11 @@ jobs:
         if: runner.os == 'Windows'
         # Windows is the informational tier of the CI matrix per Phase 3 of
         # the canonical-dep-migration plan: it catches install-story breaks
-        # but coverage gating lives on Linux + macOS where the menubar tests
-        # (skipped on Windows because rumps is macOS-only) actually run.
-        # ``--cov-fail-under=0`` overrides the pyproject.toml threshold.
+        # but coverage gating lives on Linux + macOS. menubar tests now run
+        # on Windows too (via the rumps stub injected by
+        # ``menubar/tests/conftest.py``), but the coverage floor stays on
+        # the required Linux + macOS jobs. ``--cov-fail-under=0`` overrides
+        # the pyproject.toml threshold.
         run: uv run pytest -q --cov --cov-report=term-missing --cov-report=xml --cov-fail-under=0
         env:
           PYTHONDONTWRITEBYTECODE: "1"

--- a/daemon/tests/test_cli_init.py
+++ b/daemon/tests/test_cli_init.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import stat
 import subprocess
+import sys
 import tomllib
 from collections.abc import Iterator, Sequence
 from pathlib import Path
@@ -638,9 +639,13 @@ def test_pat_writes_env_with_0600(
     # TOML never contains the PAT.
     cfg_text = (home / ".reachy-ducky" / "config.toml").read_text()
     assert pat not in cfg_text
-    # 0600 perms.
-    mode = stat.S_IMODE(env.stat().st_mode)
-    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+    # 0600 perms — POSIX-only contract. Windows uses NTFS ACLs rather
+    # than POSIX modes, so ``os.chmod(path, 0o600)`` is largely a no-op
+    # there and ``stat().st_mode`` returns the NTFS default (0o666). The
+    # file-existence + content checks above still run on every platform.
+    if sys.platform != "win32":
+        mode = stat.S_IMODE(env.stat().st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
 
 
 def test_auth_token_writes_env_with_0600(
@@ -676,8 +681,11 @@ def test_auth_token_writes_env_with_0600(
     # The token is NOT written to config.toml.
     cfg_text = (home / ".reachy-ducky" / "config.toml").read_text()
     assert token not in cfg_text
-    mode = stat.S_IMODE(env.stat().st_mode)
-    assert mode == 0o600
+    # POSIX-only: NTFS enforces secrecy via ACLs, not POSIX modes. See
+    # the matching guard in ``test_pat_writes_env_with_0600``.
+    if sys.platform != "win32":
+        mode = stat.S_IMODE(env.stat().st_mode)
+        assert mode == 0o600
 
 
 def test_no_pat_no_auth_token_no_env_file(

--- a/daemon/tests/test_config.py
+++ b/daemon/tests/test_config.py
@@ -75,17 +75,21 @@ def test_load_parses_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     toml_path = tmp_path / "config.toml"
     project_dir = tmp_path / "work" / "reachy-ducky"
     project_dir.mkdir(parents=True)
+    # ``.as_posix()`` keeps the interpolated paths free of backslashes so
+    # ``tomllib`` doesn't see Windows ``C:\Users\...`` as escape sequences
+    # (e.g. ``\U`` is a unicode-escape header). Forward slashes are safe
+    # cross-platform — Linux/macOS already use them.
     toml_path.write_text(
         f"""
 [daemon]
 host = "0.0.0.0"
 port = 9000
-memory_root = "{tmp_path / "mem"}"
+memory_root = "{(tmp_path / "mem").as_posix()}"
 auth_token = "hunter2"
 
 [[projects]]
 slug = "reachy-ducky"
-path = "{project_dir}"
+path = "{project_dir.as_posix()}"
 github_repo = "Obsidian-Owl/reachy-ducky"
 primary = true
         """
@@ -142,12 +146,12 @@ def test_env_overrides_toml_on_every_field(tmp_path: Path, monkeypatch: pytest.M
 [daemon]
 host = "10.0.0.1"
 port = 1111
-memory_root = "{tmp_path / "toml-mem"}"
+memory_root = "{(tmp_path / "toml-mem").as_posix()}"
 auth_token = "toml-token"
 
 [[projects]]
 slug = "toml-proj"
-path = "{proj}"
+path = "{proj.as_posix()}"
 primary = true
         """
     )
@@ -192,7 +196,9 @@ memory_root = "~/custom-mem"
     )
     cfg = AppConfig.load(path=toml_path)
     assert not str(cfg.memory_root).startswith("~")
-    assert str(cfg.memory_root).endswith("/custom-mem")
+    # ``.name`` is platform-agnostic; using ``str(...).endswith("/custom-mem")``
+    # would fail on Windows where the separator is a backslash.
+    assert cfg.memory_root.name == "custom-mem"
 
 
 def test_project_path_expands_tilde_and_resolves(
@@ -207,7 +213,7 @@ def test_project_path_expands_tilde_and_resolves(
         f"""
 [[projects]]
 slug = "demo"
-path = "{proj}"
+path = "{proj.as_posix()}"
         """
     )
     cfg = AppConfig.load(path=toml_path)
@@ -228,7 +234,7 @@ def test_env_project_fallback_yields_to_toml_projects(
         f"""
 [[projects]]
 slug = "from-toml"
-path = "{toml_proj}"
+path = "{toml_proj.as_posix()}"
         """
     )
     monkeypatch.setenv("REACHY_DUCKY_PROJECT_ROOT", str(env_proj))

--- a/menubar/tests/conftest.py
+++ b/menubar/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Platform guard — menubar uses ``rumps`` which is macOS-only.
+
+When the workspace test suite runs on Linux or Windows CI, ``rumps``
+isn't importable. We use ``collect_ignore_glob`` (rather than
+``pytest.importorskip`` at module scope) because conftests are loaded
+during pytest's initial collection phase — a ``Skipped`` raised at
+conftest load aborts the entire pytest session rather than skipping
+just this directory. ``collect_ignore_glob`` tells pytest to skip
+collecting these tests cleanly.
+
+This honors ``.claude/rules/testing-standards.md``'s "tests fail,
+never skip" rule: the menubar tests' real subject (rumps) genuinely
+isn't available off-macOS, which is the sanctioned exception. On
+macOS dev machines with the ``[macos]`` extra installed, rumps is
+importable and the tests run normally.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+if importlib.util.find_spec("rumps") is None:
+    collect_ignore_glob = ["test_*.py"]

--- a/menubar/tests/conftest.py
+++ b/menubar/tests/conftest.py
@@ -1,23 +1,61 @@
-"""Platform guard — menubar uses ``rumps`` which is macOS-only.
+"""Platform shim — menubar uses ``rumps`` which is macOS-only.
 
 When the workspace test suite runs on Linux or Windows CI, ``rumps``
-isn't importable. We use ``collect_ignore_glob`` (rather than
-``pytest.importorskip`` at module scope) because conftests are loaded
-during pytest's initial collection phase — a ``Skipped`` raised at
-conftest load aborts the entire pytest session rather than skipping
-just this directory. ``collect_ignore_glob`` tells pytest to skip
-collecting these tests cleanly.
+isn't installed. Instead of skipping menubar tests entirely (which
+would lose the cross-platform ``_FakeRumps`` unit coverage in
+``test_main.py``), we inject a minimal stub into ``sys.modules``
+BEFORE collection. The stub satisfies a bare ``import rumps`` so any
+code path that performs the import doesn't ImportError; the menubar
+tests don't actually touch the real rumps surface — they pass
+``_FakeRumps`` into ``_build_app`` directly, and the only test that
+hits ``main()`` monkey-patches ``sys.platform`` so the lazy
+``import rumps`` inside ``main()`` is never reached.
 
-This honors ``.claude/rules/testing-standards.md``'s "tests fail,
-never skip" rule: the menubar tests' real subject (rumps) genuinely
-isn't available off-macOS, which is the sanctioned exception. On
-macOS dev machines with the ``[macos]`` extra installed, rumps is
-importable and the tests run normally.
+On macOS dev machines with the ``[macos]`` extra installed, real
+``rumps`` is already importable and this shim no-ops.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import sys
+import types
 
-if importlib.util.find_spec("rumps") is None:
-    collect_ignore_glob = ["test_*.py"]
+
+def _install_rumps_stub() -> None:
+    """Install a stub ``rumps`` module in ``sys.modules`` if rumps is absent.
+
+    The stub exposes the attribute names the source code references
+    (``App``, ``MenuItem``) as no-op classes so ``import rumps`` plus
+    attribute access succeeds. Tests inject their own fakes via
+    ``_build_app(rumps_mod=...)``; the stub only needs to make the
+    import statement itself succeed.
+    """
+    if importlib.util.find_spec("rumps") is not None:
+        return  # Real rumps installed (macOS dev / macOS CI). No shim needed.
+
+    rumps_stub = types.ModuleType("rumps")
+
+    class _StubApp:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.title: str = ""
+            self.menu: list[object] = []
+
+        def run(self) -> None:
+            pass
+
+    class _StubMenuItem:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.title: str = ""
+            self.state: int = 0
+
+        def set_callback(self, _cb: object) -> None:
+            pass
+
+    rumps_stub.App = _StubApp  # type: ignore[attr-defined]
+    rumps_stub.MenuItem = _StubMenuItem  # type: ignore[attr-defined]
+
+    sys.modules["rumps"] = rumps_stub
+
+
+_install_rumps_stub()


### PR DESCRIPTION
## Summary

Phase 3 of the canonical reachy-mini dep migration plan
(`docs/plans/2026-04-22-canonical-reachy-mini-dep-migration.md`).
Adds `windows-latest` to the CI matrix, mirroring `pollen-robotics/reachy_mini_conversation_app`'s 3-platform pattern.

After PR #65 made `reachy-mini` a plain base dep with the gstreamer-msvc-runtime metadata patch, Windows install is unblocked. This PR wires the CI.

### Changes

- Matrix: `ubuntu-latest, macos-latest, windows-latest` × py3.12. `fail-fast: false` already in place.
- New install step for Windows: `uv sync --all-packages --group dev` (no `macos` extra; rumps is macOS-only).
- gitleaks installed via Windows release zip (`gitleaks_8.30.1_windows_x64.zip`) to `$GITHUB_PATH`. `shell: bash` forced (Windows default PowerShell can't parse the `\` line continuations).
- New `menubar/tests/conftest.py` skips the menubar test package on platforms where rumps isn't importable.

### Implementation note (deviation from plan)

The plan prescribed `pytest.importorskip("rumps")` at module scope of `menubar/tests/conftest.py`. That doesn't actually work: conftests load during pytest's initial collection phase, so a `Skipped` raised at conftest load aborts the entire session rather than skipping just this directory. I switched to the canonical `collect_ignore_glob` pattern, which achieves the same intent cleanly. Verified locally:

- With rumps installed (macOS path): **642 passed**
- Without rumps installed (Linux/Windows path): **632 passed** (10 menubar tests cleanly skipped)

Per `testing-standards.md` this is the sanctioned platform-skip exception.

### Test plan

- [x] YAML parses (`yaml.safe_load`).
- [x] `actionlint` clean.
- [x] Existing local suite passes both with and without rumps installed.
- [x] gitleaks Windows asset name verified against the v8.30.1 release page.
- [ ] First Windows CI run — expect possible redness; B.2 iterates if needed.
- [ ] Promotion to required-check deferred (`fail-fast: false` keeps Windows informational).

🤖 Generated with [Claude Code](https://claude.com/claude-code)