### PR TITLE
fix(tests/hardware): use ReachyMini context manager + tighten caplog scope

### DIFF
--- a/app/tests/test_main_hardware.py
+++ b/app/tests/test_main_hardware.py
@@ -33,36 +33,40 @@ async def test_muted_transition_zeros_live_mic() -> None:
     in the offline integration smoke, but against a LIVE ReachyMini
     via the real SDK.
     """
-    mini = reachy_mini.ReachyMini()
-    gate = MuteGate()
-    driver = MockMotionDriver()  # Don't actually care about motion side-effects here.
-    sm = EmbodimentStateMachine(driver, mute_gate=gate)
-    src = ReachyMicSource(mini, mute_gate=gate)
+    # Use the context manager so ``media_manager.close()`` runs on exit —
+    # otherwise the GStreamer/WebRTC pipeline must be torn down by GC at
+    # interpreter shutdown, which deadlocks on a tokio mutex inside
+    # libgstrswebrtc and hangs pytest indefinitely.
+    with reachy_mini.ReachyMini() as mini:
+        gate = MuteGate()
+        driver = MockMotionDriver()  # Don't actually care about motion side-effects here.
+        sm = EmbodimentStateMachine(driver, mute_gate=gate)
+        src = ReachyMicSource(mini, mute_gate=gate)
 
-    # Pull a few frames pre-mute; just confirm the pipeline is alive.
-    frames_before: list[AudioFrame] = []
+        # Pull a few frames pre-mute; just confirm the pipeline is alive.
+        frames_before: list[AudioFrame] = []
 
-    async def drain_pre() -> None:
-        with contextlib.suppress(asyncio.CancelledError):
-            async for frame in src.frames():
-                frames_before.append(frame)
-                if len(frames_before) >= 2:
-                    return
+        async def drain_pre() -> None:
+            with contextlib.suppress(asyncio.CancelledError):
+                async for frame in src.frames():
+                    frames_before.append(frame)
+                    if len(frames_before) >= 2:
+                        return
 
-    await asyncio.wait_for(drain_pre(), timeout=5.0)
+        await asyncio.wait_for(drain_pre(), timeout=5.0)
 
-    # Transition to MUTED; subsequent frames must be all zeros.
-    sm.transition(State.MUTED)
-    frames_after: list[AudioFrame] = []
+        # Transition to MUTED; subsequent frames must be all zeros.
+        sm.transition(State.MUTED)
+        frames_after: list[AudioFrame] = []
 
-    async def drain_post() -> None:
-        with contextlib.suppress(asyncio.CancelledError):
-            async for frame in src.frames():
-                frames_after.append(frame)
-                if len(frames_after) >= 2:
-                    return
+        async def drain_post() -> None:
+            with contextlib.suppress(asyncio.CancelledError):
+                async for frame in src.frames():
+                    frames_after.append(frame)
+                    if len(frames_after) >= 2:
+                        return
 
-    await asyncio.wait_for(drain_post(), timeout=5.0)
+        await asyncio.wait_for(drain_post(), timeout=5.0)
 
-    for _sr, samples in frames_after:
-        assert np.all(samples == 0), "live-hardware muted frame had signal"
+        for _sr, samples in frames_after:
+            assert np.all(samples == 0), "live-hardware muted frame had signal"

--- a/app/tests/test_main_hardware.py
+++ b/app/tests/test_main_hardware.py
@@ -10,7 +10,6 @@ when the user is back on LAN.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 
 import numpy as np
 import pytest
@@ -44,29 +43,37 @@ async def test_muted_transition_zeros_live_mic() -> None:
         src = ReachyMicSource(mini, mute_gate=gate)
 
         # Pull a few frames pre-mute; just confirm the pipeline is alive.
+        # Don't suppress CancelledError — wait_for delivers the timeout via
+        # cancellation, and swallowing it would convert a "no frames in 5s"
+        # timeout into a silent successful return. Length asserts after
+        # each drain pin the actual frame count regardless.
         frames_before: list[AudioFrame] = []
 
         async def drain_pre() -> None:
-            with contextlib.suppress(asyncio.CancelledError):
-                async for frame in src.frames():
-                    frames_before.append(frame)
-                    if len(frames_before) >= 2:
-                        return
+            async for frame in src.frames():
+                frames_before.append(frame)
+                if len(frames_before) >= 2:
+                    return
 
         await asyncio.wait_for(drain_pre(), timeout=5.0)
+        assert len(frames_before) >= 2, (
+            f"expected at least 2 pre-mute frames in 5s, got {len(frames_before)}"
+        )
 
         # Transition to MUTED; subsequent frames must be all zeros.
         sm.transition(State.MUTED)
         frames_after: list[AudioFrame] = []
 
         async def drain_post() -> None:
-            with contextlib.suppress(asyncio.CancelledError):
-                async for frame in src.frames():
-                    frames_after.append(frame)
-                    if len(frames_after) >= 2:
-                        return
+            async for frame in src.frames():
+                frames_after.append(frame)
+                if len(frames_after) >= 2:
+                    return
 
         await asyncio.wait_for(drain_post(), timeout=5.0)
+        assert len(frames_after) >= 2, (
+            f"expected at least 2 post-mute frames in 5s, got {len(frames_after)}"
+        )
 
         for _sr, samples in frames_after:
             assert np.all(samples == 0), "live-hardware muted frame had signal"

--- a/app/tests/test_sdk_audio_contract.py
+++ b/app/tests/test_sdk_audio_contract.py
@@ -112,13 +112,17 @@ def test_get_audio_sample_returns_non_empty_stereo_buffer() -> None:
     explicitly so a shape change surfaces here before the adapter
     silently produces corrupted audio at the channel-pick step.
     """
-    mini = ReachyMini()
-    deadline = time.monotonic() + 2.0
-    sample: np.ndarray | None = None
-    while time.monotonic() < deadline:
-        sample = mini.media.get_audio_sample()
-        if sample is not None and sample.size > 0:
-            break
+    # Use the context manager so ``media_manager.close()`` runs on exit —
+    # otherwise the GStreamer/WebRTC pipeline must be torn down by GC at
+    # interpreter shutdown, which deadlocks on a tokio mutex inside
+    # libgstrswebrtc and hangs pytest indefinitely.
+    with ReachyMini() as mini:
+        deadline = time.monotonic() + 2.0
+        sample: np.ndarray | None = None
+        while time.monotonic() < deadline:
+            sample = mini.media.get_audio_sample()
+            if sample is not None and sample.size > 0:
+                break
     assert sample is not None, "get_audio_sample kept returning None for 2s — mic not primed?"
     assert sample.size > 0, f"get_audio_sample yielded empty array ({sample!r})"
     assert sample.dtype == np.float32, f"expected float32 per SDK contract, got {sample.dtype}"
@@ -140,17 +144,39 @@ def test_push_audio_sample_accepts_silent_frame(
     float32↔PCM16 conversion at the Reachy adapter boundary.
 
     We assert not only that the call doesn't raise but also that it
-    emits no warning — the SDK silently logs a warning and returns on
-    wrong-shape input (media_manager.py:343-347), so a no-op silently
-    passing "must not raise" would be the accomplishment-simulator
-    anti-pattern ``testing-standards.md`` warns against.
+    emits no warning *from the media_manager logger* — the SDK
+    silently logs a warning and returns on wrong-shape input
+    (media_manager.py:340 "Audio system is not initialized" and
+    media_manager.py:344 "must have at most 2 dimensions"), so a no-op
+    silently passing "must not raise" would be the
+    accomplishment-simulator anti-pattern ``testing-standards.md``
+    warns against.
+
+    We filter on logger name because ``ReachyMini()`` construction
+    eagerly initializes the DOA mic-array (``audio_doa.py:46``), which
+    logs an ERROR at ``reachy_mini.media.audio_control_utils`` if the
+    USB-control device isn't enumerated. That path is orthogonal to
+    ``push_audio_sample`` — audio I/O routes through the GStreamer
+    backend regardless of whether USB-direct ReSpeaker control is
+    available.
     """
-    mini = ReachyMini()
-    # 40ms @ 24 kHz mono float32 = 960 samples.
-    silent = np.zeros(960, dtype=np.float32)
-    with caplog.at_level(logging.WARNING, logger="reachy_mini.media.media_manager"):
+    # Use the context manager so ``media_manager.close()`` runs on exit —
+    # otherwise the GStreamer/WebRTC pipeline must be torn down by GC at
+    # interpreter shutdown, which deadlocks on a tokio mutex inside
+    # libgstrswebrtc and hangs pytest indefinitely.
+    media_manager_logger = "reachy_mini.media.media_manager"
+    with ReachyMini() as mini, caplog.at_level(logging.WARNING, logger=media_manager_logger):
+        # 40ms @ 24 kHz mono float32 = 960 samples.
+        silent = np.zeros(960, dtype=np.float32)
         mini.media.push_audio_sample(silent)
-    assert not caplog.records, (
-        f"push_audio_sample logged warnings (data dropped silently): "
-        f"{[r.getMessage() for r in caplog.records]}"
+    # Filter on logger name AND level. ReachyMini construction emits INFO
+    # records on the media_manager logger ("Using WebRTC streaming backend.")
+    # that we don't care about — the silent-drop antipatterns we're guarding
+    # against are both at WARNING (media_manager.py:340 / :344).
+    relevant = [
+        r for r in caplog.records if r.name == media_manager_logger and r.levelno >= logging.WARNING
+    ]
+    assert not relevant, (
+        f"push_audio_sample logged warnings from media_manager (data dropped silently): "
+        f"{[r.getMessage() for r in relevant]}"
     )


### PR DESCRIPTION
## Summary

Two issues uncovered when running the hardware tier against a live Reachy Mini:

1. **`ReachyMini()` without `with` deadlocks pytest at interpreter shutdown.** The GStreamer/WebRTC pipeline must be torn down by GC, which blocks on a tokio mutex inside `libgstrswebrtc` (verified via `sample(1)` of the stuck process — main thread in `Py_FinalizeEx → gc_collect_main → gst_element_set_state_func → _pthread_mutex_firstfit_lock_wait`). The SDK's `__exit__` calls `media_manager.close()` explicitly; we just weren't using it.

2. **`caplog` assertion was too broad.** It caught any record on the `media_manager` logger, including the INFO `"Using WebRTC streaming backend."` emitted during `ReachyMini` construction (which happens *before* the `caplog.at_level` context window in a `with X, Y:` block — `X` is constructed first). Filter on `levelno >= WARNING` so only the actual silent-drop antipatterns at `media_manager.py:340` ("Audio system is not initialized") and `:344` ("must have at most 2 dimensions") trigger a failure.

The earlier ERROR `"No Reachy Mini Audio USB device found!"` (logged from `reachy_mini.media.audio_control_utils:410`, called via `audio_doa.py:46`) is benign on this hardware: DOA = direction-of-arrival mic-array USB-control, orthogonal to `push_audio_sample` (which routes through the GStreamer audio backend regardless of USB-direct ReSpeaker control). Filtering by logger name keeps the test focused on the actual contract.

## Test plan

- [x] `uv run pytest -m hardware -v` against a live Reachy Mini on LAN — 3/3 pass, no shutdown hang
- [x] `uv run pytest -q` (default tier) — green
- [x] Pre-commit (ruff, gitleaks) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)