### PR TITLE
feat(app): add alpha live-mode entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ uv run reachy-ducky-daemon
 Live hardware dev run from the Mac:
 
 ```bash
-uv run reachy-ducky-app-live
+set -a; source ~/.reachy-ducky/.env; set +a
+DAEMON_AUTH_TOKEN="$REACHY_DUCKY_AUTH_TOKEN" uv run reachy-ducky-app-live
 ```
 
-The live app loads `~/.reachy-ducky/.env`, connects to a LAN Reachy Mini, and
-uses the Mac-side daemon for `/brain/query` turns.
+The live app connects to a LAN Reachy Mini and uses the Mac-side daemon for
+`/brain/query` turns. `reachy-ducky init` writes the daemon token as
+`REACHY_DUCKY_AUTH_TOKEN`; map it to `DAEMON_AUTH_TOKEN` for the app client.
 
 Robot dashboard install: publish the app Space, then install it from the
 Reachy dashboard. Walking that dashboard path on hardware is part of alpha

--- a/README.md
+++ b/README.md
@@ -5,24 +5,48 @@ Read-only desk robot that watches your agentic SWE workflow and talks with you.
 
 See `docs/plans/2026-04-21-reachy-ducky-design.md` for the full design.
 
-Status: Phase A MVP in progress.
+Status: alpha candidate in release hardening.
 
-## Run (Phase A)
+## Run (Alpha Candidate)
 
-- Mac daemon: `uv run reachy-ducky-daemon` (first run: `uv run reachy-ducky init`
-  to write `~/.reachy-ducky/config.toml` + `.env`).
-- Menu-bar (macOS-only in Phase A — `rumps` lives in the optional `macos`
-  extra): `uv run reachy-ducky-menubar`.
-- Reachy app: one-click install from the on-robot dashboard after publishing
-  via HF Spaces. The publish path is **unverified** in Phase A — see
-  `docs/testing/2026-04-21-phase-a-e2e-procedure.md` Known gaps §3. For
-  running the app locally during development, see `app/README.md`.
-- Wake-word detection is a no-op stub in Phase A (`MockWakeDetector`); saying
-  "Hey Ducky" does nothing today. The smoke procedure below shows how to
-  exercise a turn without wake.
+First-time setup:
+
+```bash
+uv sync --all-packages --group dev
+uv run reachy-ducky init
+```
+
+The setup wizard writes `~/.reachy-ducky/config.toml`, a 0600
+`~/.reachy-ducky/.env` secrets file, and the configured memory tree.
+
+Mac daemon:
+
+```bash
+set -a; source ~/.reachy-ducky/.env; set +a
+uv run reachy-ducky-daemon
+```
+
+Live hardware dev run from the Mac:
+
+```bash
+uv run reachy-ducky-app-live
+```
+
+The live app loads `~/.reachy-ducky/.env`, connects to a LAN Reachy Mini, and
+uses the Mac-side daemon for `/brain/query` turns.
+
+Robot dashboard install: publish the app Space, then install it from the
+Reachy dashboard. Walking that dashboard path on hardware is part of alpha
+release validation; do not assume it is complete from local runs alone.
+
+Alpha wake word: say `hey jarvis`. The alpha build uses vendored openWakeWord
+ONNX weights. Custom `hey ducky` wake-word support is deferred to #75.
+
+Optional menu-bar (macOS-only; `rumps` lives in the optional `macos` extra):
+`uv run reachy-ducky-menubar`.
 
 See `docs/testing/2026-04-21-phase-a-e2e-procedure.md` for the full end-to-end
-smoke procedure and known gaps.
+smoke procedure.
 
 ## Development
 

--- a/app/README.md
+++ b/app/README.md
@@ -23,9 +23,10 @@ The Reachy Mini side of the [Reachy Ducky project](https://github.com/Obsidian-O
 ## What it does
 
 On-demand conversational rubber-ducky companion for agentic SWE work.
-Say "Hey Ducky", ask a question, get an answer. The Mac-side daemon
-does the thinking (Claude Agent SDK with a project-scoped tool surface);
-this app handles voice I/O on the robot.
+For alpha, say `hey jarvis`, ask a question, get an answer. The alpha wake
+word uses vendored openWakeWord ONNX weights; custom `hey ducky` support is
+deferred to #75. The Mac-side daemon does the thinking (Claude Agent SDK with a
+project-scoped tool surface); this app handles voice I/O on the robot.
 
 ## Install
 
@@ -47,7 +48,7 @@ this app handles voice I/O on the robot.
 Split-brain: voice on the robot, thinking on the Mac.
 Full design: https://github.com/Obsidian-Owl/reachy-ducky/blob/main/docs/plans/2026-04-21-reachy-ducky-design.md
 
-Phase A scope: on-demand conversational mode only. Wake-word triggers
+Alpha scope: on-demand conversational mode only. Wake-word triggers
 a single turn; response speaks back. Listening / thinking state machine
 expresses body motion (head tilt, antenna animation) via the Reachy
 emotions library. Always-on passive observation (phase C) is deferred.

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "reachy-mini>=1.6.4,<2",
 ]
 
+[project.scripts]
+reachy-ducky-app-live = "reachy_ducky_app.main:live_main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -265,6 +265,23 @@ def _load_dotenv(path: Path) -> int:
     return loaded
 
 
+def _mirror_daemon_auth_token() -> bool:
+    """Map daemon-side init token name to the app client's env contract.
+
+    ``reachy-ducky init`` writes ``REACHY_DUCKY_AUTH_TOKEN`` for the Mac
+    daemon. The robot-side/client code reads ``DAEMON_AUTH_TOKEN``. Live
+    mode runs both roles from the same Mac checkout, so mirror the value
+    after dotenv loading unless the caller already set the app-side name.
+    """
+    if os.environ.get("DAEMON_AUTH_TOKEN"):
+        return False
+    token = os.environ.get("REACHY_DUCKY_AUTH_TOKEN")
+    if not token:
+        return False
+    os.environ["DAEMON_AUTH_TOKEN"] = token
+    return True
+
+
 def live_main() -> None:
     """Mac-side live dev entry — connects to a real Reachy Mini over LAN.
 
@@ -292,6 +309,8 @@ def live_main() -> None:
     loaded = _load_dotenv(env_path)
     if loaded:
         print(f"Loaded {loaded} env var(s) from {env_path}.", flush=True)
+    if _mirror_daemon_auth_token():
+        print("Mapped REACHY_DUCKY_AUTH_TOKEN to DAEMON_AUTH_TOKEN for app requests.", flush=True)
 
     if not os.environ.get("OPENAI_API_KEY"):
         print(

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import threading
+from pathlib import Path
 
 from reachy_ducky_protocol.messages import State
 
@@ -235,6 +237,34 @@ def main() -> None:
     app.run(reachy_mini=None, stop_event=stop)
 
 
+def _load_dotenv(path: Path) -> int:
+    """Load ``KEY=VALUE`` lines from ``path`` into ``os.environ`` (no overwrite).
+
+    Returns the number of variables loaded. Existing env vars take
+    precedence — this matches every dotenv loader's expected semantics
+    and lets users override the on-disk file via the shell. Lines that
+    aren't ``KEY=VALUE`` (comments, blanks) are ignored. We don't pull
+    in ``python-dotenv`` because the format we write is trivial and the
+    extra dep is unjustified.
+    """
+    if not path.is_file():
+        return 0
+    loaded = 0
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+            loaded += 1
+    return loaded
+
+
 def live_main() -> None:
     """Mac-side live dev entry — connects to a real Reachy Mini over LAN.
 
@@ -244,6 +274,9 @@ def live_main() -> None:
     say-wake-word → run-a-turn flow from a dev Mac without installing
     the app on the robot.
 
+    Auto-loads ``~/.reachy-ducky/.env`` (written by ``reachy-ducky init``)
+    so the user doesn't have to ``source`` it manually before each run.
+
     Prereqs (per CLAUDE.md):
       1. ``uv run reachy-ducky init`` has populated ``~/.reachy-ducky/``
       2. Brain daemon is running on the Mac (``uv run reachy-ducky-daemon``
@@ -251,13 +284,30 @@ def live_main() -> None:
       3. Reachy Mini Wireless is on the LAN
     """
     import signal
+    import sys
 
     import reachy_mini  # type: ignore[import-untyped]
+
+    env_path = Path.home() / ".reachy-ducky" / ".env"
+    loaded = _load_dotenv(env_path)
+    if loaded:
+        print(f"Loaded {loaded} env var(s) from {env_path}.", flush=True)
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        print(
+            "ERROR: OPENAI_API_KEY is not set.\n"
+            f"  Either add it to {env_path} (re-run `uv run reachy-ducky init` "
+            "and provide the key), or export it in your shell:\n"
+            "    export OPENAI_API_KEY=sk-...\n"
+            "  Get a key at https://platform.openai.com/api-keys.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(2)
 
     stop = threading.Event()
 
     def _on_sigint(_signum: int, _frame: object) -> None:
-        # Ctrl-C cleanly drains the loop. Re-raises if pressed twice.
         if stop.is_set():
             raise KeyboardInterrupt
         stop.set()
@@ -268,5 +318,12 @@ def live_main() -> None:
     with reachy_mini.ReachyMini() as mini:
         print("Connected. Say 'hey jarvis' to start a turn. Ctrl-C to quit.", flush=True)
         app = ReachyDuckyApp()
-        app.run(reachy_mini=mini, stop_event=stop)
+        try:
+            app.run(reachy_mini=mini, stop_event=stop)
+        except ValueError as exc:
+            # Voice / brain construction errors that we want to surface
+            # without a stack trace (the user's already seen the failure
+            # path; the trace just buries the actual fix).
+            print(f"\nERROR: {exc}", file=sys.stderr, flush=True)
+            sys.exit(1)
     print("Stopped.", flush=True)

--- a/app/src/reachy_ducky_app/main.py
+++ b/app/src/reachy_ducky_app/main.py
@@ -233,3 +233,40 @@ def main() -> None:
     stop = threading.Event()
     stop.set()  # immediate exit; dev-loop only
     app.run(reachy_mini=None, stop_event=stop)
+
+
+def live_main() -> None:
+    """Mac-side live dev entry — connects to a real Reachy Mini over LAN.
+
+    Constructs a live ``ReachyMini()`` (which connects to the robot's
+    on-board daemon at ``reachy-mini.local:8000`` over WebRTC) and runs
+    ``ReachyDuckyApp`` until SIGINT (Ctrl-C). Lets you exercise the full
+    say-wake-word → run-a-turn flow from a dev Mac without installing
+    the app on the robot.
+
+    Prereqs (per CLAUDE.md):
+      1. ``uv run reachy-ducky init`` has populated ``~/.reachy-ducky/``
+      2. Brain daemon is running on the Mac (``uv run reachy-ducky-daemon``
+         in another terminal)
+      3. Reachy Mini Wireless is on the LAN
+    """
+    import signal
+
+    import reachy_mini  # type: ignore[import-untyped]
+
+    stop = threading.Event()
+
+    def _on_sigint(_signum: int, _frame: object) -> None:
+        # Ctrl-C cleanly drains the loop. Re-raises if pressed twice.
+        if stop.is_set():
+            raise KeyboardInterrupt
+        stop.set()
+
+    signal.signal(signal.SIGINT, _on_sigint)
+
+    print("reachy-ducky-app — live mode. Connecting to Reachy Mini…", flush=True)
+    with reachy_mini.ReachyMini() as mini:
+        print("Connected. Say 'hey jarvis' to start a turn. Ctrl-C to quit.", flush=True)
+        app = ReachyDuckyApp()
+        app.run(reachy_mini=mini, stop_event=stop)
+    print("Stopped.", flush=True)

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -270,6 +270,32 @@ def test_load_dotenv_returns_zero_when_file_missing(tmp_path: Path) -> None:
     assert _load_dotenv(tmp_path / "nonexistent.env") == 0
 
 
+def test_mirror_daemon_auth_token_maps_init_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live mode bridges daemon init token name to the app client contract."""
+    from reachy_ducky_app.main import _mirror_daemon_auth_token
+
+    monkeypatch.delenv("DAEMON_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("REACHY_DUCKY_AUTH_TOKEN", "daemon-token")
+
+    assert _mirror_daemon_auth_token() is True
+    assert os.environ["DAEMON_AUTH_TOKEN"] == "daemon-token"
+
+
+def test_mirror_daemon_auth_token_preserves_explicit_app_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicitly exported app token wins over the daemon-side token."""
+    from reachy_ducky_app.main import _mirror_daemon_auth_token
+
+    monkeypatch.setenv("DAEMON_AUTH_TOKEN", "app-token")
+    monkeypatch.setenv("REACHY_DUCKY_AUTH_TOKEN", "daemon-token")
+
+    assert _mirror_daemon_auth_token() is False
+    assert os.environ["DAEMON_AUTH_TOKEN"] == "app-token"
+
+
 async def test_run_async_closes_daemon_client_on_shutdown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/app/tests/test_app_main.py
+++ b/app/tests/test_app_main.py
@@ -11,8 +11,10 @@ construction path via a fake ``reachy_mini_app`` stand-in.
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 from collections.abc import AsyncIterator
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -232,6 +234,40 @@ def test_main_exits_with_stopped_event(monkeypatch: pytest.MonkeyPatch) -> None:
     # it; belt-and-braces, the stop_event.set() inside main() guarantees the
     # loop body is skipped, so this returns synchronously.
     main()
+
+
+def test_load_dotenv_reads_key_value_lines_without_overwriting_existing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_load_dotenv`` parses KEY=VALUE lines, skips comments, no overwrite."""
+    from reachy_ducky_app.main import _load_dotenv
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# a comment\n"
+        "\n"
+        "OPENAI_API_KEY=sk-from-file\n"
+        'GITHUB_PERSONAL_ACCESS_TOKEN="ghp_quoted"\n'
+        "REACHY_DUCKY_AUTH_TOKEN=existing_should_not_overwrite\n"
+    )
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+    monkeypatch.setenv("REACHY_DUCKY_AUTH_TOKEN", "process_env_wins")
+
+    loaded = _load_dotenv(env_file)
+    assert loaded == 2  # OpenAI + GH; auth-token already in env
+    assert os.environ["OPENAI_API_KEY"] == "sk-from-file"
+    assert os.environ["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_quoted"
+    assert os.environ["REACHY_DUCKY_AUTH_TOKEN"] == "process_env_wins"
+
+
+def test_load_dotenv_returns_zero_when_file_missing(tmp_path: Path) -> None:
+    """No .env file is fine — load_dotenv returns 0 silently."""
+    from reachy_ducky_app.main import _load_dotenv
+
+    assert _load_dotenv(tmp_path / "nonexistent.env") == 0
 
 
 async def test_run_async_closes_daemon_client_on_shutdown(

--- a/daemon/src/reachy_ducky_daemon/cli.py
+++ b/daemon/src/reachy_ducky_daemon/cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import secrets
 import subprocess  # nosec B404 — used only to invoke the `claude` CLI for an auth-status check; list-form, no shell, no user-controlled args
 from dataclasses import dataclass
 from pathlib import Path
@@ -159,27 +160,7 @@ def _collect_daemon(existing_default_memory: Path) -> _DaemonConfig:
         typer.secho(f"  port {port_str!r} is not a number — using 8765.", fg=typer.colors.YELLOW)
         port = 8765
 
-    auth_token: str | None = None
-    raw = typer.prompt(
-        "Auth token (leave blank for no auth; safe on loopback)",
-        default="",
-        show_default=False,
-        hide_input=True,
-    )
-    if raw:
-        typer.secho(
-            "  Tip: for a strong token, run `openssl rand -hex 32` and paste the output.",
-            fg=typer.colors.YELLOW,
-        )
-        # Default no: the typical answer is "no, keep what I typed". We only
-        # prompt at all so the user sees the openssl hint.
-        if _confirm("  Regenerate with openssl instead?", default=False):
-            typer.echo(
-                "  OK — leaving auth_token unset for now. Run `openssl rand -hex 32` "
-                "and edit ~/.reachy-ducky/.env before starting the daemon."
-            )
-        else:
-            auth_token = raw
+    auth_token = _collect_auth_token(host=host)
 
     return _DaemonConfig(
         memory_root=memory_root,
@@ -187,6 +168,67 @@ def _collect_daemon(existing_default_memory: Path) -> _DaemonConfig:
         port=port,
         auth_token=auth_token,
     )
+
+
+def _collect_auth_token(*, host: str) -> str | None:
+    """Resolve the daemon auth token.
+
+    Default action is **auto-generate** — a 256-bit random hex string via
+    :func:`secrets.token_hex`, the cryptographic equivalent of
+    ``openssl rand -hex 32`` without the subprocess. Generate is the
+    primary path because there's no good reason to type a weaker custom
+    token, and the wizard previously buried this option behind a
+    confusing post-prompt offer.
+
+    The "skip" path is genuinely safe ONLY on loopback (``127.0.0.1``);
+    any other bind exposes an unauthenticated HTTP endpoint to the LAN.
+    The wizard prints an explicit warning when the user picks Skip with
+    a non-loopback bind.
+    """
+    typer.echo("Auth token — used by the on-robot app to authenticate to this daemon.")
+    choice = (
+        _ask(
+            "  [G]enerate (recommended), [P]aste your own, or [S]kip",
+            default="G",
+        )
+        .strip()
+        .lower()
+    )
+    if choice in {"", "g", "generate"}:
+        token = secrets.token_hex(32)
+        typer.secho(
+            "  Generated a 256-bit random auth token (saved to ~/.reachy-ducky/.env).",
+            fg=typer.colors.GREEN,
+        )
+        return token
+    if choice in {"p", "paste"}:
+        raw = str(
+            typer.prompt(
+                "  Paste auth token",
+                default="",
+                show_default=False,
+                hide_input=True,
+            )
+        ).strip()
+        if not raw:
+            typer.secho(
+                "  Empty token — skipping. (Re-run init to set one.)",
+                fg=typer.colors.YELLOW,
+            )
+            return None
+        return raw
+    # Skip
+    if host not in {"127.0.0.1", "localhost", "::1"}:
+        typer.secho(
+            f"  WARNING: skipping the auth token while bound to {host} exposes "
+            "the daemon to anyone on the LAN. Re-run init and pick Generate "
+            "before starting the daemon, or rebind to 127.0.0.1.",
+            fg=typer.colors.RED,
+            bold=True,
+        )
+    else:
+        typer.echo("  Skipped (safe on loopback).")
+    return None
 
 
 def _collect_github_pat() -> str | None:
@@ -203,6 +245,38 @@ def _collect_github_pat() -> str | None:
         hide_input=True,
     ).strip()
     return pat or None
+
+
+def _collect_openai_key() -> str | None:
+    """Prompt for OPENAI_API_KEY (required for the realtime voice path).
+
+    Skipping is allowed (handy for headless setups that wire the key via
+    a system-level env var or a secret manager), but ``reachy-ducky-app
+    -live`` will fail-fast at voice construction if neither this nor the
+    process environment provides one. The wizard prints a clear warning
+    when the user skips so the failure is anticipated, not surprising.
+    """
+    typer.secho("\nOpenAI API key", fg=typer.colors.CYAN, bold=True)
+    typer.echo(
+        "Required for the realtime voice (gpt-4o-realtime-preview). "
+        "Get one at https://platform.openai.com/api-keys."
+    )
+    key = str(
+        typer.prompt(
+            "OpenAI API key (leave blank to skip)",
+            default="",
+            show_default=False,
+            hide_input=True,
+        )
+    ).strip()
+    if not key:
+        typer.secho(
+            "  Skipped. The voice path will fail until OPENAI_API_KEY is set "
+            "in ~/.reachy-ducky/.env or the process env.",
+            fg=typer.colors.YELLOW,
+        )
+        return None
+    return key
 
 
 def _prompt_slug(*, taken: frozenset[str] = frozenset()) -> str:
@@ -377,6 +451,7 @@ def init() -> None:
     default_memory = cfg_dir / "memory"
     daemon = _collect_daemon(default_memory)
     pat = _collect_github_pat()
+    openai_key = _collect_openai_key()
     projects = _collect_projects()
 
     # --- write outputs ---
@@ -387,6 +462,8 @@ def init() -> None:
         env_entries["REACHY_DUCKY_AUTH_TOKEN"] = daemon.auth_token
     if pat:
         env_entries["GITHUB_PERSONAL_ACCESS_TOKEN"] = pat
+    if openai_key:
+        env_entries["OPENAI_API_KEY"] = openai_key
     if env_entries:
         _write_env(env_path, env_entries)
 

--- a/daemon/src/reachy_ducky_daemon/cli.py
+++ b/daemon/src/reachy_ducky_daemon/cli.py
@@ -186,49 +186,54 @@ def _collect_auth_token(*, host: str) -> str | None:
     a non-loopback bind.
     """
     typer.echo("Auth token — used by the on-robot app to authenticate to this daemon.")
-    choice = (
-        _ask(
-            "  [G]enerate (recommended), [P]aste your own, or [S]kip",
-            default="G",
-        )
-        .strip()
-        .lower()
-    )
-    if choice in {"", "g", "generate"}:
-        token = secrets.token_hex(32)
-        typer.secho(
-            "  Generated a 256-bit random auth token (saved to ~/.reachy-ducky/.env).",
-            fg=typer.colors.GREEN,
-        )
-        return token
-    if choice in {"p", "paste"}:
-        raw = str(
-            typer.prompt(
-                "  Paste auth token",
-                default="",
-                show_default=False,
-                hide_input=True,
+    while True:
+        choice = (
+            _ask(
+                "  [G]enerate (recommended), [P]aste your own, or [S]kip",
+                default="G",
             )
-        ).strip()
-        if not raw:
+            .strip()
+            .lower()
+        )
+        if choice in {"", "g", "generate"}:
+            token = secrets.token_hex(32)
             typer.secho(
-                "  Empty token — skipping. (Re-run init to set one.)",
-                fg=typer.colors.YELLOW,
+                "  Generated a 256-bit random auth token (saved to ~/.reachy-ducky/.env).",
+                fg=typer.colors.GREEN,
             )
+            return token
+        if choice in {"p", "paste"}:
+            raw = str(
+                typer.prompt(
+                    "  Paste auth token",
+                    default="",
+                    show_default=False,
+                    hide_input=True,
+                )
+            ).strip()
+            if not raw:
+                typer.secho(
+                    "  Empty token — skipping. (Re-run init to set one.)",
+                    fg=typer.colors.YELLOW,
+                )
+                return None
+            return raw
+        if choice in {"s", "skip"}:
+            if host not in {"127.0.0.1", "localhost", "::1"}:
+                typer.secho(
+                    f"  WARNING: skipping the auth token while bound to {host} exposes "
+                    "the daemon to anyone on the LAN. Re-run init and pick Generate "
+                    "before starting the daemon, or rebind to 127.0.0.1.",
+                    fg=typer.colors.RED,
+                    bold=True,
+                )
+            else:
+                typer.echo("  Skipped (safe on loopback).")
             return None
-        return raw
-    # Skip
-    if host not in {"127.0.0.1", "localhost", "::1"}:
         typer.secho(
-            f"  WARNING: skipping the auth token while bound to {host} exposes "
-            "the daemon to anyone on the LAN. Re-run init and pick Generate "
-            "before starting the daemon, or rebind to 127.0.0.1.",
-            fg=typer.colors.RED,
-            bold=True,
+            "  Unrecognized choice — enter G to generate, P to paste, or S to skip.",
+            fg=typer.colors.YELLOW,
         )
-    else:
-        typer.echo("  Skipped (safe on loopback).")
-    return None
 
 
 def _collect_github_pat() -> str | None:

--- a/daemon/src/reachy_ducky_daemon/cli.py
+++ b/daemon/src/reachy_ducky_daemon/cli.py
@@ -213,10 +213,10 @@ def _collect_auth_token(*, host: str) -> str | None:
             ).strip()
             if not raw:
                 typer.secho(
-                    "  Empty token — skipping. (Re-run init to set one.)",
+                    "  Empty token — choose Paste again or Skip explicitly.",
                     fg=typer.colors.YELLOW,
                 )
-                return None
+                continue
             return raw
         if choice in {"s", "skip"}:
             if host not in {"127.0.0.1", "localhost", "::1"}:

--- a/daemon/tests/test_cli_init.py
+++ b/daemon/tests/test_cli_init.py
@@ -13,6 +13,7 @@ not-logged-in paths without touching the real CLI.
 
 from __future__ import annotations
 
+import re
 import stat
 import subprocess
 import sys
@@ -135,17 +136,17 @@ def test_happy_path_creates_config_env_and_memory(
     """Scripted answers produce a valid config.toml, .env, and memory tree."""
     fake_claude_auth(logged_in=True)
     # Order matches the wizard prompt sequence:
-    # 1. memory_root (accept default), 2. host default, 3. port default,
-    # 4. auth_token (empty), 5. GH PAT (empty),
-    # 6. project slug, 7. path, 8. github_repo (empty),
-    # 9. primary=y, 10. add another=n.
+    # 1. memory_root, 2. host, 3. port, 4. auth-token CHOICE (s=skip),
+    # 5. GH PAT, 6. OpenAI API key, 7. project slug, 8. path, 9. github_repo,
+    # 10. primary, 11. add another.
     script = "\n".join(
         [
             "",  # memory_root default
             "",  # host default
             "",  # port default
-            "",  # auth_token empty
+            "s",  # auth-token: skip
             "",  # GH PAT empty
+            "",  # OpenAI key empty
             "reachy-ducky",  # slug
             str(git_repo),  # path
             "",  # github_repo empty
@@ -173,7 +174,7 @@ def test_happy_path_creates_config_env_and_memory(
     assert (home / ".reachy-ducky" / "memory" / "ducky" / "soul.md").exists()
     assert (home / ".reachy-ducky" / "memory" / "projects").is_dir()
 
-    # No .env: no PAT, no auth token.
+    # No .env: no PAT, no auth token, no OpenAI key.
     assert not (home / ".reachy-ducky" / ".env").exists()
 
 
@@ -188,11 +189,12 @@ def test_happy_path_round_trips_through_app_config(
     fake_claude_auth(logged_in=True)
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "my-proj",
             str(git_repo),
             "owner/my-proj",
@@ -250,11 +252,12 @@ def test_existing_config_overwrite_yes_replaces_file(
     script = "\n".join(
         [
             "y",  # overwrite yes
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "fresh-proj",
             str(git_repo),
             "",
@@ -284,11 +287,12 @@ def test_invalid_slug_reprompts_until_valid(
     fake_claude_auth(logged_in=True)
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "Bad_Slug",  # rejected: underscore + uppercase
             "no spaces ok",  # rejected: space
             "good-slug",  # accepted
@@ -335,8 +339,9 @@ def test_init_wizard_rejects_duplicate_slug(
             "",  # memory default
             "",  # host default
             "",  # port default
-            "",  # no auth token
+            "s",  # auth-token: skip
             "",  # no PAT
+            "",  # no OpenAI key
             "alpha",  # project #1 slug
             str(git_repo),  # project #1 path
             "",  # no github_repo
@@ -375,11 +380,12 @@ def test_invalid_path_nonexistent_reprompts(
     nonexistent = tmp_path / "does" / "not" / "exist"
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "good-slug",
             str(nonexistent),  # rejected
             str(git_repo),  # accepted
@@ -406,11 +412,12 @@ def test_invalid_path_not_a_git_repo_reprompts(
     not_a_repo.mkdir()
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "good-slug",
             str(not_a_repo),  # rejected
             str(git_repo),  # accepted
@@ -434,11 +441,12 @@ def test_invalid_github_repo_reprompts_and_accepts_empty(
     fake_claude_auth(logged_in=True)
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "proj",
             str(git_repo),
             "not-a-repo",  # rejected: no slash
@@ -472,11 +480,12 @@ def test_multiple_projects_only_first_primary(
     fake_claude_auth(logged_in=True)
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "first-proj",
             str(git_repo),
             "",
@@ -512,11 +521,12 @@ def test_primary_swap_demotes_previous(
     fake_claude_auth(logged_in=True)
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "first-proj",
             str(git_repo),
             "",
@@ -555,11 +565,12 @@ def test_claude_not_logged_in_warns_and_continues(
     fake_claude_auth(logged_in=False)
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "proj",
             str(git_repo),
             "",
@@ -584,11 +595,12 @@ def test_claude_binary_missing_warns_and_continues(
     fake_claude_auth(missing=True)
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # GH PAT
+            "",  # OpenAI key
             "proj",
             str(git_repo),
             "",
@@ -617,11 +629,12 @@ def test_pat_writes_env_with_0600(
     pat = "ghp_" + "x" * 36
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            "",
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
             pat,  # GH PAT
+            "",  # OpenAI key
             "proj",
             str(git_repo),
             "",
@@ -653,17 +666,18 @@ def test_auth_token_writes_env_with_0600(
     git_repo: Path,
     fake_claude_auth: _ConfigureClaudeAuth,
 ) -> None:
-    """An auth_token is written to .env (not TOML) with 0600 perms."""
+    """A pasted auth_token is written to .env (not TOML) with 0600 perms."""
     fake_claude_auth(logged_in=True)
     token = "supersecrettoken123"
     script = "\n".join(
         [
-            "",
-            "",
-            "",
-            token,  # auth_token prompt
-            "n",  # decline the "generate a stronger one" offer
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "p",  # auth-token: paste
+            token,  # auth-token value
             "",  # no PAT
+            "",  # no OpenAI key
             "proj",
             str(git_repo),
             "",
@@ -688,6 +702,82 @@ def test_auth_token_writes_env_with_0600(
         assert mode == 0o600
 
 
+def test_auth_token_default_generate_writes_random_token(
+    home: Path,
+    git_repo: Path,
+    fake_claude_auth: _ConfigureClaudeAuth,
+) -> None:
+    """Hitting Enter on the auth-token choice generates a 256-bit random token.
+
+    Generate is the recommended primary path. The wizard previously
+    buried this behind a confusing post-prompt offer; the new flow
+    defaults to G so the secure choice is one Enter away.
+    """
+    fake_claude_auth(logged_in=True)
+    script = "\n".join(
+        [
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "",  # auth-token CHOICE — empty == default == G (generate)
+            "",  # no PAT
+            "",  # no OpenAI key
+            "proj",
+            str(git_repo),
+            "",
+            "y",
+            "n",
+            "",
+        ]
+    )
+    result = _invoke(script)
+    assert result.exit_code == 0, result.output
+    env = home / ".reachy-ducky" / ".env"
+    assert env.exists()
+    content = env.read_text()
+    # 64-hex-char token (32 bytes * 2).
+    match = re.search(r"^REACHY_DUCKY_AUTH_TOKEN=([0-9a-f]{64})$", content, re.MULTILINE)
+    assert match, f"expected 64-hex-char token in .env, got: {content!r}"
+
+
+def test_openai_key_writes_env_with_0600(
+    home: Path,
+    git_repo: Path,
+    fake_claude_auth: _ConfigureClaudeAuth,
+) -> None:
+    """OPENAI_API_KEY supplied to the wizard lands in .env with the other secrets."""
+    fake_claude_auth(logged_in=True)
+    key = "sk-test-" + "y" * 40
+    script = "\n".join(
+        [
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "s",  # auth-token: skip
+            "",  # no PAT
+            key,  # OpenAI key
+            "proj",
+            str(git_repo),
+            "",
+            "y",
+            "n",
+            "",
+        ]
+    )
+    result = _invoke(script)
+    assert result.exit_code == 0, result.output
+    env = home / ".reachy-ducky" / ".env"
+    assert env.exists()
+    content = env.read_text()
+    assert f"OPENAI_API_KEY={key}" in content
+    # TOML never contains the key.
+    cfg_text = (home / ".reachy-ducky" / "config.toml").read_text()
+    assert key not in cfg_text
+    if sys.platform != "win32":
+        mode = stat.S_IMODE(env.stat().st_mode)
+        assert mode == 0o600
+
+
 def test_no_pat_no_auth_token_no_env_file(
     home: Path,
     git_repo: Path,
@@ -700,8 +790,9 @@ def test_no_pat_no_auth_token_no_env_file(
             "",
             "",
             "",
-            "",  # no auth token
+            "s",  # auth-token: skip
             "",  # no PAT
+            "",  # no OpenAI key
             "proj",
             str(git_repo),
             "",

--- a/daemon/tests/test_cli_init.py
+++ b/daemon/tests/test_cli_init.py
@@ -770,6 +770,38 @@ def test_auth_token_invalid_choice_reprompts_before_skip(
     assert not (home / ".reachy-ducky" / ".env").exists()
 
 
+def test_auth_token_empty_paste_reprompts_before_non_loopback_skip_warning(
+    home: Path,
+    git_repo: Path,
+    fake_claude_auth: _ConfigureClaudeAuth,
+) -> None:
+    """An empty pasted token must not silently skip auth on a LAN bind."""
+    fake_claude_auth(logged_in=True)
+    script = "\n".join(
+        [
+            "",  # memory_root
+            "0.0.0.0",  # host: non-loopback bind
+            "",  # port
+            "p",  # auth-token: paste
+            "",  # empty pasted token
+            "s",  # explicit skip after re-prompt
+            "",  # no PAT
+            "",  # no OpenAI key
+            "proj",
+            str(git_repo),
+            "",
+            "y",
+            "n",
+            "",
+        ]
+    )
+    result = _invoke(script)
+    assert result.exit_code == 0, result.output
+    assert "Empty token" in result.output
+    assert "WARNING: skipping the auth token while bound to 0.0.0.0" in result.output
+    assert not (home / ".reachy-ducky" / ".env").exists()
+
+
 def test_openai_key_writes_env_with_0600(
     home: Path,
     git_repo: Path,

--- a/daemon/tests/test_cli_init.py
+++ b/daemon/tests/test_cli_init.py
@@ -740,6 +740,36 @@ def test_auth_token_default_generate_writes_random_token(
     assert match, f"expected 64-hex-char token in .env, got: {content!r}"
 
 
+def test_auth_token_invalid_choice_reprompts_before_skip(
+    home: Path,
+    git_repo: Path,
+    fake_claude_auth: _ConfigureClaudeAuth,
+) -> None:
+    """A typo at the auth-token menu must not silently choose Skip."""
+    fake_claude_auth(logged_in=True)
+    script = "\n".join(
+        [
+            "",  # memory_root
+            "",  # host
+            "",  # port
+            "x",  # invalid auth-token choice
+            "s",  # explicit skip after re-prompt
+            "",  # no PAT
+            "",  # no OpenAI key
+            "proj",
+            str(git_repo),
+            "",
+            "y",
+            "n",
+            "",
+        ]
+    )
+    result = _invoke(script)
+    assert result.exit_code == 0, result.output
+    assert "Unrecognized choice" in result.output
+    assert not (home / ".reachy-ducky" / ".env").exists()
+
+
 def test_openai_key_writes_env_with_0600(
     home: Path,
     git_repo: Path,

--- a/docs/plans/2026-04-30-alpha-release-plan.md
+++ b/docs/plans/2026-04-30-alpha-release-plan.md
@@ -1,0 +1,882 @@
+# Alpha Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut a credible `v0.1.0-alpha` release that proves the live Reachy Mini loop: wake word, voice turn, daemon query, spoken reply, mute, and documented setup.
+
+**Architecture:** Treat alpha as release hardening, not a new feature wave. The code path is already present on `main` plus the current `live-mode-entry` branch; the plan finishes that branch, validates hardware, resolves release-blocking security and distribution work, refreshes docs, and tags a release. Alpha is scoped to one configured primary project; on-robot project selection (#22) is deferred.
+
+**Tech Stack:** Python 3.12, uv workspace, FastAPI daemon, OpenAI Realtime voice, openWakeWord ONNX wake detector, Reachy Mini SDK, GitHub Actions, Hugging Face Spaces, GitHub CLI.
+
+---
+
+## Alpha Cutline
+
+Alpha is successful when a technical early user can:
+
+- Run `uv run reachy-ducky init` and start the Mac daemon.
+- Run the live Reachy Mini app path from a Mac with `uv run reachy-ducky-app-live`, or install the app from the published Hugging Face Space.
+- Say `hey jarvis`, speak a short development question, and hear a reply sourced through the Mac daemon.
+- Mute and unmute without frames leaving the robot while muted.
+- Follow README and smoke-test docs without reading old plan files.
+- Inspect known alpha limitations in docs before using the release.
+
+## Explicit Non-Goals
+
+- On-robot multi-project selection (#22). Alpha uses the daemon primary project fallback.
+- Custom `hey ducky` wake model (#75). Alpha uses openWakeWord's pretrained `hey jarvis`.
+- Mac daemon auto-discovery from the robot (#58). Alpha documents `DAEMON_URL`.
+- Rich wake/listening menubar phase strings (#76).
+- PyPI or Homebrew distribution unless issue #28 explicitly chooses one before release.
+- Passive observation, Codex/Claude hooks, interruption tiers, or transcript ingestion.
+
+## File Map
+
+- `README.md`: root status, alpha run path, accurate wake/audio docs, release install notes.
+- `app/README.md`: Hugging Face Space install instructions and alpha wake-word wording.
+- `docs/testing/2026-04-21-phase-a-e2e-procedure.md`: refresh from stale Phase A procedure into current alpha smoke procedure.
+- `docs/testing/2026-04-30-alpha-smoke-log.md`: create during hardware validation with exact commands and outcomes.
+- `.github/workflows/release.yml`: tag-based GitHub Release workflow.
+- `.github/workflows/hf-space-sync.yml`: tag-based production Hugging Face Space sync workflow.
+- `.github/workflows/hf-space-preview.yml`: optional PR-preview Space workflow if #26 stays in alpha scope.
+- `docs/release/2026-04-30-alpha-install.md`: offline/manual robot install and upgrade path.
+- `pyproject.toml`, `app/pyproject.toml`, `daemon/pyproject.toml`, `uv.lock`: dependency changes for Dependabot alert triage when needed.
+
+## Current Baseline
+
+- Local branch: `live-mode-entry`, two commits ahead of `main`.
+- `main`: PR #79 merged ONNX wake detector and Pattern C handoff.
+- Local unit gate observed on 2026-04-30: `uv run pytest -q` passed with `662 passed, 10 deselected`.
+- Release plumbing open issues: #24, #26, #28, #29, #30, #40, #48.
+- Hardware bring-up open issue: #22, deferred for alpha by explicit scope decision.
+- Current open Dependabot alerts observed on 2026-04-30:
+
+| Alert | Severity | Package | Current locked version | Patched version | Alpha action |
+|---|---|---|---|---|---|
+| #12 | medium | pip | 26.0.1 | none | Document risk or remove from release artifact if it is tooling-only. |
+| #11 | high | pillow | 11.3.0 | 12.2.0 | Upgrade or pin direct dep to `pillow>=12.2.0`. |
+| #10 | medium | pytest | 8.4.2 | 9.0.3 | Upgrade dev group to `pytest>=9.0.3,<10`. |
+| #9 | high | gradio | 5.13.2 | 6.6.0 | Upgrade upstream path or pin direct dep if compatible. |
+| #8 | medium | gradio | 5.13.2 | 6.6.0 | Same as #9. |
+| #7 | high | gradio | 5.13.2 | 6.7.0 | Target `gradio>=6.7.0`. |
+| #6 | low | gradio | 5.13.2 | 6.6.0 | Same as #9. |
+| #5 | high | pillow | 11.3.0 | 12.1.1 | Covered by `pillow>=12.2.0`. |
+| #4 | high | starlette | 0.48.0 | 0.49.1 | Upgrade FastAPI or pin direct dep to `starlette>=0.49.1`. |
+| #3 | low | gradio | 5.13.2 | none | Document risk if no patched release. |
+| #2 | medium | gradio | 5.13.2 | 5.31.0 | Covered by `gradio>=6.7.0`. |
+| #1 | high | gradio | 5.13.2 | none | Document risk if no patched release. |
+
+## Milestone 1 - Finish `live-mode-entry`
+
+### Task 1: Refresh alpha docs on the live-mode branch
+
+**Files:**
+- Modify: `README.md`
+- Modify: `app/README.md`
+- Modify: `docs/testing/2026-04-21-phase-a-e2e-procedure.md`
+
+- [ ] **Step 1: Update root README status**
+
+Replace the stale status and Phase A wake text with:
+
+```markdown
+Status: Alpha candidate in release hardening.
+
+## Run (alpha)
+
+- First-time setup: `uv run reachy-ducky init`. The wizard writes
+  `~/.reachy-ducky/config.toml`, secrets to `~/.reachy-ducky/.env`,
+  and seeds the memory tree.
+- Mac daemon: `set -a; source ~/.reachy-ducky/.env; set +a`
+  then `uv run reachy-ducky-daemon`.
+- Live hardware dev run from the Mac: `uv run reachy-ducky-app-live`.
+  This connects to a LAN Reachy Mini and loads `~/.reachy-ducky/.env`.
+- Robot dashboard install: publish the app Space, then install from the
+  Reachy dashboard. The dashboard path is part of alpha release
+  validation, not assumed.
+
+Alpha wake word is `hey jarvis`, using vendored openWakeWord ONNX
+weights. A custom `hey ducky` model is deferred to #75.
+```
+
+- [ ] **Step 2: Update `app/README.md` wake wording**
+
+Replace "Say `Hey Ducky`" with:
+
+```markdown
+Say `hey jarvis` for the alpha wake word, ask a question, get an
+answer. A custom `hey ducky` wake model is tracked separately in #75.
+```
+
+- [ ] **Step 3: Refresh the E2E procedure header**
+
+Replace the opening stale warning in `docs/testing/2026-04-21-phase-a-e2e-procedure.md` with:
+
+```markdown
+> This procedure was refreshed for the alpha release path on 2026-04-30.
+> The old Phase A limitations around stub wake and silent mock audio no
+> longer describe `main` after PR #68 and PR #79.
+```
+
+- [ ] **Step 4: Add live-mode command sequence to the E2E procedure**
+
+Add this Mac-side live path before the dashboard install path:
+
+````markdown
+### Live hardware run from the Mac
+
+```bash
+cd /Users/dmccarthy/Projects/reachy-ducky
+uv sync --all-packages --group dev
+uv run reachy-ducky init
+
+# Terminal 1
+set -a; source ~/.reachy-ducky/.env; set +a
+REACHY_DUCKY_DAEMON_HOST=0.0.0.0 uv run reachy-ducky-daemon
+
+# Terminal 2
+uv run reachy-ducky-app-live
+```
+
+Expected:
+
+- The app prints `Connected. Say 'hey jarvis' to start a turn.`
+- Saying `hey jarvis` transitions to listening.
+- A spoken question reaches `/brain/query`.
+- The robot speaks the daemon reply.
+- Ctrl-C exits with `Stopped.`
+````
+
+- [ ] **Step 5: Run docs-adjacent checks**
+
+Run:
+
+```bash
+uv run ruff check README.md app/README.md docs/testing/2026-04-21-phase-a-e2e-procedure.md
+uv run ruff format --check README.md app/README.md docs/testing/2026-04-21-phase-a-e2e-procedure.md
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 6: Commit docs refresh**
+
+```bash
+git add README.md app/README.md docs/testing/2026-04-21-phase-a-e2e-procedure.md
+git commit -m "docs: refresh alpha live-mode run instructions"
+```
+
+### Task 2: Push `live-mode-entry` and open PR
+
+**Files:**
+- Existing branch files from `live-mode-entry`
+- Modify only if tests or review require it.
+
+- [ ] **Step 1: Run local quality gate**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy --strict daemon/src app/src menubar/src protocol/src
+uv run mypy --strict daemon/tests protocol/tests menubar/tests app/tests
+uv run pyright
+uv run bandit -ll -r daemon/src app/src menubar/src protocol/src
+uv run pytest -q --cov
+```
+
+Expected: all pass, coverage stays at or above the configured 90 percent floor.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin live-mode-entry
+```
+
+- [ ] **Step 3: Create PR body**
+
+Write `/tmp/reachy-ducky-live-mode-pr.md` with:
+
+```markdown
+## Summary
+
+- add `reachy-ducky-app-live` for Mac-side live hardware runs
+- load `~/.reachy-ducky/.env` before live voice startup
+- prompt for `OPENAI_API_KEY` in `reachy-ducky init`
+- generate a daemon auth token by default
+- refresh alpha run docs
+
+## Alpha scope
+
+Alpha uses the configured primary project. On-robot project selection
+is deferred to #22.
+
+## Verification
+
+- `uv run ruff check .`
+- `uv run ruff format --check .`
+- `uv run mypy --strict daemon/src app/src menubar/src protocol/src`
+- `uv run mypy --strict daemon/tests protocol/tests menubar/tests app/tests`
+- `uv run pyright`
+- `uv run bandit -ll -r daemon/src app/src menubar/src protocol/src`
+- `uv run pytest -q --cov`
+```
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create \
+  --base main \
+  --head live-mode-entry \
+  --title "feat(app): add alpha live-mode entrypoint" \
+  --body-file /tmp/reachy-ducky-live-mode-pr.md
+```
+
+- [ ] **Step 5: Re-fetch review and CI**
+
+```bash
+gh pr view live-mode-entry --json number,state,mergeStateStatus,reviewDecision,statusCheckRollup
+gh pr checks live-mode-entry
+```
+
+Expected: required CI passes. If `claude-review` fails for a known workflow-touch limitation, record the exact failure link in the PR and confirm required checks are green.
+
+## Milestone 2 - Hardware Alpha Smoke
+
+### Task 3: Run live hardware smoke and capture evidence
+
+**Files:**
+- Create: `docs/testing/2026-04-30-alpha-smoke-log.md`
+- Modify: source files only if the smoke reveals a bug.
+
+- [ ] **Step 1: Create smoke log template**
+
+Create `docs/testing/2026-04-30-alpha-smoke-log.md` with:
+
+````markdown
+# Alpha Smoke Log - 2026-04-30
+
+## Environment
+
+- Branch:
+- Commit:
+- Mac:
+- Reachy Mini:
+- Network:
+- Daemon URL:
+- Wake word: hey jarvis
+- Project source: configured primary project
+
+## Commands
+
+```bash
+uv sync --all-packages --group dev
+uv run reachy-ducky init
+set -a; source ~/.reachy-ducky/.env; set +a
+REACHY_DUCKY_DAEMON_HOST=0.0.0.0 uv run reachy-ducky-daemon
+uv run reachy-ducky-app-live
+```
+
+## Results
+
+- Daemon `/health`:
+- Wake fired:
+- User transcript captured:
+- Daemon `/brain/query` returned:
+- Spoken reply heard:
+- Mute prevented turn:
+- Shutdown clean:
+
+## Failures And Fixes
+
+- None.
+````
+
+- [ ] **Step 2: Start daemon**
+
+```bash
+set -a; source ~/.reachy-ducky/.env; set +a
+REACHY_DUCKY_DAEMON_HOST=0.0.0.0 uv run reachy-ducky-daemon
+```
+
+Expected: uvicorn starts and `/health` returns `{"ok": true, ...}`.
+
+- [ ] **Step 3: Start live app**
+
+```bash
+uv run reachy-ducky-app-live
+```
+
+Expected: app prints `Connected. Say 'hey jarvis' to start a turn.`
+
+- [ ] **Step 4: Exercise golden path**
+
+Say:
+
+```text
+hey jarvis
+What is the status of this branch?
+```
+
+Expected:
+
+- Wake detector fires once.
+- Robot transitions to listening, then thinking, then listening.
+- Daemon receives `/brain/query`.
+- Robot speaks a relevant reply.
+- App returns to idle after the reply.
+
+- [ ] **Step 5: Exercise mute**
+
+Use the available mute path for the current build. If only the state-machine test path is available, run:
+
+```bash
+uv run pytest -q app/tests/test_mute_integration.py app/tests/test_main_wake_pump.py
+```
+
+Expected: tests pass and the smoke log records that live UI mute propagation is outside alpha unless wired by the current branch.
+
+- [ ] **Step 6: Run hardware-marked tests**
+
+```bash
+uv run pytest -m hardware -q app/tests/test_main_hardware.py app/tests/test_wake_hardware.py app/tests/test_sdk_audio_contract.py
+```
+
+Expected: hardware tests pass on a LAN-reachable Reachy Mini. Any failure gets fixed before continuing or documented as an explicit alpha limitation.
+
+- [ ] **Step 7: Commit smoke log**
+
+```bash
+git add docs/testing/2026-04-30-alpha-smoke-log.md
+git commit -m "docs: capture alpha hardware smoke evidence"
+```
+
+## Milestone 3 - Security And Dependency Readiness
+
+### Task 4: Triage #48 Dependabot alerts
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: subpackage `pyproject.toml` files only when a direct dependency range owns the vulnerable package.
+- Create: `docs/release/2026-04-30-dependency-triage.md`
+
+- [ ] **Step 1: Capture current alert list**
+
+```bash
+gh api repos/Obsidian-Owl/reachy-ducky/dependabot/alerts --paginate \
+  --jq '.[] | select(.state == "open") | [.number, .security_advisory.severity, .dependency.package.name, .security_advisory.summary, .security_vulnerability.vulnerable_version_range, (.security_vulnerability.first_patched_version.identifier // "none")] | @tsv' \
+  | tee /tmp/reachy-ducky-alerts.tsv
+```
+
+Expected: the list includes current `gradio`, `pillow`, `starlette`, `pytest`, and `pip` alerts or a smaller set if Dependabot has updated.
+
+- [ ] **Step 2: Inspect dependency paths**
+
+```bash
+uv tree --package gradio --depth 4
+uv tree --package pillow --depth 4
+uv tree --package starlette --depth 4
+uv tree --package pytest --depth 3
+uv tree --package pip --depth 3
+```
+
+Expected current baseline:
+
+- `gradio` is locked at `5.13.2`.
+- `pillow` is locked at `11.3.0`.
+- `starlette` is locked at `0.48.0`.
+- `pytest` is locked at `8.4.2`.
+- `pip` is locked at `26.0.1`.
+
+- [ ] **Step 3: Attempt direct safe pins**
+
+Apply the smallest direct pins that satisfy patched versions:
+
+```toml
+# pyproject.toml dependency-groups.dev
+"pytest>=9.0.3,<10",
+
+# app/pyproject.toml dependencies, if resolution allows
+"pillow>=12.2.0,<13",
+"starlette>=0.49.1,<0.50",
+"gradio>=6.7.0,<7",
+```
+
+If `gradio>=6.7.0` is incompatible with `fastrtc` or `reachy-mini`, do not force the upgrade. Remove that pin and document the incompatibility in the triage doc.
+
+- [ ] **Step 4: Sync and test**
+
+```bash
+uv sync --all-packages --group dev
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy --strict daemon/src app/src menubar/src protocol/src
+uv run mypy --strict daemon/tests protocol/tests menubar/tests app/tests
+uv run pyright
+uv run bandit -ll -r daemon/src app/src menubar/src protocol/src
+uv run pytest -q
+```
+
+Expected: all pass. If a pin breaks runtime imports, revert the pin and document why the alert is risk-accepted for alpha.
+
+- [ ] **Step 5: Write dependency triage doc**
+
+Create `docs/release/2026-04-30-dependency-triage.md` with one row per alert:
+
+```markdown
+# Alpha Dependency Triage - 2026-04-30
+
+| Alert | Package | Severity | Current | Patched | Decision | Rationale |
+|---|---|---|---|---|---|---|
+| #12 | pip | medium | 26.0.1 | none | accepted | Tooling-only in alpha environment; no patched release exists at triage time. |
+| #11/#5 | pillow | high | 11.3.0 | 12.2.0 | fixed or accepted | Fixed if lock contains 12.2.0 or newer; otherwise accepted only if upstream constraints block it. |
+| #10 | pytest | medium | 8.4.2 | 9.0.3 | fixed or accepted | Dev-only, but fix preferred before tag. |
+| #9/#8/#7/#6/#3/#2/#1 | gradio | high/medium/low | 5.13.2 | mixed | fixed or accepted | Alpha does not expose Gradio as a public route; fix if upstream constraints allow. |
+| #4 | starlette | high | 0.48.0 | 0.49.1 | fixed or accepted | Daemon uses FastAPI; fix preferred before tag. |
+```
+
+Replace `fixed or accepted` with the actual decision before committing.
+
+- [ ] **Step 6: Commit dependency triage**
+
+```bash
+git add pyproject.toml app/pyproject.toml daemon/pyproject.toml uv.lock docs/release/2026-04-30-dependency-triage.md
+git commit -m "chore(deps): triage alpha dependency alerts (#48)"
+```
+
+- [ ] **Step 7: Update #48**
+
+```bash
+gh issue comment 48 --body-file docs/release/2026-04-30-dependency-triage.md
+```
+
+Close #48 only if all high severity alerts are fixed or explicitly risk-accepted in the issue comment.
+
+## Milestone 4 - Release Plumbing
+
+### Task 5: Decide alpha daemon distribution (#28)
+
+**Files:**
+- Create: `docs/release/2026-04-30-alpha-distribution.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Record decision**
+
+Create `docs/release/2026-04-30-alpha-distribution.md` with:
+
+```markdown
+# Alpha Distribution Decision
+
+Decision: tagged source checkout with `uv sync --all-packages --group dev`.
+
+Rationale:
+
+- No PyPI release process required for alpha.
+- The install target is immutable after the tag.
+- Early users can still inspect the exact source.
+- `uv tool install` from a subpackage is not the alpha path because the
+  daemon package depends on the workspace-local protocol package.
+- Homebrew and PyPI remain available for beta.
+
+Robot app distribution:
+
+- Production Hugging Face Space sync from `v*` tags.
+- Manual offline install documented for recovery and local testing.
+
+Deferred:
+
+- PyPI packaging.
+- Homebrew tap.
+```
+
+- [ ] **Step 2: Update issue #28**
+
+```bash
+gh issue comment 28 --body-file docs/release/2026-04-30-alpha-distribution.md
+gh issue close 28 --reason completed
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/release/2026-04-30-alpha-distribution.md README.md
+git commit -m "docs: choose alpha distribution path (#28)"
+```
+
+### Task 6: Add GitHub Release workflow (#29)
+
+**Files:**
+- Create: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add workflow**
+
+Create `.github/workflows/release.yml`:
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create release notes
+        run: |
+          mkdir -p dist
+          {
+            echo "# ${GITHUB_REF_NAME}"
+            echo
+            echo "Alpha release for Reachy Ducky."
+            echo
+            echo "## Changes"
+            git log --oneline "$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || git rev-list --max-parents=0 HEAD)".."${GITHUB_REF_NAME}" || true
+          } > dist/release-notes.md
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prerelease_flag=""
+          case "${GITHUB_REF_NAME}" in
+            *alpha*|*beta*|*rc*) prerelease_flag="--prerelease" ;;
+          esac
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file dist/release-notes.md \
+            ${prerelease_flag}
+```
+
+- [ ] **Step 2: Validate syntax**
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+import yaml
+yaml.safe_load(Path(".github/workflows/release.yml").read_text())
+print("release workflow yaml ok")
+PY
+```
+
+Expected: prints `release workflow yaml ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: add tag-based GitHub release workflow (#29)"
+```
+
+### Task 7: Add tag-based Hugging Face Space sync (#30)
+
+**Files:**
+- Create: `.github/workflows/hf-space-sync.yml`
+- Modify: `README.md`
+
+- [ ] **Step 1: Add workflow**
+
+Create `.github/workflows/hf-space-sync.yml`:
+
+```yaml
+name: Hugging Face Space sync
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync-space:
+    name: Sync app to production Space
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.5.30"
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install Hugging Face CLI
+        run: uv tool install "huggingface_hub[cli]"
+
+      - name: Sync app directory
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE: Obsidian-Owl/reachy_ducky_app
+        run: |
+          test -n "$HF_TOKEN"
+          hf upload "$HF_SPACE" app . --repo-type space --delete "*"
+```
+
+- [ ] **Step 2: Add README secret note**
+
+Add:
+
+```markdown
+### Release secrets
+
+The tag-based Hugging Face Space sync requires repository secret
+`HF_TOKEN` with write access to `Obsidian-Owl/reachy_ducky_app`.
+```
+
+- [ ] **Step 3: Validate syntax**
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+import yaml
+yaml.safe_load(Path(".github/workflows/hf-space-sync.yml").read_text())
+print("hf workflow yaml ok")
+PY
+```
+
+Expected: prints `hf workflow yaml ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/hf-space-sync.yml README.md
+git commit -m "ci: add tag-based Hugging Face Space sync (#30)"
+```
+
+### Task 8: Decide whether PR-preview Spaces block alpha (#26)
+
+**Files:**
+- Create: `.github/workflows/hf-space-preview.yml` only if kept in alpha scope.
+- Or modify: `docs/release/2026-04-30-alpha-distribution.md` if deferred.
+
+- [ ] **Step 1: Apply alpha decision**
+
+Recommended alpha decision: defer #26. Production tag sync plus Mac live mode is enough for alpha; PR-preview Spaces improve review ergonomics but are not required to prove the release.
+
+- [ ] **Step 2: Record deferral**
+
+Append to `docs/release/2026-04-30-alpha-distribution.md`:
+
+```markdown
+## PR-preview Spaces
+
+Decision: deferred from alpha.
+
+Reason: alpha only needs a production Space published from the release
+tag plus `reachy-ducky-app-live` for local hardware validation.
+PR-preview Spaces remain useful for later review ergonomics but do not
+block `v0.1.0-alpha`.
+```
+
+- [ ] **Step 3: Update #26**
+
+```bash
+gh issue comment 26 --body "Deferred from alpha. Production tag sync (#30) plus live-mode hardware validation is sufficient for v0.1.0-alpha; PR-preview Spaces remain useful post-alpha review ergonomics."
+```
+
+Do not close #26 unless the team wants the milestone cleaned by moving it out of `v0.1.0 release plumbing`.
+
+### Task 9: Document offline install and manual upgrade (#24)
+
+**Files:**
+- Create: `docs/release/2026-04-30-alpha-install.md`
+- Modify: `README.md`
+- Modify: `app/README.md`
+
+- [ ] **Step 1: Create install doc**
+
+Create `docs/release/2026-04-30-alpha-install.md`:
+
+````markdown
+# Alpha Install And Manual Upgrade
+
+## Mac daemon
+
+```bash
+git clone https://github.com/Obsidian-Owl/reachy-ducky.git
+cd reachy-ducky
+git checkout v0.1.0-alpha
+uv sync --all-packages --group dev
+uv run reachy-ducky init
+set -a; source ~/.reachy-ducky/.env; set +a
+REACHY_DUCKY_DAEMON_HOST=0.0.0.0 uv run reachy-ducky-daemon
+```
+
+## Robot app through dashboard
+
+1. Open the Reachy dashboard.
+2. Install the published `Obsidian-Owl/reachy_ducky_app` Space.
+3. Set `DAEMON_URL`, `DAEMON_AUTH_TOKEN`, and `OPENAI_API_KEY`.
+4. Start the app.
+
+## Manual live hardware run from Mac
+
+```bash
+git checkout v0.1.0-alpha
+uv sync --all-packages --group dev
+uv run reachy-ducky-app-live
+```
+
+## Upgrade
+
+1. Stop the daemon and app.
+2. Fetch and check out the new tag.
+3. Re-run `reachy-ducky init` only when release notes say config shape changed.
+4. Restart daemon and app.
+````
+
+- [ ] **Step 2: Link install doc**
+
+Add this link to `README.md`:
+
+```markdown
+For alpha install, offline fallback, and manual upgrade instructions, see
+`docs/release/2026-04-30-alpha-install.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/release/2026-04-30-alpha-install.md README.md app/README.md
+git commit -m "docs: add alpha offline install and upgrade path (#24)"
+```
+
+## Milestone 5 - Issue Hygiene And Final Tag
+
+### Task 10: Clean stale and deferred issues
+
+**Files:**
+- No code files expected.
+
+- [ ] **Step 1: Close stale #56 if merged evidence still holds**
+
+Verify:
+
+```bash
+rg -n "plans omitted|single oversized|symlink.*nonplan|_discover" daemon/tests daemon/src/reachy_ducky_daemon/brain/plans_mcp.py
+```
+
+Expected: the #56 follow-up tests and docstring changes are present.
+
+Then:
+
+```bash
+gh issue comment 56 --body "Verified on 2026-04-30: the follow-ups are already present on main via PR #70 / commit 4fe93b6. Closing as completed."
+gh issue close 56 --reason completed
+```
+
+- [ ] **Step 2: Mark #22 deferred from alpha**
+
+```bash
+gh issue comment 22 --body "Alpha scope decision: v0.1.0-alpha uses the configured primary project fallback. On-robot project selection remains valuable but is deferred until after alpha."
+```
+
+Move #22 out of the alpha milestone if milestone hygiene is required.
+
+- [ ] **Step 3: Triage #78**
+
+```bash
+gh pr view 78 --json number,title,state,mergeStateStatus,statusCheckRollup
+gh pr checks 78
+```
+
+If only `claude-review` fails and required CI passes, either merge after review or close with a comment that the Ruff bump will be handled in the dependency triage branch.
+
+### Task 11: Final release verification
+
+**Files:**
+- No code files expected unless verification finds a defect.
+
+- [ ] **Step 1: Sync with main**
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+- [ ] **Step 2: Run full local gate**
+
+```bash
+uv sync --all-packages --group dev
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy --strict daemon/src app/src menubar/src protocol/src
+uv run mypy --strict daemon/tests protocol/tests menubar/tests app/tests
+uv run pyright
+uv run bandit -ll -r daemon/src app/src menubar/src protocol/src
+uv run pytest -q --cov
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Verify release blockers**
+
+```bash
+gh issue list --state open --milestone "v0.1.0 release plumbing"
+gh issue list --state open --milestone "v0.1.0 hardware bring-up"
+gh pr list --state open
+```
+
+Expected:
+
+- Release plumbing has no open blockers, or only explicitly deferred #26/#40.
+- Hardware bring-up has only deferred #22.
+- No open PR is required for alpha.
+
+- [ ] **Step 4: Create tag**
+
+```bash
+git tag -a v0.1.0-alpha -m "v0.1.0-alpha"
+git push origin v0.1.0-alpha
+```
+
+Expected: `Release` and `Hugging Face Space sync` workflows start.
+
+- [ ] **Step 5: Verify release artifacts**
+
+```bash
+gh release view v0.1.0-alpha
+gh run list --workflow release.yml --limit 3
+gh run list --workflow hf-space-sync.yml --limit 3
+```
+
+Expected: GitHub Release exists and HF Space sync succeeded.
+
+- [ ] **Step 6: Post-tag smoke**
+
+Run the live hardware path from the tag:
+
+```bash
+git checkout v0.1.0-alpha
+uv sync --all-packages --group dev
+uv run reachy-ducky-app-live
+```
+
+Expected: same golden path as Milestone 2.
+
+## Done When
+
+- `live-mode-entry` is merged.
+- Alpha smoke log proves wake, voice, daemon query, spoken reply, and shutdown.
+- #48 is fixed or explicitly risk-accepted with a written triage.
+- #28 is decided for alpha.
+- #29 and #30 are implemented and verified.
+- #24 docs exist and are linked.
+- Stale docs no longer claim wake/audio are stubs.
+- #22 is documented as deferred because alpha uses the primary project fallback.
+- `v0.1.0-alpha` tag creates a GitHub Release and syncs the production Hugging Face Space.

--- a/docs/testing/2026-04-21-phase-a-e2e-procedure.md
+++ b/docs/testing/2026-04-21-phase-a-e2e-procedure.md
@@ -50,7 +50,7 @@ wake-word support is deferred to #75.
 ### One-time first-run wizard
 
 ```bash
-cd /Users/dmccarthy/Projects/reachy-ducky
+cd /path/to/reachy-ducky
 uv sync --all-packages --group dev
 uv run reachy-ducky init
 ```
@@ -62,7 +62,7 @@ memory tree. At least one project is required; mark one as primary.
 ## 1. Start the daemon
 
 ```bash
-cd /Users/dmccarthy/Projects/reachy-ducky
+cd /path/to/reachy-ducky
 # Load secrets written by `reachy-ducky init`:
 set -a; source ~/.reachy-ducky/.env; set +a
 uv run reachy-ducky-daemon
@@ -141,7 +141,7 @@ Use this path before dashboard install. It validates the alpha live-mode app
 against a LAN Reachy Mini while running from the Mac checkout.
 
 ```bash
-cd /Users/dmccarthy/Projects/reachy-ducky
+cd /path/to/reachy-ducky
 uv sync --all-packages --group dev
 uv run reachy-ducky init
 

--- a/docs/testing/2026-04-21-phase-a-e2e-procedure.md
+++ b/docs/testing/2026-04-21-phase-a-e2e-procedure.md
@@ -150,11 +150,15 @@ set -a; source ~/.reachy-ducky/.env; set +a
 REACHY_DUCKY_DAEMON_HOST=0.0.0.0 uv run reachy-ducky-daemon
 
 # Terminal 2
-uv run reachy-ducky-app-live
+set -a; source ~/.reachy-ducky/.env; set +a
+DAEMON_AUTH_TOKEN="$REACHY_DUCKY_AUTH_TOKEN" uv run reachy-ducky-app-live
 ```
 
 Expected output / behavior:
 
+- Terminal 2 maps the daemon token from `REACHY_DUCKY_AUTH_TOKEN` to the app
+  client's `DAEMON_AUTH_TOKEN`; without that, `/brain/query` returns `401` when
+  auth is enabled.
 - Terminal 2 prints `Connected. Say 'hey jarvis' to start a turn.` after it
   connects to the LAN Reachy Mini.
 - Saying `hey jarvis` triggers wake detection and moves the app into the
@@ -243,7 +247,7 @@ draft. A follow-up issue should update the plan.
 |---|---|---|
 | Menu-bar shows `🦆⚠` "daemon unreachable" | Daemon not running, or bound to a different host/port than `http://127.0.0.1:8765` | Start the daemon; or edit `_DAEMON_URL_DEFAULT` in `menubar/src/reachy_ducky_menubar/main.py:24` - the menu-bar URL is not yet env-overridable. |
 | `curl /brain/query` returns `401 {"detail":"missing bearer token"}` | `REACHY_DUCKY_AUTH_TOKEN` is set on the daemon; your curl didn't send `Authorization: Bearer <token>` | Add the header, or unset the env var and restart the daemon. |
-| `curl /brain/query` returns `401 {"detail":"invalid bearer token"}` | Token mismatch between daemon and caller | Re-source `~/.reachy-ducky/.env` in both shells. |
+| `curl /brain/query` returns `401 {"detail":"invalid bearer token"}` | Token mismatch between daemon and caller | Re-source `~/.reachy-ducky/.env` in both shells; for the live app, map `DAEMON_AUTH_TOKEN="$REACHY_DUCKY_AUTH_TOKEN"`. |
 | `curl /brain/query` returns `400 {"detail":"no project_slug in request and no primary project configured"}` | Wizard was not run, or no `primary = true` project in `config.toml` | Re-run `uv run reachy-ducky init`, or edit `~/.reachy-ducky/config.toml`. |
 | `curl /brain/query` returns `404 {"detail":"unknown project: <slug>"}` | Slug in request body does not appear in the loaded project list | Check `/health`'s `projects` field; fix the slug or add the project. |
 | Daemon logs `ClaudeSDKError: not authenticated` (or similar) on first query | `claude login` never run on the Mac | Run `claude login`; re-run the query. |

--- a/docs/testing/2026-04-21-phase-a-e2e-procedure.md
+++ b/docs/testing/2026-04-21-phase-a-e2e-procedure.md
@@ -1,80 +1,77 @@
-# Phase A End-to-End Smoke Procedure
+# Alpha Live-Mode End-to-End Smoke Procedure
 
-> This procedure mirrors the tree on `m8-voice` as of 2026-04-22. Re-verify after every merge.
+> This procedure was refreshed for the alpha release path on 2026-04-30.
+> The old Phase A limitations around stub wake and silent mock audio no
+> longer describe main after PR #68 and PR #79.
 
-This procedure walks a teammate through bringing up the three Phase A
-surfaces (Mac daemon, Mac menu-bar, Reachy Mini app) and exercising the
-wire between them. Phase A wake detection and Reachy dashboard install
-are NOT yet fully wired — see "Known gaps" below; a full "say 'Hey
-Ducky', get a spoken reply" demo is not achievable today without a
-code-level override.
+This procedure walks a teammate through bringing up the alpha live-mode path:
+Mac daemon, optional Mac menu-bar, Mac-side live hardware run against a LAN
+Reachy Mini, and the robot dashboard install path. The alpha wake word is
+`hey jarvis`, backed by vendored openWakeWord ONNX weights. Custom `hey ducky`
+wake-word support is deferred to #75.
 
 ## 0. Prereqs
 
 ### Accounts / logins
 
-- `claude login` — run on the Mac. `ClaudeSDKBrain` uses the locally
-  installed Claude CLI's OAuth credentials via `claude_agent_sdk`.
-  (`CLAUDE_CODE_OAUTH_TOKEN` is a CI-only path used by the GitHub
-  workflows under `.github/workflows/`; local runs do NOT need it.)
-- `gh auth login` — only if you plan to manually inspect GitHub via
-  `gh`. The daemon itself reaches GitHub via `github-mcp-server`, not
-  `gh`.
+- `claude login` - run on the Mac. `ClaudeSDKBrain` uses the locally installed
+  Claude CLI's OAuth credentials via `claude_agent_sdk`.
+  (`CLAUDE_CODE_OAUTH_TOKEN` is a CI-only path used by the GitHub workflows
+  under `.github/workflows/`; local runs do NOT need it.)
+- `gh auth login` - only if you plan to manually inspect GitHub via `gh`. The
+  daemon itself reaches GitHub via `github-mcp-server`, not `gh`.
 
 ### Runtimes on the Mac
 
 - `uv` installed (`brew install uv`).
 - Node.js 20+ on `PATH` (`brew install node@20`). Required for
-  `npx -y github-mcp-server` which the Pattern B brain spawns
-  (declared in `.mcp.json`).
+  `npx -y github-mcp-server` which the Pattern B brain spawns (declared in
+  `.mcp.json`).
 
 ### Env vars (Mac daemon side)
 
-- `GITHUB_PERSONAL_ACCESS_TOKEN` — `repo:read` + `pull_requests:read`
-  + `issues:read`. Required for the `mcp__github__*` tool surface when
-  a project sets `github_repo`. Read from process env at daemon start
-  by `build_brain_options` and forwarded into the MCP subprocess.
-- `REACHY_DUCKY_AUTH_TOKEN` — optional bearer token. When set, every
-  daemon route except `/health`, `/docs`, and `/openapi.json` requires
+- `GITHUB_PERSONAL_ACCESS_TOKEN` - `repo:read` + `pull_requests:read` +
+  `issues:read`. Required for the `mcp__github__*` tool surface when a project
+  sets `github_repo`. Read from process env at daemon start by
+  `build_brain_options` and forwarded into the MCP subprocess.
+- `REACHY_DUCKY_AUTH_TOKEN` - optional bearer token. When set, every daemon
+  route except `/health`, `/docs`, and `/openapi.json` requires
   `Authorization: Bearer <token>`. `reachy-ducky init` writes this to
   `~/.reachy-ducky/.env` at 0600 if you supply one during the wizard.
 
-### Env vars (Reachy side)
+### Env vars (live app / robot side)
 
-- `OPENAI_API_KEY` — required. `OpenAIRealtimeVoice.__init__` fails
-  fast with `ValueError` if unset.
-- `DAEMON_URL` — e.g. `http://<mac>.tailnet.ts.net:8765`. Defaults to
-  `http://127.0.0.1:8765`, which is only right if daemon + app share a
-  host.
-- `DAEMON_AUTH_TOKEN` — must match `REACHY_DUCKY_AUTH_TOKEN` if the
-  daemon has one set.
+- `OPENAI_API_KEY` - required for OpenAI Realtime voice.
+- `DAEMON_URL` - e.g. `http://<mac>.tailnet.ts.net:8765`. Defaults to
+  `http://127.0.0.1:8765`, which is only right if daemon + app share a host.
+- `DAEMON_AUTH_TOKEN` - must match `REACHY_DUCKY_AUTH_TOKEN` if the daemon has
+  one set.
 
 ### One-time first-run wizard
 
 ```bash
-cd reachy-ducky
+cd /Users/dmccarthy/Projects/reachy-ducky
 uv sync --all-packages --group dev
 uv run reachy-ducky init
 ```
 
-The wizard writes `~/.reachy-ducky/config.toml` (bind host/port,
-memory root, project list) and a 0600 `~/.reachy-ducky/.env` (auth
-token, GitHub PAT). At least one project is required; mark one as
-primary.
+The wizard writes `~/.reachy-ducky/config.toml` (bind host/port, memory root,
+project list), a 0600 `~/.reachy-ducky/.env` secrets file, and the configured
+memory tree. At least one project is required; mark one as primary.
 
 ## 1. Start the daemon
 
 ```bash
-cd reachy-ducky
+cd /Users/dmccarthy/Projects/reachy-ducky
 # Load secrets written by `reachy-ducky init`:
 set -a; source ~/.reachy-ducky/.env; set +a
 uv run reachy-ducky-daemon
 ```
 
-Expected on stdout: `uvicorn` banner listening on the host/port chosen
-in the wizard (defaults: `127.0.0.1:8765`). If `host` is off-loopback
-and no `auth_token` is set, the daemon logs a loud warning — treat
-that as a bug you need to fix before continuing.
+Expected on stdout: `uvicorn` banner listening on the host/port chosen in the
+wizard (defaults: `127.0.0.1:8765`). If `host` is off-loopback and no auth
+token is set, the daemon logs a loud warning; fix that before continuing
+unless you are on a trusted isolated network.
 
 ### Health check (open route)
 
@@ -94,12 +91,13 @@ Expected body shape (from `HealthResponse` in
 }
 ```
 
-`brain` is `"unbuilt"` on a fresh boot (lazy build — no
-`ClaudeSDKBrain` has been constructed yet), `"none"` if no primary
-project is configured, or the class name (`"ClaudeSDKBrain"`) once a
-brain has been materialised by a request.
+`brain` is `"unbuilt"` on a fresh boot (lazy build; no `ClaudeSDKBrain` has
+been constructed yet), `"none"` if no primary project is configured, or the
+class name (`"ClaudeSDKBrain"`) once a brain has been materialised by a request.
 
-### Protected-route sanity check (only when `REACHY_DUCKY_AUTH_TOKEN` is set)
+### Protected-route sanity check
+
+When `REACHY_DUCKY_AUTH_TOKEN` is set:
 
 ```bash
 curl -s -X POST http://127.0.0.1:8765/brain/query \
@@ -108,16 +106,15 @@ curl -s -X POST http://127.0.0.1:8765/brain/query \
   -d '{"user_utterance":"ping"}' | jq
 ```
 
-Expected: `200` with `{"text": "...", "specialist_invoked": null}`.
-Omitting the header should return `401 {"detail":"missing bearer
-token"}`.
+Expected: `200` with `{"text": "...", "specialist_invoked": null}`. Omitting
+the header should return `401 {"detail":"missing bearer token"}`.
 
 If no primary project is configured the daemon returns
-`400 {"detail":"no project_slug in request and no primary project
-configured"}`; add `"project_slug":"<slug>"` to the body. An unknown
-slug returns `404 {"detail":"unknown project: <slug>"}`.
+`400 {"detail":"no project_slug in request and no primary project configured"}`;
+add `"project_slug":"<slug>"` to the body. An unknown slug returns
+`404 {"detail":"unknown project: <slug>"}`.
 
-## 2. Start the menu-bar app
+## 2. Optional: start the menu-bar app
 
 macOS only. Install the optional extra first:
 
@@ -131,165 +128,150 @@ Verification (reading `menubar/src/reachy_ducky_menubar/main.py` +
 
 - Idle glyph: `🦆`.
 - Status item reads `Status: idle`.
-- Click "Mute" — glyph becomes `🦆🔇`, status reads `Status: muted`,
-  menu item shows a check. Click again to unmute.
-- Stop the daemon. Within ~2s the glyph changes to `🦆⚠` and status
-  reads `Status: daemon unreachable` (or `Status: daemon error
-  (<code>)` for a reachable-but-broken daemon). Restart the daemon
-  and the glyph returns to `🦆`.
+- Click "Mute" - glyph becomes `🦆🔇`, status reads `Status: muted`, menu item
+  shows a check. Click again to unmute.
+- Stop the daemon. Within ~2s the glyph changes to `🦆⚠` and status reads
+  `Status: daemon unreachable` (or `Status: daemon error (<code>)` for a
+  reachable-but-broken daemon). Restart the daemon and the glyph returns to
+  `🦆`.
 
-See "Known gaps" §2.
+## 3. Mac-side live hardware run
 
-## 3. Start the Reachy app on the robot
-
-Install the robot-side deps (SSH into the robot):
+Use this path before dashboard install. It validates the alpha live-mode app
+against a LAN Reachy Mini while running from the Mac checkout.
 
 ```bash
-ssh <robot>
-cd reachy-ducky
+cd /Users/dmccarthy/Projects/reachy-ducky
 uv sync --all-packages --group dev
-export OPENAI_API_KEY=sk-...
-export DAEMON_URL=http://<mac-host>:8765
-export DAEMON_AUTH_TOKEN=<same as REACHY_DUCKY_AUTH_TOKEN on the Mac>
+uv run reachy-ducky init
+
+# Terminal 1
+set -a; source ~/.reachy-ducky/.env; set +a
+REACHY_DUCKY_DAEMON_HOST=0.0.0.0 uv run reachy-ducky-daemon
+
+# Terminal 2
+uv run reachy-ducky-app-live
 ```
 
-`reachy-mini` is a plain base dep and installs on every platform,
-including this Linux/aarch64 robot image — no `--extra robot` needed.
+Expected output / behavior:
 
-Start path: the on-robot Pollen dashboard (`http://<robot>:8000`)
-instantiates `ReachyDuckyApp` from `app_class:
-reachy_ducky_app.main.ReachyDuckyApp` declared in
-`app/reachy_mini_app.yaml`. Publishing to HF Space + one-click install
-from the dashboard is the intended flow but is not yet demonstrably
-wired end-to-end; see "Known gaps".
+- Terminal 2 prints `Connected. Say 'hey jarvis' to start a turn.` after it
+  connects to the LAN Reachy Mini.
+- Saying `hey jarvis` triggers wake detection and moves the app into the
+  listening state.
+- The captured turn is sent to the Mac daemon through `/brain/query`.
+- The reply is spoken back through the live voice path, with Reachy returning
+  to idle after the turn completes.
+- Ctrl-C exits the live app cleanly and prints `Stopped.`.
 
-## 4. Interact — intended golden path
+## 4. Robot dashboard install
+
+The dashboard path is part of alpha release validation; do not treat it as
+complete just because the Mac-side live hardware run works.
+
+1. Publish the Reachy Ducky app Space.
+2. Open the Reachy dashboard at `http://<robot>:8000`.
+3. Install the app from its Space URL.
+4. Set robot-side environment variables:
+   - `DAEMON_URL=http://<your-mac>.tailnet.ts.net:8765`
+   - `DAEMON_AUTH_TOKEN=<bearer token if you set one on the Mac>`
+   - `OPENAI_API_KEY=<for OpenAI Realtime voice>`
+5. Start the dashboard-installed app and repeat the `hey jarvis` turn.
+
+The dashboard instantiates `ReachyDuckyApp` from
+`app_class: reachy_ducky_app.main.ReachyDuckyApp` declared in
+`app/reachy_mini_app.yaml`.
+
+## 5. Interact - intended golden path
 
 The orchestrated turn (from `app/src/reachy_ducky_app/conversation.py`
 `run_one_turn` + `app/src/reachy_ducky_app/embodiment/state_machine.py`):
 
-1. Wake trigger fires.
-2. `sm.transition(LISTENING)` → `play_move("listening")`.
-3. `voice.start_turn()` → `turn.get_user_text()` blocks for a final
+1. Wake trigger fires on `hey jarvis`.
+2. `sm.transition(LISTENING)` -> `play_move("listening")`.
+3. `voice.start_turn()` -> `turn.get_user_text()` blocks for a final
    transcript event from OpenAI Realtime.
-4. `sm.transition(THINKING)` → `play_move("thinking")`.
-5. `daemon.brain_query(text)` → Mac daemon's `/brain/query`.
-6. `sm.transition(LISTENING)` — the robot looks at the user WHILE
-   Ducky speaks (not during thinking).
-7. `turn.speak_text(reply)` → OpenAI Realtime TTS over the same
-   WebSocket.
-8. `sm.transition(IDLE)` → `play_move("neutral")`.
+4. `sm.transition(THINKING)` -> `play_move("thinking")`.
+5. `daemon.brain_query(text)` -> Mac daemon's `/brain/query`.
+6. `sm.transition(LISTENING)` - the robot looks at the user while Ducky speaks.
+7. `turn.speak_text(reply)` -> OpenAI Realtime TTS over the same WebSocket.
+8. `sm.transition(IDLE)` -> `play_move("neutral")`.
 
-A mute toggle anywhere flips the state machine to `MUTED`, which
-calls `driver.go_to_sleep()` (the visible "off" posture). Exiting
-`MUTED` calls `driver.wake_up()` before the next `play_move`. The
-menu-bar mute is a local UI control; Phase A does NOT propagate
-mute from the menu bar to the robot.
-
-Phase A cannot be driven through wake word today — see "Known
-gaps" §1.
+A mute toggle anywhere flips the state machine to `MUTED`, which calls
+`driver.go_to_sleep()` (the visible "off" posture). Exiting `MUTED` calls
+`driver.wake_up()` before the next `play_move`. The menu-bar mute is a local UI
+control; alpha does not propagate mute from the menu bar to the robot.
 
 ## Known gaps
 
-### 1. Wake detection is a no-op in Phase A
+### 1. Custom wake word is deferred
 
-`app/src/reachy_ducky_app/wake.py` ships `MockWakeDetector` as the
-default. `load_default_wake_detector()` returns it, and
-`ReachyDuckyApp._wake_triggered()` returns `False` unconditionally.
+Alpha uses `hey jarvis` with vendored openWakeWord ONNX weights. Custom
+`hey ducky` wake-word support is tracked in #75.
 
-Consequence: saying "Hey Ducky" into the robot's mic does nothing.
-A turn is only invoked if you subclass `ReachyDuckyApp` and override
-`_wake_triggered` (the test suite does this in
-`app/tests/test_app_main.py::test_run_async_calls_run_one_turn_when_wake_triggers`).
+### 2. Menu-bar does not show robot `LISTENING` / `THINKING`
 
-Workarounds for smoke-verifying the daemon + voice path without wake:
+`state_icon.py` defines `🦆👂` and `🦆💭`, but the menu-bar's poll loop
+(`main.py::_poll_loop`) only writes the local IDLE / MUTED state. There is no
+`/state` push from the robot or daemon.
 
-- Run `uv run pytest app -q` on the Mac — the unit suite exercises
-  `run_one_turn` end-to-end with `MockVoice` + `MockMotionDriver`
-  + `httpx_mock` against a local `DaemonClient`.
-- From any shell on the Mac, POST to `/brain/query` directly
-  (see §1 "Protected-route sanity check"); that exercises the brain
-  and tool surface without the robot in the loop.
+- TODO (follow-up issue): Menu-bar daemon URL should become env-overridable;
+  currently hardcoded as `_DAEMON_URL_DEFAULT` at
+  `menubar/src/reachy_ducky_menubar/main.py:24`. Note this is distinct from the
+  Reachy-side `DAEMON_URL` env var (`daemon_client.py`) which the robot process
+  does read - same conceptual value, two different wiring stories.
 
-### 1b. Default audio I/O is silent mocks
+### 3. Dashboard install must be validated on hardware
 
-The voice layer is now structurally wired end-to-end — mic frames flow
-into `input_audio_buffer.append`, transcription events drive
-`get_user_text`, and `response.audio.delta` events are piped to
-`SpeakerSink.play()`. But `load_default_mic_source()` /
-`load_default_speaker_sink()` return `MockMicSource()` /
-`MockSpeakerSink()` today (silent mic, dropping speaker).
-
-Consequence: even once wake fires, the robot has no real mic input and
-no audible replies until `ReachyMicSource` / `ReachySpeakerSink` land
-(tracked as follow-up). Unit tests drive the full event flow with
-`MockMicSource(frames=[...])` + `MockSpeakerSink()` captures.
-
-### 2. Menu-bar never shows `LISTENING` / `THINKING`
-
-`state_icon.py` defines `🦆👂` and `🦆💭` but the menu-bar's
-poll loop (`main.py::_poll_loop`) only writes the local IDLE /
-MUTED state. There is no `/state` push from the robot or daemon.
-
-- TODO (follow-up issue): Menu-bar daemon URL should become
-  env-overridable; currently hardcoded as `_DAEMON_URL_DEFAULT`
-  at `menubar/src/reachy_ducky_menubar/main.py:24`. Note this is
-  distinct from the Reachy-side `DAEMON_URL` env var (`daemon_client.py`)
-  which the robot process does read — same conceptual value, two
-  different wiring stories.
-
-### 3. Reachy dashboard install is unverified
-
-`app/reachy_mini_app.yaml` declares `app_class:
-reachy_ducky_app.main.ReachyDuckyApp` and `app/README.md` has the HF
-Space frontmatter, but we have NOT yet published to HF Spaces and
-one-click-installed on a real robot. The app package exposes no
-`reachy_mini_apps` entry-point in `app/pyproject.toml` either — the
-YAML `app_class` field is the sole registration mechanism. Treat
-step 3 of this procedure as untested until someone walks the publish
-path on hardware.
+`app/reachy_mini_app.yaml` declares
+`app_class: reachy_ducky_app.main.ReachyDuckyApp` and `app/README.md` carries
+the HF Space metadata. The alpha release is not complete until someone
+publishes the Space, installs it through the Reachy dashboard, and repeats the
+live `hey jarvis` turn from the dashboard-launched process.
 
 ### 4. Plan-doc draft has drifted
 
-The Phase A plan's §12.1 draft suggested the daemon console script
-`reachy-ducky-daemon` would log `uvicorn listening on
-127.0.0.1:8765`, mentioned a non-existent `reachy-ducky-app`
-command, and hand-wrote a menu-bar mute spec that differs from the
-live glyph set. Follow this procedure (which mirrors the code),
-not the plan's draft. A follow-up issue should update the plan.
+The Phase A plan's section 12.1 draft suggested the daemon console script
+`reachy-ducky-daemon` would log `uvicorn listening on 127.0.0.1:8765`, mentioned
+a non-existent `reachy-ducky-app` command, and hand-wrote a menu-bar mute spec
+that differs from the live glyph set. Follow this procedure, not the plan's
+draft. A follow-up issue should update the plan.
 
 ## Failure modes
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Menu-bar shows `🦆⚠` "daemon unreachable" | Daemon not running, or bound to a different host/port than `http://127.0.0.1:8765` | Start the daemon; or edit `_DAEMON_URL_DEFAULT` in `menubar/src/reachy_ducky_menubar/main.py:24` — the menu-bar URL is not yet env-overridable in Phase A. |
+| Menu-bar shows `🦆⚠` "daemon unreachable" | Daemon not running, or bound to a different host/port than `http://127.0.0.1:8765` | Start the daemon; or edit `_DAEMON_URL_DEFAULT` in `menubar/src/reachy_ducky_menubar/main.py:24` - the menu-bar URL is not yet env-overridable. |
 | `curl /brain/query` returns `401 {"detail":"missing bearer token"}` | `REACHY_DUCKY_AUTH_TOKEN` is set on the daemon; your curl didn't send `Authorization: Bearer <token>` | Add the header, or unset the env var and restart the daemon. |
 | `curl /brain/query` returns `401 {"detail":"invalid bearer token"}` | Token mismatch between daemon and caller | Re-source `~/.reachy-ducky/.env` in both shells. |
 | `curl /brain/query` returns `400 {"detail":"no project_slug in request and no primary project configured"}` | Wizard was not run, or no `primary = true` project in `config.toml` | Re-run `uv run reachy-ducky init`, or edit `~/.reachy-ducky/config.toml`. |
-| `curl /brain/query` returns `404 {"detail":"unknown project: <slug>"}` | Slug in request body doesn't appear in the loaded project list | Check `/health`'s `projects` field; fix the slug or add the project. |
+| `curl /brain/query` returns `404 {"detail":"unknown project: <slug>"}` | Slug in request body does not appear in the loaded project list | Check `/health`'s `projects` field; fix the slug or add the project. |
 | Daemon logs `ClaudeSDKError: not authenticated` (or similar) on first query | `claude login` never run on the Mac | Run `claude login`; re-run the query. |
 | Daemon brain errors mentioning `github-mcp-server` | Node.js missing, or `GITHUB_PERSONAL_ACCESS_TOKEN` unset for a project with `github_repo` | `brew install node@20`; export the PAT; restart the daemon. |
-| `uv run reachy-ducky-menubar` crashes with `ImportError: reachy-ducky-menubar is macOS-only` | Running on Linux | Menubar is macOS-only by design; there's nothing to run on Linux. |
+| `uv run reachy-ducky-menubar` crashes with `ImportError: reachy-ducky-menubar is macOS-only` | Running on Linux | Menubar is macOS-only by design; there is nothing to run on Linux. |
 | `uv run reachy-ducky-menubar` crashes with `ModuleNotFoundError: rumps` | `macos` extra not installed | `uv sync --all-packages --extra macos`. |
-| `OpenAIRealtimeVoice` raises `ValueError: OPENAI_API_KEY not set` on the robot | Env var missing in the robot-side process | Export `OPENAI_API_KEY` before starting the app. |
+| `OpenAIRealtimeVoice` raises `ValueError: OPENAI_API_KEY not set` | Env var missing in the live app process | Export `OPENAI_API_KEY` before starting the app. |
 | Realtime session opens but hangs up immediately after user speech | Schema drift between the `openai` SDK version and `voice/openai_realtime.py`'s assumed event names | Confirm `openai==1.109.x`; see module docstring for the verified event shape. |
 
 ## Tailing logs
 
 The daemon logs to stdout. For long smoke sessions, start it under
-`2>&1 | tee /tmp/reachy-ducky-daemon.log` (or similar) so failure
-modes can be cross-referenced with the log after the fact.
+`2>&1 | tee /tmp/reachy-ducky-daemon.log` (or similar) so failure modes can be
+cross-referenced with the log after the fact.
 
 ## Clean shutdown
 
-Ctrl-C the daemon in its terminal; quit the menu-bar app from its
-own menu; stop the Reachy app from the dashboard (or SSH the robot
-and terminate the python process).
+Ctrl-C the daemon in its terminal; quit the menu-bar app from its own menu; stop
+the Reachy app from the dashboard (or SSH the robot and terminate the python
+process). The Mac-side live app should print `Stopped.` after Ctrl-C.
 
 ## Done checklist
 
 - [ ] `/health` returns `ok: true` and the expected brain state
 - [ ] Menu-bar icon shows `🦆` (unmuted) and toggles to `🦆🔇` / back
 - [ ] Protected-route curl with bearer token succeeds
-- [ ] Daemon process exits cleanly on Ctrl-C
-- [ ] (Deferred until Known gaps close) Robot app instantiates from the Reachy dashboard and plays `listening` → `thinking` moves end-to-end
+- [ ] Mac-side live app prints `Connected. Say 'hey jarvis' to start a turn.`
+- [ ] Saying `hey jarvis` enters listening, calls `/brain/query`, and speaks a
+  reply
+- [ ] Mac-side live app exits cleanly on Ctrl-C and prints `Stopped.`
+- [ ] Dashboard-installed app repeats the same `hey jarvis` turn on hardware


### PR DESCRIPTION
## Summary

- add `reachy-ducky-app-live` for Mac-side live hardware runs
- load `~/.reachy-ducky/.env` before live voice startup
- prompt for `OPENAI_API_KEY` in `reachy-ducky init`
- generate a daemon auth token by default
- refresh alpha run docs and preserve the alpha release plan

## Alpha scope

Alpha uses the configured primary project. On-robot project selection is deferred to #22.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy --strict daemon/src app/src menubar/src protocol/src`
- `uv run mypy --strict daemon/tests protocol/tests menubar/tests app/tests`
- `uv run pyright`
- `uv run bandit -ll -r daemon/src app/src menubar/src protocol/src`
- `uv run pytest -q --cov` (662 passed, 10 deselected, 90.31%)
- pre-push hook: gitleaks-history + mypy-full

## Notes

The live app command sequence maps `DAEMON_AUTH_TOKEN="$REACHY_DUCKY_AUTH_TOKEN"` because the daemon wizard writes the daemon-side token name while the app client reads the app-side token name.
